### PR TITLE
HRIS-50 [Markup] Create Work Interruption Drawer Markup

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@headlessui/react": "^1.7.7",
+        "@hookform/resolvers": "^2.9.10",
         "@tanstack/match-sorter-utils": "^8.7.2",
         "@tanstack/react-query": "^4.22.0",
         "@tanstack/react-table": "^8.7.4",
@@ -20,6 +21,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-feather": "^2.0.10",
+        "react-hook-form": "^7.42.1",
         "react-hot-toast": "^2.4.0",
         "react-icons": "^4.7.1",
         "react-textarea-autosize": "^8.4.0",
@@ -48,7 +50,8 @@
         "tailwind-scrollbar": "^2.0.1",
         "tailwindcss": "^3.2.4",
         "tailwindcss-labeled-groups": "^0.0.2",
-        "typescript": "4.9.4"
+        "typescript": "4.9.4",
+        "yup": "^0.32.11"
       }
     },
     "node_modules/@babel/runtime": {
@@ -106,6 +109,14 @@
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "2.9.10",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.9.10.tgz",
+      "integrity": "sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -504,6 +515,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2266,7 +2283,6 @@
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -2753,6 +2769,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2864,6 +2892,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
       "dev": true
     },
     "node_modules/nanoid": {
@@ -3519,6 +3553,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==",
+      "dev": true
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -3668,6 +3708,21 @@
       },
       "peerDependencies": {
         "react": ">=16.8.6"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.42.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.42.1.tgz",
+      "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-hot-toast": {
@@ -4153,6 +4208,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -4462,6 +4523,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     }
   },
   "dependencies": {
@@ -4503,6 +4582,12 @@
       "requires": {
         "client-only": "^0.0.1"
       }
+    },
+    "@hookform/resolvers": {
+      "version": "2.9.10",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.9.10.tgz",
+      "integrity": "sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -4710,6 +4795,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
     },
     "@types/node": {
@@ -5964,8 +6055,7 @@
     "graphql": {
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "peer": true
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
     "graphql-request": {
       "version": "5.1.0",
@@ -6304,6 +6394,18 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6385,6 +6487,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
       "dev": true
     },
     "nanoid": {
@@ -6799,6 +6907,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==",
+      "dev": true
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -6894,6 +7008,12 @@
       "requires": {
         "prop-types": "^15.7.2"
       }
+    },
+    "react-hook-form": {
+      "version": "7.42.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.42.1.tgz",
+      "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==",
+      "requires": {}
     },
     "react-hot-toast": {
       "version": "2.4.0",
@@ -7227,6 +7347,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true
+    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -7437,6 +7563,21 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      }
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.7",
+    "@hookform/resolvers": "^2.9.10",
     "@tanstack/match-sorter-utils": "^8.7.2",
     "@tanstack/react-query": "^4.22.0",
     "@tanstack/react-table": "^8.7.4",
@@ -26,6 +27,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-feather": "^2.0.10",
+    "react-hook-form": "^7.42.1",
     "react-hot-toast": "^2.4.0",
     "react-icons": "^4.7.1",
     "react-textarea-autosize": "^8.4.0",
@@ -54,6 +56,7 @@
     "tailwind-scrollbar": "^2.0.1",
     "tailwindcss": "^3.2.4",
     "tailwindcss-labeled-groups": "^0.0.2",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "yup": "^0.32.11"
   }
 }

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -26,6 +26,7 @@ type Props = {
     handleToggleSidebar: () => void
     handleToggleTimeInDrawer: () => void
     handleToggleTimeOutDrawer: () => void
+    handleToggleWorkInterruptionDrawer: () => void
   }
 }
 
@@ -35,6 +36,7 @@ const Header: FC<Props> = (props): JSX.Element => {
       handleToggleSidebar,
       handleToggleDrawer,
       handleToggleTimeInDrawer,
+      handleToggleWorkInterruptionDrawer,
       handleToggleTimeOutDrawer
     }
   } = props
