### PR TITLE
HRIS-28 [Markup] Create Drawer Markup

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "18.2.0",
         "react-feather": "^2.0.10",
         "react-icons": "^4.7.1",
+        "react-textarea-autosize": "^8.4.0",
         "use-local-storage-state": "^18.1.2",
         "windstitch": "^0.3.0"
       },
@@ -1662,19 +1663,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint-utils": {
@@ -3360,6 +3348,22 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3912,6 +3916,43 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-local-storage-state": {
@@ -4903,6 +4944,24 @@
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
       }
     },
     "eslint-config-prettier": {
@@ -5118,16 +5177,6 @@
         }
       }
     },
-    "eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      }
-    },
     "eslint-utils": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
@@ -5177,6 +5226,14 @@
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
@@ -6251,6 +6308,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-textarea-autosize": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      }
+    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -6628,6 +6695,26 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "requires": {}
+    },
+    "use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.1.1"
       }
     },
     "use-local-storage-state": {

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "react-dom": "18.2.0",
     "react-feather": "^2.0.10",
     "react-icons": "^4.7.1",
+    "react-textarea-autosize": "^8.4.0",
     "use-local-storage-state": "^18.1.2",
     "windstitch": "^0.3.0"
   },

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -20,12 +20,19 @@ type Props = {
   actions: {
     handleToggleDrawer: () => void
     handleToggleSidebar: () => void
+    handleToggleTimeInDrawer: () => void
+    handleToggleTimeOutDrawer: () => void
   }
 }
 
 const Header: FC<Props> = (props): JSX.Element => {
   const {
-    actions: { handleToggleSidebar, handleToggleDrawer }
+    actions: {
+      handleToggleSidebar,
+      handleToggleDrawer,
+      handleToggleTimeInDrawer,
+      handleToggleTimeOutDrawer
+    }
   } = props
 
   const router = useRouter()
@@ -70,7 +77,7 @@ const Header: FC<Props> = (props): JSX.Element => {
             overlay="Clock In"
             arrowContent={<div className="rc-tooltip-arrow-inner"></div>}
           >
-            <Button>
+            <Button onClick={handleToggleTimeInDrawer}>
               <ClockInIcon className="h-7 w-7 fill-current" />
             </Button>
           </Tooltip>
@@ -90,7 +97,7 @@ const Header: FC<Props> = (props): JSX.Element => {
             overlay="Clock Out"
             arrowContent={<div className="rc-tooltip-arrow-inner"></div>}
           >
-            <Button>
+            <Button onClick={handleToggleTimeOutDrawer}>
               <ClockOutIcon className="h-7 w-7 fill-current" />
             </Button>
           </Tooltip>

--- a/client/src/components/organisms/TimeInDrawer/index.tsx
+++ b/client/src/components/organisms/TimeInDrawer/index.tsx
@@ -1,0 +1,126 @@
+import React, { FC } from 'react'
+import { X } from 'react-feather'
+import classNames from 'classnames'
+import TextareaAutosize from 'react-textarea-autosize'
+
+import Text from '~/components/atoms/Text'
+import Avatar from '~/components/atoms/Avatar'
+import DrawerTemplate from '~/components/templates/DrawerTemplate'
+
+type Props = {
+  isOpenTimeInDrawer: boolean
+  actions: {
+    handleToggleTimeInDrawer: () => void
+  }
+}
+
+const TimeInDrawer: FC<Props> = (props): JSX.Element => {
+  const {
+    isOpenTimeInDrawer,
+    actions: { handleToggleTimeInDrawer }
+  } = props
+
+  return (
+    <DrawerTemplate
+      {...{
+        isOpen: isOpenTimeInDrawer,
+        actions: {
+          handleToggle: handleToggleTimeInDrawer
+        }
+      }}
+    >
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+        <h1 className="text-base font-medium text-slate-900">Confirm Time In</h1>
+        <button onClick={handleToggleTimeInDrawer} className="active:scale-95">
+          <X className="h-6 w-6 stroke-0.5 text-slate-400" />
+        </button>
+      </header>
+      {/* Body */}
+      <div className="flex flex-col space-y-3 px-4 py-2">
+        {/* User */}
+        <div className="flex items-center space-x-3 border-b border-slate-200 py-3">
+          <Avatar
+            src="https://avatars.githubusercontent.com/u/38458781?v=4"
+            alt="user-avatar"
+            size="lg"
+            rounded="full"
+          />
+          <div>
+            <Text theme="md" size="sm" weight="bold">
+              Joshua Galit
+            </Text>
+            <p className="text-[11px] leading-tight text-slate-500">Clocking from GMT +8</p>
+            <p className="text-[11px] leading-tight text-slate-500">Last in a few seconds ago</p>
+            <p className="text-[11px] leading-tight text-slate-500">Split time: 12:00 am</p>
+          </div>
+        </div>
+        {/* Error Message */}
+        <div className="relative flex items-center justify-center rounded-md border border-rose-400 bg-rose-50 py-2.5 px-4 shadow-md">
+          <X className="absolute left-4 h-4 w-4 rounded-full bg-rose-500 p-0.5 text-white" />
+          <p className="text-xs font-medium text-rose-500">Something went wrong</p>
+        </div>
+        {/* Remarks */}
+        <div className="form-group space-y-2">
+          <div>
+            <label htmlFor="remarks" className="space-y-0.5">
+              <span className="text-xs text-slate-500">Remarks</span>
+              <TextareaAutosize
+                id="remarks"
+                className={classNames(
+                  'm-0 block min-h-[20vh] w-full rounded placeholder:text-slate-400',
+                  'border border-solid border-slate-300 bg-white bg-clip-padding focus:ring-primary',
+                  'resize-none px-3 py-1.5 text-sm font-normal text-slate-700 transition focus:border-primary',
+                  'ease-in-out focus:border-blue-600 focus:bg-white focus:text-slate-700 focus:outline-none'
+                )}
+                placeholder="Message..."
+              />
+            </label>
+          </div>
+          <div>
+            <label htmlFor="screenshots">
+              <span className="text-xs">Screenshots/Proof</span>
+              <input
+                id="screenshots"
+                className={classNames(
+                  'block w-full rounded-md border border-slate-200 bg-white text-xs text-slate-700',
+                  'transition ease-in-out file:rounded-l-md  file:border-0 file:bg-slate-700 file:py-3 file:px-2',
+                  'file:text-xs file:text-white focus:border-primary focus:bg-white focus:text-slate-700',
+                  'focus:outline-none focus:ring-1 focus:ring-primary'
+                )}
+                type="file"
+              />
+            </label>
+          </div>
+        </div>
+      </div>
+      {/* Footer Options */}
+      <section className="mt-auto border-t border-slate-200">
+        <div className="flex justify-end py-2 px-4">
+          <button
+            type="button"
+            onClick={handleToggleTimeInDrawer}
+            className={classNames(
+              'flex items-center justify-center border-slate-200 text-xs active:scale-95',
+              'w-24 border-dark-primary py-2 text-dark-primary outline-none'
+            )}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleToggleTimeInDrawer}
+            className={classNames(
+              'flex items-center justify-center rounded-md border active:scale-95',
+              'w-24 border-dark-primary bg-primary text-xs text-white outline-none hover:bg-dark-primary'
+            )}
+          >
+            Save
+          </button>
+        </div>
+      </section>
+    </DrawerTemplate>
+  )
+}
+
+export default TimeInDrawer

--- a/client/src/components/organisms/TimeOutDrawer/index.tsx
+++ b/client/src/components/organisms/TimeOutDrawer/index.tsx
@@ -1,0 +1,111 @@
+import React, { FC } from 'react'
+import { X } from 'react-feather'
+import classNames from 'classnames'
+import TextareaAutosize from 'react-textarea-autosize'
+
+import Text from '~/components/atoms/Text'
+import Avatar from '~/components/atoms/Avatar'
+import DrawerTemplate from '~/components/templates/DrawerTemplate'
+
+type Props = {
+  isOpenTimeOutDrawer: boolean
+  actions: {
+    handleToggleTimeOutDrawer: () => void
+  }
+}
+
+const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
+  const {
+    isOpenTimeOutDrawer,
+    actions: { handleToggleTimeOutDrawer }
+  } = props
+
+  return (
+    <DrawerTemplate
+      {...{
+        isOpen: isOpenTimeOutDrawer,
+        actions: {
+          handleToggle: handleToggleTimeOutDrawer
+        }
+      }}
+    >
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+        <h1 className="text-base font-medium text-slate-900">Confirm Time Out</h1>
+        <button onClick={handleToggleTimeOutDrawer} className="active:scale-95">
+          <X className="h-6 w-6 stroke-0.5 text-slate-400" />
+        </button>
+      </header>
+      {/* Body */}
+      <div className="flex flex-col space-y-3 px-4 py-2">
+        {/* User */}
+        <div className="flex items-center space-x-3 border-b border-slate-200 py-3">
+          <Avatar
+            src="https://avatars.githubusercontent.com/u/38458781?v=4"
+            alt="user-avatar"
+            size="lg"
+            rounded="full"
+          />
+          <div>
+            <Text theme="md" size="sm" weight="bold">
+              Joshua Galit
+            </Text>
+            <p className="text-[11px] leading-tight text-slate-500">Clocking from GMT +8</p>
+            <p className="text-[11px] leading-tight text-slate-500">Last in a few seconds ago</p>
+            <p className="text-[11px] leading-tight text-slate-500">Split time: 12:00 am</p>
+          </div>
+        </div>
+        {/* Error Message */}
+        <div className="relative flex items-center justify-center rounded-md border border-rose-400 bg-rose-50 py-2.5 px-4 shadow-md">
+          <X className="absolute left-4 h-4 w-4 rounded-full bg-rose-500 p-0.5 text-white" />
+          <p className="text-xs font-medium text-rose-500">Something went wrong</p>
+        </div>
+        {/* Remarks */}
+        <div className="form-group space-y-2">
+          <div>
+            <label htmlFor="remarks" className="space-y-0.5">
+              <span className="text-xs text-slate-500">Remarks</span>
+              <TextareaAutosize
+                id="remarks"
+                className={classNames(
+                  'm-0 block min-h-[20vh] w-full rounded placeholder:font-light placeholder:text-slate-400',
+                  'border border-solid border-slate-300 bg-white bg-clip-padding focus:ring-primary',
+                  'resize-none px-3 py-1.5 text-sm font-normal text-slate-700 transition focus:border-primary',
+                  'ease-in-out focus:border-blue-600 focus:bg-white focus:text-slate-700 focus:outline-none'
+                )}
+                placeholder="Message..."
+              />
+            </label>
+          </div>
+        </div>
+      </div>
+      {/* Footer Options */}
+      <section className="mt-auto border-t border-slate-200">
+        <div className="flex justify-end py-2 px-4">
+          <button
+            type="button"
+            onClick={handleToggleTimeOutDrawer}
+            className={classNames(
+              'flex items-center justify-center border-slate-200 text-xs active:scale-95',
+              'w-24 border-dark-primary py-2 text-dark-primary outline-none'
+            )}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleToggleTimeOutDrawer}
+            className={classNames(
+              'flex items-center justify-center rounded-md border active:scale-95',
+              'w-24 border-dark-primary bg-primary text-xs text-white outline-none hover:bg-dark-primary'
+            )}
+          >
+            Save
+          </button>
+        </div>
+      </section>
+    </DrawerTemplate>
+  )
+}
+
+export default TimeOutDrawer

