### PR TITLE
HRIS-51 [BE] Implement file work interruption request functionality

### DIFF
--- a/api/Context/HrisContext.cs
+++ b/api/Context/HrisContext.cs
@@ -18,7 +18,8 @@ public partial class HrisContext : DbContext
     public DbSet<WorkingDayTime> WorkingDayTimes { get; set; } = default!;
     public DbSet<Personal_Access_Token> Personal_Access_Tokens { get; set; } = default!;
     public DbSet<Media> Medias { get; set; } = default!;
-
+    public DbSet<WorkInterruptionType> WorkInterruptionTypes { get; set; } = default!;
+    public DbSet<WorkInterruption> WorkInterruptions { get; set; } = default!;
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<EmployeeSchedule>().HasData(
@@ -35,6 +36,9 @@ public partial class HrisContext : DbContext
         );
         modelBuilder.Entity<TimeEntry>().HasData(
             DatabaseSeeder.timeEntries()
+        );
+        modelBuilder.Entity<WorkInterruptionType>().HasData(
+            DatabaseSeeder.workInterruptionType
         );
     }
 

--- a/api/Entities/TimeEntry.cs
+++ b/api/Entities/TimeEntry.cs
@@ -19,5 +19,6 @@ namespace api.Entities
         public User User { get; set; } = default!;
         public Time? TimeIn { get; set; }
         public Time? TimeOut { get; set; }
+        public ICollection<WorkInterruption> WorkInterruptions { get; set; } = default!;
     }
 }

--- a/api/Entities/WorkInterruption.cs
+++ b/api/Entities/WorkInterruption.cs
@@ -1,0 +1,15 @@
+namespace api.Entities
+{
+    public class WorkInterruption : BaseEntity
+    {
+        public int Id { get; set; }
+        public int TimeEntryId { get; set; }
+        public int? WorkInterruptionTypeId { get; set; }
+        public string? OtherReason { get; set; }
+        public TimeSpan? TimeOut { get; set; }
+        public TimeSpan? TimeIn { get; set; }
+        public string? Remarks { get; set; }
+        public WorkInterruptionType? WorkInterruptionType { get; set; }
+        public TimeEntry? TimeEntry { get; set; } = default!;
+    }
+}

--- a/api/Entities/WorkInterruptionType.cs
+++ b/api/Entities/WorkInterruptionType.cs
@@ -1,0 +1,9 @@
+namespace api.Entities
+{
+    public class WorkInterruptionType : BaseEntity
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public ICollection<WorkInterruption> WorkInterruption { get; set; } = default!;
+    }
+}

--- a/api/Enums/WorkInterruptionEnum.cs
+++ b/api/Enums/WorkInterruptionEnum.cs
@@ -1,0 +1,11 @@
+namespace api.Enums
+{
+    public static class WorkInterruptionEnum
+    {
+        public static readonly string POWER_INTERRUPTION = "Power Interruption";
+        public static readonly string LOST_INTERNET_CONNECTION = "Lost Internet Connection";
+        public static readonly string EMERGENCY = "Emergency";
+        public static readonly string ERRANDS = "Errands";
+        public static readonly string OTHERS = "Others";
+    }
+}