@@ -155,7 +157,7 @@ const Header: FC<Props> = (props): JSX.Element => {
             overlay="Break Time"
             arrowContent={<div className="rc-tooltip-arrow-inner"></div>}
           >
-            <Button>
+            <Button onClick={handleToggleWorkInterruptionDrawer}>
               <BreakIcon className="h-7 w-7 fill-current" />
             </Button>
           </Tooltip>

--- a/client/src/components/organisms/WorkInterruptionDrawer/index.tsx
+++ b/client/src/components/organisms/WorkInterruptionDrawer/index.tsx
@@ -1,0 +1,259 @@
+import { X } from 'react-feather'
+import classNames from 'classnames'
+import React, { FC, useEffect } from 'react'
+import { FieldError, useForm } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import TextareaAutosize from 'react-textarea-autosize'
+
+import Text from '~/components/atoms/Text'
+import Avatar from '~/components/atoms/Avatar'
+import SpinnerIcon from '~/utils/icons/SpinnerIcon'
+import { ConfirmInterruptionSchema } from '~/utils/validation'
+import DrawerTemplate from '~/components/templates/DrawerTemplate'
+import { ConfirmInterruptionValues } from '~/utils/types/formValues'
+
+type Props = {
+  isOpenWorkInterruptionDrawer: boolean
+  actions: {
+    handleToggleWorkInterruptionDrawer: () => void
+  }
+}
+
+const WorkInterruptionDrawer: FC<Props> = (props): JSX.Element => {
+  const {
+    isOpenWorkInterruptionDrawer,
+    actions: { handleToggleWorkInterruptionDrawer }
+  } = props
+
+  const {
+    reset,
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting }
+  } = useForm<ConfirmInterruptionValues>({
+    mode: 'onTouched',
+    resolver: yupResolver(ConfirmInterruptionSchema)
+  })
+
+  // This will handle Save Work Interruption
+  const handleSave = async (data: ConfirmInterruptionValues): Promise<void> => {
+    return await new Promise((resolve) => {
+      setTimeout(() => {
+        resolve()
+        handleToggleWorkInterruptionDrawer()
+        alert(JSON.stringify(data, null, 2))
+      }, 2000)
+    })
+  }
+
+  useEffect(() => {
+    if (isOpenWorkInterruptionDrawer) {
+      reset({
+        specify_reason: '',
+        time_in: '',
+        time_out: '',
+        remarks: ''
+      })
+    }
+  }, [isOpenWorkInterruptionDrawer])
+
+  const validationError = (error: FieldError | undefined): string => {
+    return error !== null && error !== undefined
+      ? 'border-rose-500 ring-rose-500 focus:border-rose-500 focus:ring-rose-500'
+      : 'focus:border-primary focus:ring-primary'
+  }
+
+  return (
+    <DrawerTemplate
+      {...{
+        isOpen: isOpenWorkInterruptionDrawer,
+        actions: {
+          handleToggle: handleToggleWorkInterruptionDrawer
+        }
+      }}
+    >
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+        <h1 className="text-base font-medium text-slate-900">Confirm Interruption</h1>
+        <button onClick={handleToggleWorkInterruptionDrawer} className="active:scale-95">
+          <X className="h-6 w-6 stroke-0.5 text-slate-400" />
+        </button>
+      </header>
+      <form
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        onSubmit={handleSubmit(handleSave)}
+        className="default-scrollbar flex h-full flex-col justify-between overflow-y-auto"
+      >
+        {/* Body */}
+        <main className="flex flex-col space-y-3 px-4 py-2">
+          {/* User */}
+          <div className="flex items-center space-x-3 border-b border-slate-200 py-3">
+            <Avatar
+              src="https://avatars.githubusercontent.com/u/38458781?v=4"
+              alt="user-avatar"
+              size="lg"
+              rounded="full"
+            />
+            <div>
+              <Text theme="md" size="sm" weight="bold">
+                Joshua Galit
+              </Text>
+              <p className="text-[11px] leading-tight text-slate-500">Clocking from GMT +8</p>
+              <p className="text-[11px] leading-tight text-slate-500">Last in a few seconds ago</p>
+              <p className="text-[11px] leading-tight text-slate-500">Split time: 12:00 am</p>
+            </div>
+          </div>
+          {/* Error Message */}
+          <div className="relative flex items-center justify-center rounded-md border border-rose-400 bg-rose-50 py-2.5 px-4 shadow-md">
+            <X className="absolute left-4 h-4 w-4 rounded-full bg-rose-500 p-0.5 text-white" />
+            <p className="text-xs font-medium text-rose-500">Something went wrong</p>
+          </div>
+          {/* Work Interruption DropDown */}
+          <section>
+            <label htmlFor="remarks" className="space-y-0.5">
+              <span className="text-xs text-slate-500">Work Interruption</span>
+              <div className="flex justify-center">
+                <select
+                  {...register('work_interruption')}
+                  disabled={isSubmitting}
+                  className={classNames(
+                    'm-0 block w-full rounded placeholder:font-light placeholder:text-slate-400',
+                    'border border-solid border-slate-300 bg-white bg-clip-padding focus:ring-primary',
+                    'resize-none px-3 py-2 text-xs font-normal text-slate-700 transition focus:border-primary',
+                    'ease-in-out focus:bg-white focus:text-slate-700 focus:outline-none',
+                    'disabled:cursor-not-allowed disabled:opacity-50'
+                  )}
+                  aria-label="Default select example"
+                >
+                  <option value="1">Power Interruption</option>
+                  <option value="2">Lost Internet Connection</option>
+                  <option value="3">Emergency</option>
+                  <option value="4">Errands</option>
+                  <option value="5">Others</option>
+                </select>
+              </div>
+            </label>
+          </section>
+
+          {/* Others */}
+          <section>
+            <label htmlFor="remarks" className="space-y-0.5">
+              <span className="text-xs text-slate-500">Specify Reason</span>
+              <TextareaAutosize
+                id="remarks"
+                disabled={isSubmitting}
+                className={classNames(
+                  'm-0 block w-full rounded placeholder:font-light placeholder:text-slate-400',
+                  'border border-solid border-slate-300 bg-white bg-clip-padding',
+                  'resize-none px-3 py-1.5 text-sm font-normal text-slate-700 transition',
+                  'ease-in-out focus:bg-white focus:text-slate-700 focus:outline-none',
+                  'disabled:cursor-not-allowed disabled:opacity-50',
+                  validationError(errors?.specify_reason)
+                )}
+                placeholder="Reason..."
+                {...register('specify_reason')}
+              />
+            </label>
+            {errors?.specify_reason !== null && errors?.specify_reason !== undefined && (
+              <span className="error">{errors?.specify_reason.message}</span>
+            )}
+          </section>
+
+          {/* Time Out */}
+          <section>
+            <label htmlFor="remarks" className="space-y-0.5">
+              <span className="text-xs text-slate-500">Time Out</span>
+              <input
+                type="time"
+                disabled={isSubmitting}
+                className={classNames(
+                  'm-0 block w-full rounded placeholder:font-light placeholder:text-slate-400',
+                  'border border-solid border-slate-300 bg-white bg-clip-padding',
+                  'resize-none px-3 py-2 text-xs font-normal text-slate-700 transition',
+                  'clock:text-white ease-in-out focus:bg-white focus:text-slate-700 focus:outline-none',
+                  'disabled:cursor-not-allowed disabled:opacity-50',
+                  validationError(errors?.time_out)
+                )}
+                {...register('time_out')}
+              />
+            </label>
+            {errors?.time_out !== null && errors?.time_out !== undefined && (
+              <span className="error">{errors?.time_out.message}</span>
+            )}
+          </section>
+          {/* Time In */}
+          <section>
+            <label htmlFor="remarks" className="space-y-0.5">
+              <span className="text-xs text-slate-500">Time In</span>
+              <input
+                type="time"
+                disabled={isSubmitting}
+                className={classNames(
+                  'm-0 block w-full rounded placeholder:font-light placeholder:text-slate-400',
+                  'border border-solid border-slate-300 bg-white bg-clip-padding',
+                  'resize-none px-3 py-2 text-xs font-normal text-slate-700 transition',
+                  'ease-in-out focus:bg-white focus:text-slate-700 focus:outline-none',
+                  'disabled:cursor-not-allowed disabled:opacity-50',
+                  validationError(errors?.time_in)
+                )}
+                {...register('time_in')}
+              />
+            </label>
+            {errors?.time_in !== null && errors?.time_in !== undefined && (
+              <span className="error">{errors?.time_in.message}</span>
+            )}
+          </section>
+          {/* Remarks */}
+          <section>
+            <label htmlFor="remarks" className="space-y-0.5">
+              <span className="text-xs text-slate-500">Remarks</span>
+              <TextareaAutosize
+                id="remarks"
+                disabled={isSubmitting}
+                className={classNames(
+                  'm-0 block min-h-[20vh] w-full rounded placeholder:font-light placeholder:text-slate-400',
+                  'border border-solid border-slate-300 bg-white bg-clip-padding focus:ring-primary',
+                  'resize-none px-3 py-1.5 text-sm font-normal text-slate-700 transition focus:border-primary',
+                  'ease-in-out focus:bg-white focus:text-slate-700 focus:outline-none',
+                  'disabled:cursor-not-allowed disabled:opacity-50'
+                )}
+                placeholder="Message..."
+                {...register('remarks')}
+              />
+            </label>
+          </section>
+        </main>
+        {/* Footer Options */}
+        <footer className="border-t border-slate-200">
+          <div className="flex justify-end py-2 px-4">
+            <button
+              type="button"
+              disabled={isSubmitting}
+              onClick={handleToggleWorkInterruptionDrawer}
+              className={classNames(
+                'disabled:cursor-not-allowed disabled:opacity-50',
+                'flex items-center justify-center border-slate-200 text-xs active:scale-95',
+                'w-24 border-dark-primary py-2 text-dark-primary outline-none'
+              )}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className={classNames(
+                'disabled:cursor-not-allowed disabled:opacity-50',
+                'flex items-center justify-center rounded-md border active:scale-95',
+                'w-24 border-dark-primary bg-primary text-xs text-white outline-none hover:bg-dark-primary'
+              )}
+            >
+              {isSubmitting ? <SpinnerIcon className="h-4 w-4 !fill-amber-500" /> : 'Save'}
+            </button>
+          </div>
+        </footer>
+      </form>
+    </DrawerTemplate>
+  )
+}
+
+export default WorkInterruptionDrawer

