### PR TITLE
HRIS-18 [BE] Create time out functionality

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -18,10 +18,12 @@ builder.Services.AddGraphQLServer()
 
 builder.Services.AddGraphQLServer()
     .AddMutationType(q => q.Name("Mutation"))
-    .AddType<TimeInMutation>();
+    .AddType<TimeInMutation>()
+    .AddType<TimeOutMutation>();
 
 builder.Services.AddPooledDbContextFactory<HrisContext>(o => o.UseSqlServer(connectionString));
 builder.Services.AddScoped<TimeInService>();
+builder.Services.AddScoped<TimeOutService>();
 var app = builder.Build();
 
 app.UseRouting();

--- a/api/Requests/TimeOutRequest.cs
+++ b/api/Requests/TimeOutRequest.cs
@@ -1,0 +1,10 @@
+namespace api.Requests
+{
+    public class TimeOutRequest
+    {
+        public int UserId { get; set; }
+        public int? TimeEntryId { get; set; }
+        public TimeSpan TimeHour { get; set; }
+        public string? Remarks { get; set; }
+    }
+}

--- a/api/Schema/Mutations/TimeOutMutation.cs
+++ b/api/Schema/Mutations/TimeOutMutation.cs
@@ -1,0 +1,19 @@
+using api.Requests;
+using api.Services;
+
+namespace api.Schema.Mutations
+{
+    [ExtendObjectType("Mutation")]
+    public class TimeOutMutation
+    {
+        private readonly TimeOutService _timeOutService;
+        public TimeOutMutation(TimeOutService timeOutService)
+        {
+            _timeOutService = timeOutService;
+        }
+        public async Task<string> UpdateTimeEntry(TimeOutRequest timeOut)
+        {
+            return await _timeOutService.Update(timeOut);
+        }
+    }
+}

--- a/api/Services/TimeOutService.cs
+++ b/api/Services/TimeOutService.cs
@@ -1,0 +1,48 @@
+using api.Context;
+using api.Entities;
+using api.Requests;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Services
+{
+    public class TimeOutService
+    {
+        private readonly IDbContextFactory<HrisContext> _contextFactory = default!;
+        public TimeOutService(IDbContextFactory<HrisContext> contextFactory)
+        {
+            _contextFactory = contextFactory;
+        }
+        public async Task<string> Update(TimeOutRequest timeout)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                using var transaction = context.Database.BeginTransaction();
+                try
+                {
+                    var time = context.Times.Add(new Time
+                    {
+                        TimeHour = timeout.TimeHour,
+                        Remarks = timeout.Remarks
+                    });
+
+                    await context.SaveChangesAsync();
+                    var timeEntry = await context.TimeEntries
+                    .Include(i => i.TimeIn)
+                    .FirstAsync(x => x.Id == timeout.TimeEntryId);
+                    timeEntry.TimeOutId = time.Entity.Id;
+                    timeEntry.WorkedHours = time.Entity.TimeHour.Subtract(timeEntry.TimeIn?.TimeHour ?? DateTime.Now.TimeOfDay).Subtract(TimeSpan.FromHours(1));
+                    timeEntry.TrackedHours = timeEntry.EndTime.Subtract(timeEntry.StartTime).Subtract(TimeSpan.FromHours(1));
+                    context.TimeEntries.Update(timeEntry);
+                    await context.SaveChangesAsync();
+
+                    transaction.Commit();
+                    return "Successful Time Out!";
+                }
+                catch (Exception e)
+                {
+                    return e.InnerException?.Message ?? "Something went wrong...";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-18

## Definition of Done

- [x] Can update the time out value in the related time entry in db
- [x] Created mutation, request and service classes

## Notes
- Please note that I have restructured the schema folder which is also reflected my previous pr hris-16
- This is a backend integration only
- You can access the graphql playground enpoint at http://localhost:5257/graphql/

## Pre-condition
- run docker compose 
- http://localhost:5257/graphql/
- try running this mutation
```
mutation{
  updateTimeEntry(timeOut: {
    userId: 1
    timeEntryId: 1
    timeHour: "PT18H50M"
    remarks: "Goodbye [logout]"
  })
}
```

## Expected Output

You should receive the response below upon running the mutation
```
{
  "data": {
    "updateTimeEntry": "Successful Time Out!"
  }
}
```

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/110364637/210919373-a846b0c4-17b6-45f4-b2d5-bb30f458cc92.png)
![image](https://user-images.githubusercontent.com/110364637/210921100-1f14daa9-aa7d-4fcb-a8ab-c9bf1dfe50de.png)