--- a/client/src/components/templates/DrawerTemplate/index.tsx
+++ b/client/src/components/templates/DrawerTemplate/index.tsx
@@ -1,0 +1,43 @@
+import React, { FC, ReactNode } from 'react'
+import classNames from 'classnames'
+
+type Props = {
+  children: ReactNode
+  isOpen: boolean
+  actions: {
+    handleToggle: () => void
+  }
+}
+
+const DrawerTemplate: FC<Props> = (props): JSX.Element => {
+  const {
+    children,
+    isOpen,
+    actions: { handleToggle }
+  } = props
+
+  return (
+    <aside className="h-screen">
+      <div
+        className={classNames(
+          'flex h-full max-w-[280px] shrink-0 flex-col border-r border-slate-200',
+          'fixed top-0 z-50 w-full bg-white shadow-lg transition-all duration-300',
+          isOpen ? 'z-50 translate-x-0' : '-translate-x-full'
+        )}
+      >
+        {children}
+      </div>
+      <>
+        {/* This will served as the background of the drawer */}
+        {!isOpen && (
+          <div
+            onClick={handleToggle}
+            className="fixed inset-0 z-40 cursor-default bg-black/10"
+          ></div>
+        )}
+      </>
+    </aside>
+  )
+}
+
+export default DrawerTemplate