--- a/client/src/components/templates/Layout/index.tsx
+++ b/client/src/components/templates/Layout/index.tsx
@@ -10,6 +10,12 @@ const Sidebar = dynamic(async () => await import('~/components/organisms/Sidebar
 const TimeInDrawer = dynamic(async () => await import('~/components/organisms/TimeInDrawer'), {
   ssr: false
 })
+const WorkInterruptionDrawer = dynamic(
+  async () => await import('~/components/organisms/WorkInterruptionDrawer'),
+  {
+    ssr: false
+  }
+)
 const TimeOutDrawer = dynamic(async () => await import('~/components/organisms/TimeOutDrawer'), {
   ssr: false
 })
@@ -26,6 +32,12 @@ const Layout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
   const [isOpenTimeInDrawer, setIsOpenTimeInDrawer] = useLocalStorageState('timeInDrawerToggle', {
     defaultValue: false
   })
+  const [isOpenWorkInterruptionDrawer, setIsOpenWorkInterruptionDrawer] = useLocalStorageState(
+    'workInterruptionDrawerToggle',
+    {
+      defaultValue: false
+    }
+  )
   const [isOpenTimeOutDrawer, setIsOpenTimeOutDrawer] = useLocalStorageState(
     'timeOutDrawerToggle',
     {
@@ -37,6 +49,8 @@ const Layout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
   const handleToggleDrawer = (): void => setIsOpenDrawer(!isOpenDrawer)
   const handleToggleSidebar = (): void => setIsOpenSidebar(!isOpenSidebar)
   const handleToggleTimeInDrawer = (): void => setIsOpenTimeInDrawer(!isOpenTimeInDrawer)
+  const handleToggleWorkInterruptionDrawer = (): void =>
+    setIsOpenWorkInterruptionDrawer(!isOpenWorkInterruptionDrawer)
   const handleToggleTimeOutDrawer = (): void => setIsOpenTimeOutDrawer(!isOpenTimeOutDrawer)
 
   return (
@@ -74,6 +88,7 @@ const Layout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
                 handleToggleDrawer,
                 handleToggleSidebar,
                 handleToggleTimeInDrawer,
+                handleToggleWorkInterruptionDrawer,
                 handleToggleTimeOutDrawer
               }
             }}
@@ -87,6 +102,14 @@ const Layout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
             isOpenTimeInDrawer,
             actions: {
               handleToggleTimeInDrawer
+            }
+          }}
+        />
+        <WorkInterruptionDrawer
+          {...{
+            isOpenWorkInterruptionDrawer,
+            actions: {
+              handleToggleWorkInterruptionDrawer
             }
           }}
         />