--- a/api/Migrations/20230117091858_AddWorkInterruption.Designer.cs
+++ b/api/Migrations/20230117091858_AddWorkInterruption.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
@@ -11,9 +12,11 @@ using api.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(HrisContext))]
-    partial class HrisContextModelSnapshot : ModelSnapshot
+    [Migration("20230117091858_AddWorkInterruption")]
+    partial class AddWorkInterruption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20230117091858_AddWorkInterruption.cs
+++ b/api/Migrations/20230117091858_AddWorkInterruption.cs
@@ -1,0 +1,332 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkInterruption : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WorkInterruptionTypes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkInterruptionTypes", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WorkInterruptions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TimeEntryId = table.Column<int>(type: "int", nullable: false),
+                    WorkInterruptionTypeId = table.Column<int>(type: "int", nullable: true),
+                    OtherReason = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    TimeOut = table.Column<TimeSpan>(type: "time", nullable: true),
+                    TimeIn = table.Column<TimeSpan>(type: "time", nullable: true),
+                    Remarks = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkInterruptions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WorkInterruptions_TimeEntries_TimeEntryId",
+                        column: x => x.TimeEntryId,
+                        principalTable: "TimeEntries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WorkInterruptions_WorkInterruptionTypes_WorkInterruptionTypeId",
+                        column: x => x.WorkInterruptionTypeId,
+                        principalTable: "WorkInterruptionTypes",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.UpdateData(
+                table: "EmployeeSchedules",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 57, 557, DateTimeKind.Local).AddTicks(9570), new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(5989) });
+
+            migrationBuilder.UpdateData(
+                table: "TimeEntries",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "Date", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3704), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3705), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3705) });
+
+            migrationBuilder.UpdateData(
+                table: "TimeEntries",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "Date", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3737), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3738), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3738) });
+
+            migrationBuilder.UpdateData(
+                table: "TimeEntries",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "Date", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3794), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3795), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3794) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3653), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3654) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3683), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3683) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3684), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3684) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3685), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3686) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3686), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3687) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 6,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3688), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3688) });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3507), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3524) });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3528), new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3529) });
+
+            migrationBuilder.InsertData(
+                table: "WorkInterruptionTypes",
+                columns: new[] { "Id", "CreatedAt", "Name", "UpdatedAt" },
+                values: new object[,]
+                {
+                    { 1, new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(184), "Power Interruption", new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(185) },
+                    { 2, new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(1163), "Lost Internet Connection", new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(1165) },
+                    { 3, new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(1166), "Emergency", new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(1167) },
+                    { 4, new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(1167), "Errands", new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(1168) },
+                    { 5, new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(1169), "Others", new DateTime(2023, 1, 17, 17, 18, 57, 562, DateTimeKind.Local).AddTicks(1169) }
+                });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(8502), new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(8508) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(9786), new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(9787) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(9789), new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(9790) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(9791), new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(9792) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(9793), new DateTime(2023, 1, 17, 17, 18, 57, 561, DateTimeKind.Local).AddTicks(9793) });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkInterruptions_TimeEntryId",
+                table: "WorkInterruptions",
+                column: "TimeEntryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkInterruptions_WorkInterruptionTypeId",
+                table: "WorkInterruptions",
+                column: "WorkInterruptionTypeId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WorkInterruptions");
+
+            migrationBuilder.DropTable(
+                name: "WorkInterruptionTypes");
+
+            migrationBuilder.UpdateData(
+                table: "EmployeeSchedules",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 11, 16, 29, 21, 119, DateTimeKind.Local).AddTicks(6322), new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(3854) });
+
+            migrationBuilder.UpdateData(
+                table: "TimeEntries",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "Date", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9692), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9694), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9693) });
+
+            migrationBuilder.UpdateData(
+                table: "TimeEntries",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "Date", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9736), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9737), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9736) });
+
+            migrationBuilder.UpdateData(
+                table: "TimeEntries",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "Date", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9763), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9764), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9764) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9660), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9661) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9665), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9665) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9666), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9667) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9668), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9669) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9669), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9670) });
+
+            migrationBuilder.UpdateData(
+                table: "Times",
+                keyColumn: "Id",
+                keyValue: 6,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9671), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9672) });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 11, 16, 29, 21, 822, DateTimeKind.Local).AddTicks(6529), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9632) });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9638), new DateTime(2023, 1, 12, 17, 5, 8, 395, DateTimeKind.Local).AddTicks(9639) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(6519), new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(6525) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(8034), new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(8036) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(8092), new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(8092) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(8094), new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(8094) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(8098), new DateTime(2023, 1, 11, 16, 29, 21, 121, DateTimeKind.Local).AddTicks(8098) });
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -25,7 +25,8 @@ builder.Services.AddGraphQLServer()
     .AddType<TimeInMutation>()
     .AddType<TimeOutMutation>()
     .AddType<SigninMutation>()
-    .AddType<LogoutMutation>();
+    .AddType<LogoutMutation>()
+    .AddType<InterruptionMutation>();
 
 builder.Services.AddGraphQLServer().AddProjections().AddFiltering().AddSorting();
 
@@ -40,7 +41,7 @@ builder.Services.AddScoped<TimeOutService>();
 builder.Services.AddScoped<TimeSheetService>();
 builder.Services.AddScoped<SigninService>();
 builder.Services.AddScoped<LogoutService>();
