### PR TITLE
HRIS-40 [BE] Implement GET specific Time Entry functionality

### DIFF
--- a/api/Schema/Queries/TimeSheetQuery.cs
+++ b/api/Schema/Queries/TimeSheetQuery.cs
@@ -13,6 +13,11 @@ namespace api.Schema.Queries
             _timeSheetService = timeSheetService;
         }
 
+        public async Task<Time?> GetTimeById(int id)
+        {
+            return await _timeSheetService.GetTimeById(id);
+        }
+
         public async Task<TimeEntry?> GetTimeEntryById(int id)
         {
             return await _timeSheetService.GetById(id);

--- a/api/Services/TimeSheetService.cs
+++ b/api/Services/TimeSheetService.cs
@@ -13,6 +13,15 @@ namespace api.Services
             _contextFactory = contextFactory;
         }
 
+        public async Task<Time?> GetTimeById(int id)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                return await context.Times
+                    .FirstOrDefaultAsync(c => c.Id == id);
+            }
+        }
+
         public static TimeEntryDTO ToTimeEntryDTO(TimeEntry timeEntry)
         {
             return new TimeEntryDTO(timeEntry);


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-40

## Definition of Done

- [x] User can fetch Time In/Time Out and Remarks data from the Time Entry Table

## Notes
- BE integration only

## Pre-condition
- Existing Time In/Time Out record inside the Times table
- in your terminal run ``` docker compose up --build ```
- access ``` http://localhost:5257/graphql/ ```
- Try this query:
```
query ($id: Int!) {
    timeById(id: $id) {
        timeHour
        remarks
    }
  }
```
- Variable is the Id of the Time query we want to get:
```
{
  "id": 1
}
```

## Expected Output
- It should return the TimeHour and Remark of the Entry
```
{
  "data": {
    "timeById": {
      "timeHour": "PT9H15M",
      "remarks": "First time in"
    }
  }
}
```

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/109492180/212841852-826ac38e-54fb-4ce1-af82-85a638661e08.png)