--- a/client/src/utils/styles/tailwind.css
+++ b/client/src/utils/styles/tailwind.css
@@ -6,4 +6,7 @@
   .default-scrollbar {
     @apply scrollbar-thin scrollbar-thumb-slate-400 scrollbar-thumb-rounded-md;
   }
+  .error {
+    @apply mt-1 ml-0.5 block text-left text-[11px] text-rose-500;
+  }
 }

--- a/client/src/utils/types/formValues.ts
+++ b/client/src/utils/types/formValues.ts
@@ -1,0 +1,7 @@
+export type ConfirmInterruptionValues = {
+  work_interruption: string
+  specify_reason: string
+  time_out: string
+  time_in: string
+  remarks: string
+}

--- a/client/src/utils/validation/index.ts
+++ b/client/src/utils/validation/index.ts
@@ -1,0 +1,9 @@
+import * as Yup from 'yup'
+
+export const ConfirmInterruptionSchema = Yup.object().shape({
+  work_interruption: Yup.string().required().label('Work Interruption'),
+  specify_reason: Yup.string().required().label('Specify Reason'),
+  time_out: Yup.string().required().label('Time Out'),
+  time_in: Yup.string().required().label('Time In'),
+  remarks: Yup.string().label('Remarks')
+})


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/board/HRIS?selectedIssueKey=HRIS-50&assignee=405757

## Definition of Done

- [x] Re-use the drawer already implemented in the previous Tasks
- [x] Modify its content similar to what is provided in the Figma Design

## Notes
Clock and dropdown might look different from figma but this is the full extent of the customizability of tailwind. 

## Pre-condition

- [x] cd client
- [x] npm i
- [x] npm run dev

## Expected Output

It should display confirm work interruption drawer upon click of orange button.

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/109579325/213085766-589df7cb-063f-49c1-9257-306e49e6e266.png)
![image](https://user-images.githubusercontent.com/109579325/213085835-e1baf631-5f71-4c38-a900-44bd3d54855a.png)

