### PR TITLE
HRIS-29 [BugTask] DTR Management Deformation

### DIFF
--- a/client/src/components/molecules/FooterTable/index.tsx
+++ b/client/src/components/molecules/FooterTable/index.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const FooterTable: FC<Props> = ({ table }): JSX.Element => {
   return (
-    <footer className="sticky left-0 flex w-full items-center justify-between px-4 py-3">
+    <footer className="sticky bottom-0 left-0 flex w-full items-center justify-between bg-slate-100 px-4 py-3">
       <div className="flex flex-wrap items-center md:space-x-2">
         <div className="hidden md:block">
           <PageCount

--- a/client/src/components/molecules/NotificationPopOver/index.tsx
+++ b/client/src/components/molecules/NotificationPopOver/index.tsx
@@ -19,7 +19,7 @@ const NotificationPopover: FC<Props> = ({ className }): JSX.Element => {
   const main = 'default-scrollbar max-h-[25vh] min-h-[25vh] py-2'
 
   return (
-    <Popover className="relative z-20">
+    <Popover className="relative z-30">
       {({ open }) => (
         <>
           <Popover.Button className="flex cursor-pointer items-center rounded-full p-1 outline-none active:scale-95">

--- a/client/src/components/molecules/TimeSheetFilterDropdown/index.tsx
+++ b/client/src/components/molecules/TimeSheetFilterDropdown/index.tsx
@@ -4,7 +4,6 @@ import React, { FC, ReactNode } from 'react'
 
 import Text from '~/components/atoms/Text'
 import Button from '~/components/atoms/Buttons/Button'
-import RadioButton from '~/components/atoms/RadioButton'
 import MenuTransition from '~/components/templates/MenuTransition'
 
 type Props = {
@@ -25,7 +24,7 @@ const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
       <MenuTransition>
         <Menu.Items
           className={classNames(
-            'absolute top-8 right-0 flex w-80 flex-col overflow-hidden rounded-md',
+            'fixed right-6 top-[138px] flex w-80 flex-col overflow-hidden rounded-md sm:right-16 md:top-[102px]',
             'flex flex-col bg-white shadow-xl ring-1 ring-black',
             'shadow-slate-200 ring-opacity-5 focus:outline-none'
           )}
@@ -67,13 +66,6 @@ const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
                 {filterStatusOptions(['All', 'On-Duty', 'Sick Leave', 'Vacation Leave', 'Absent'])}
               </select>
             </label>
-            <hr />
-            <div className="grid grid-cols-2 gap-y-3">
-              <RadioButton label="Work Hours" />
-              <RadioButton label="Undertime" />
-              <RadioButton label="Late" />
-              <RadioButton label="Overtime" />
-            </div>
           </main>
           <footer className="bg-slate-100 px-5 py-3">
             <Button

--- a/client/src/components/molecules/UserMenuDropdown/index.tsx
+++ b/client/src/components/molecules/UserMenuDropdown/index.tsx
@@ -20,7 +20,7 @@ const UserMenuDropDown: FC<Props> = (props): JSX.Element => {
     className = 'shrink-0 outline-none active:scale-95'
   } = props
 
-  const menu = 'relative z-20 flex w-full text-left'
+  const menu = 'relative z-30 flex w-full text-left'
   const menuItems = classNames(
     'absolute flex w-44 flex-col divide-y divide-slate-200 overflow-hidden rounded-md',
     'bg-white py-1 shadow-xl shadow-slate-200 ring-1 ring-black ring-opacity-5 focus:outline-none',

--- a/client/src/pages/dtr-management.tsx
+++ b/client/src/pages/dtr-management.tsx
@@ -7,12 +7,12 @@ import FilterIcon from '~/utils/icons/FilterIcon'
 import Layout from '~/components/templates/Layout'
 import DTRTable from '~/components/molecules/DTRManagementTable'
 import LegendTooltip from '~/components/molecules/LegendTooltip'
+import { mapDTRManagement } from '~/utils/mapping/dtrManagementMap'
 import GlobalSearchFilter from '~/components/molecules/GlobalSearchFilter'
 import { columns } from '~/components/molecules/DTRManagementTable/columns'
 import SummaryMenuDropdown from '~/components/molecules/SummaryMenuDropdown'
 import TimeSheetFilterDropdown from '~/components/molecules/TimeSheetFilterDropdown'
 import { getAllEmployeeTimesheet, IAllTimeSheet } from '~/hooks/useTimesheetQuery'
-import { mapDTRManagement } from '~/utils/mapping/dtrManagementMap'
 
 const DTRManagement: NextPage = (): JSX.Element => {
   const [globalFilter, setGlobalFilter] = useState<string>('')
@@ -26,7 +26,7 @@ const DTRManagement: NextPage = (): JSX.Element => {
   return (
     <Layout metaTitle="DTR Management">
       <section className="default-scrollbar relative h-full min-h-full overflow-auto text-xs text-slate-800">
-        <div className="block md:hidden">
+        <div className="sticky top-0 z-20 block bg-slate-100 md:hidden">
           <div className="flex items-center space-x-2 border-b border-slate-200 px-4 py-2">
             <h1 className="text-base font-semibold text-slate-700">DTR Management</h1>
             <LegendTooltip
@@ -38,7 +38,7 @@ const DTRManagement: NextPage = (): JSX.Element => {
         </div>
         <header
           className={classNames(
-            'sticky top-0 left-0 flex items-center justify-between',
+            'sticky top-[41px] left-0 z-20 flex items-center justify-between md:top-0',
             'border-b border-slate-200 bg-slate-100 px-4 py-2'
           )}
         >
@@ -69,7 +69,7 @@ const DTRManagement: NextPage = (): JSX.Element => {
         </header>
         <DTRTable
           {...{
-            data: mapDTRManagement(timesheets.timeEntries),
+            data: mapDTRManagement(timesheets?.timeEntries),
             columns,
             globalFilter,
             setGlobalFilter

--- a/client/src/utils/mapping/dtrManagementMap.tsx
+++ b/client/src/utils/mapping/dtrManagementMap.tsx
@@ -23,12 +23,12 @@ export interface fetchedData {
 export const mapDTRManagement = (data: fetchedData[]): IDTRManagement[] => {
   const newTable: IDTRManagement[] = []
 
-  data.forEach((entry: fetchedData) => {
+  data?.forEach((entry: fetchedData) => {
     const newRow: IDTRManagement = {
       id: entry.id,
       name: entry.user.name,
-      time_in: entry.timeIn.timeHour,
-      time_out: entry.timeIn.timeHour,
+      time_in: entry.timeIn?.timeHour,
+      time_out: entry.timeIn?.timeHour,
       start_time: entry.startTime,
       end_time: entry.endTime,
       work_hours: parseInt(entry.workedHours.split(':')[0]),


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-29

## Definition of Done

- [x] Resolved the Dropdown TimeSheet Overlays
- [x] Removed the TimeSheet Filter RadioButtons
- [x] Fixed Mobile Deformation Dropdown Timesheet

## Notes
N/A

## Pre-condition
- docker compose build (to build the images)
- docker compose up (to run the containers)
- docker compose up --build (to build and run the containers)
- docker compose down (to stop the containers)

## Expected Output

It should now fixed the Deformation of Timesheet Dropdown

## Screenshots/Recordings
[1.webm](https://user-images.githubusercontent.com/108642414/212615843-c758bd5d-14db-4512-978a-0851cb420f5a.webm)