--- a/client/src/components/templates/Layout/index.tsx
+++ b/client/src/components/templates/Layout/index.tsx
@@ -7,6 +7,12 @@ import Drawer from '~/components/organisms/Drawer'
 import Header from '~/components/organisms/Header'
 
 const Sidebar = dynamic(async () => await import('~/components/organisms/Sidebar'), { ssr: false })
+const TimeInDrawer = dynamic(async () => await import('~/components/organisms/TimeInDrawer'), {
+  ssr: false
+})
+const TimeOutDrawer = dynamic(async () => await import('~/components/organisms/TimeOutDrawer'), {
+  ssr: false
+})
 
 type Props = {
   metaTitle: string
@@ -17,10 +23,21 @@ const Layout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
   const [isOpenSidebar, setIsOpenSidebar] = useLocalStorageState('sidebarToggle', {
     defaultValue: true
   })
+  const [isOpenTimeInDrawer, setIsOpenTimeInDrawer] = useLocalStorageState('timeInDrawerToggle', {
+    defaultValue: false
+  })
+  const [isOpenTimeOutDrawer, setIsOpenTimeOutDrawer] = useLocalStorageState(
+    'timeOutDrawerToggle',
+    {
+      defaultValue: false
+    }
+  )
   const [isOpenDrawer, setIsOpenDrawer] = useState<boolean>(false)
 
   const handleToggleDrawer = (): void => setIsOpenDrawer(!isOpenDrawer)
   const handleToggleSidebar = (): void => setIsOpenSidebar(!isOpenSidebar)
+  const handleToggleTimeInDrawer = (): void => setIsOpenTimeInDrawer(!isOpenTimeInDrawer)
+  const handleToggleTimeOutDrawer = (): void => setIsOpenTimeOutDrawer(!isOpenTimeOutDrawer)
 
   return (
     <>
@@ -55,13 +72,32 @@ const Layout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
               isOpenSidebar,
               actions: {
                 handleToggleDrawer,
-                handleToggleSidebar
+                handleToggleSidebar,
+                handleToggleTimeInDrawer,
+                handleToggleTimeOutDrawer
               }
             }}
           />
           {/* Dynamic Content */}
           {children}
         </main>