-// builder.Services.AddScoped<UserService>();
+builder.Services.AddScoped<InterruptionService>();
 
 builder.Services.AddCors(options =>
 {

--- a/api/Requests/CreateInterruptionRequest.cs
+++ b/api/Requests/CreateInterruptionRequest.cs
@@ -1,0 +1,12 @@
+namespace api.Requests
+{
+    public class CreateInterruptionRequest
+    {
+        public int TimeEntryId { get; set; }
+        public int WorkInterruptionTypeId { get; set; }
+        public TimeSpan? TimeOut { get; set; }
+        public TimeSpan? TimeIn { get; set; }
+        public string? Remarks { get; set; }
+        public string? OtherReason { get; set; }
+    }
+}

--- a/api/Schema/Mutations/InterruptionMutation.cs
+++ b/api/Schema/Mutations/InterruptionMutation.cs
@@ -1,0 +1,21 @@
+using api.Entities;
+using api.Requests;
+using api.Services;
+
+namespace api.Schema.Mutations
+{
+    [ExtendObjectType("Mutation")]
+    public class InterruptionMutation
+    {
+        private readonly InterruptionService _interruptionService;
+        public InterruptionMutation(InterruptionService interruptionService)
+        {
+            _interruptionService = interruptionService;
+        }
+        public async Task<WorkInterruption> CreateWorkInterruption(CreateInterruptionRequest interruption)
+        {
+            return await _interruptionService.Create(interruption);
+        }
+
+    }
+}

--- a/api/Seeders/DatabaseSeeder.cs
+++ b/api/Seeders/DatabaseSeeder.cs
@@ -1,4 +1,5 @@
 using api.Entities;
+using api.Enums;
 
 namespace api.Seeders
 {
@@ -13,37 +14,59 @@ namespace api.Seeders
             new WorkingDayTime {
                 Id = 1,
                 EmployeeScheduleId = employeeSchedule.Id,
-                Day="Monday",
+                Day = "Monday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0)
             },
             new WorkingDayTime {
                 Id = 2,
                 EmployeeScheduleId = employeeSchedule.Id,
-                Day="Tuesday",
+                Day = "Tuesday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0)
             },
             new WorkingDayTime {
                 Id = 3,
                 EmployeeScheduleId = employeeSchedule.Id,
-                Day="Wednesday",
+                Day = "Wednesday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0)
             },
             new WorkingDayTime {
                 Id = 4,
                 EmployeeScheduleId = employeeSchedule.Id,
-                Day="Thursday",
+                Day = "Thursday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0)
             },
             new WorkingDayTime {
                 Id = 5,
                 EmployeeScheduleId = employeeSchedule.Id,
-                Day="Friday",
+                Day = "Friday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0)
+            },
+        };
+        public static List<WorkInterruptionType> workInterruptionType = new List<WorkInterruptionType>(){
+            new WorkInterruptionType {
+                Id = 1,
+                Name = WorkInterruptionEnum.POWER_INTERRUPTION
+            },
+            new WorkInterruptionType {
+                Id = 2,
+                Name = WorkInterruptionEnum.LOST_INTERNET_CONNECTION
+            },
+            new WorkInterruptionType {
+                Id = 3,
+                Name = WorkInterruptionEnum.EMERGENCY
+            },
+            new WorkInterruptionType {
+                Id = 4,
+                Name = WorkInterruptionEnum.ERRANDS
+            },
+            new WorkInterruptionType {
+                Id = 5,
+                Name = WorkInterruptionEnum.OTHERS
             },
         };
         public static User[] users()

--- a/api/Services/InterruptionService.cs
+++ b/api/Services/InterruptionService.cs
@@ -1,0 +1,35 @@
+using api.Context;
+using api.Entities;
+using api.Requests;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Services
+{
+    public class InterruptionService
+    {
+        private readonly IDbContextFactory<HrisContext> _contextFactory = default!;
+        public InterruptionService(IDbContextFactory<HrisContext> contextFactory)
+        {
+            _contextFactory = contextFactory;
+        }
+
+        public async Task<WorkInterruption> Create(CreateInterruptionRequest interruption)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                WorkInterruption work = context.WorkInterruptions.Add(new WorkInterruption
+                {
+                    TimeEntryId = interruption.TimeEntryId,
+                    WorkInterruptionTypeId = interruption.WorkInterruptionTypeId,
+                    OtherReason = interruption.OtherReason,
+                    TimeOut = interruption.TimeOut,
+                    TimeIn = interruption.TimeIn,
+                    Remarks = interruption.Remarks,
+                }).Entity;
+                await context.SaveChangesAsync();
+
+                return work;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-51

## Definition of Done

- [x] Can create work interruption based on time entry
- [x] Setup services, mutation and enums 

## Notes

- This is a backend integration only
- You can access the graphql playground enpoint at http://localhost:5257/graphql/
- To run the mutation, use the following below:
```
mutation($interruption:CreateInterruptionRequestInput!)
{
  createWorkInterruption(interruption:$interruption){
    id
    timeOut
    remarks
  }
}
```
- And use this as your variables:
```
{
  "interruption":{
    "timeEntryId": 3,
    "workInterruptionTypeId": 5,
    "timeOut": "PT13H00M",
    "timeIn": "PT13H30M",
    "remarks": "sample remarks",
    "otherReason": "sample other reason"
  }
}
```
- Also, please bear in mind the ID you pass on your variables such as the time entry and work interruption ids
## Pre-condition
- run the db service on docker first using docker desktop or `docker-compose up -d db`
- cd api
- `dotnet ef database update`
- `docker compose up`

## Expected Output
- You should receive the response below upon running the mutation:
```
{
  "data": {
    "createWorkInterruption": {
      "id": 6,
      "timeOut": "PT13H",
      "remarks": "sample remarks"
    }
  }
}
```
## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/110364637/212873517-327d1dde-4f13-4915-894d-016b750fa4cf.png)