+        {/* Time In Drawer */}
+        <TimeInDrawer
+          {...{
+            isOpenTimeInDrawer,
+            actions: {
+              handleToggleTimeInDrawer
+            }
+          }}
+        />
+        <TimeOutDrawer
+          {...{
+            isOpenTimeOutDrawer,
+            actions: {
+              handleToggleTimeOutDrawer
+            }
+          }}
+        />
       </Wrapper>
     </>
   )


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-28

## Definition of Done

- [x] When the time-in button is clicked, it should view the drawer from the right side
- [x] When the time-out button is clicked, it should view the drawer from the right side
- [x] The drawer should have a slide animation when opening and closing it
- [x] All fields are optional
- [x] It should follow the design on the Figma reference provided in the Notes section

## Notes

Optional
- I added all the possible fields on this one. It will be put into hidden during integration.
- All fields are optional. Not required.
- Moved the file input to its traditional location which is below the form input.

## Pre-condition

Commands to run
cd client
npm i
npm run dev
click on the time in button

## Expected Output

Users can pull the time in drawer by clicking on the time in button
Users can close the timein drawer by clicking the close button, close mark on top, and also clicking outside the drawer

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/109579325/211244770-870325fb-4243-4bf2-adbd-aabcd6507732.png)
![image](https://user-images.githubusercontent.com/109579325/211244792-8f0a62df-208d-4796-add1-cdf168521334.png)
![image](https://user-images.githubusercontent.com/109579325/211244811-bddfe59a-5496-4ea7-9074-f7d35f03141a.png)
![image](https://user-images.githubusercontent.com/109579325/211244837-c0935683-c863-4953-b51c-124952c75c61.png)



