### PR TITLE
HRIS-56 [BE] Implement GET list of work interruptions for a specific employee functionality

### DIFF
--- a/api/DTOs/WorkInterruptionDTO.cs
+++ b/api/DTOs/WorkInterruptionDTO.cs
@@ -1,0 +1,21 @@
+using api.Entities;
+
+namespace api.DTOs
+{
+    public class WorkInterruptionDTO : WorkInterruption
+    {
+        public new string? TimeOut { get; set; }
+        public new string? TimeIn { get; set; }
+        public WorkInterruptionDTO(WorkInterruption interruption)
+        {
+            Id = interruption.Id;
+            TimeEntryId = interruption.TimeEntryId;
+            WorkInterruptionTypeId = interruption.WorkInterruptionTypeId;
+            OtherReason = interruption.OtherReason;
+            Remarks = interruption.Remarks;
+            TimeOut = interruption.TimeOut.HasValue ? interruption.TimeOut.Value.ToString(@"hh\:mm\:ss") : null;
+            TimeIn = interruption.TimeIn.HasValue ? interruption.TimeIn.Value.ToString(@"hh\:mm\:ss") : null;
+            WorkInterruptionType = interruption.WorkInterruptionType;
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -18,7 +18,8 @@ var connectionString = $"Data Source={dbHost};Initial Catalog={dbName};User ID={
 builder.Services.AddGraphQLServer()
     .AddQueryType(q => q.Name("Query"))
     .AddType<UserQuery>()
-    .AddType<TimeSheetQuery>();
+    .AddType<TimeSheetQuery>()
+    .AddType<InterruptionQuery>();
 
 builder.Services.AddGraphQLServer()
     .AddMutationType(q => q.Name("Mutation"))

--- a/api/Requests/ShowInterruptionRequest.cs
+++ b/api/Requests/ShowInterruptionRequest.cs
@@ -1,0 +1,7 @@
+namespace api.Requests
+{
+    public class ShowInterruptionRequest
+    {
+        public int TimeEntryId { get; set; }
+    }
+}

--- a/api/Schema/Mutations/InterruptionMutation.cs
+++ b/api/Schema/Mutations/InterruptionMutation.cs
@@ -1,4 +1,4 @@
-using api.Entities;
+using api.DTOs;
 using api.Requests;
 using api.Services;
 
@@ -12,7 +12,7 @@ namespace api.Schema.Mutations
         {
             _interruptionService = interruptionService;
         }
-        public async Task<WorkInterruption> CreateWorkInterruption(CreateInterruptionRequest interruption)
+        public async Task<WorkInterruptionDTO> CreateWorkInterruption(CreateInterruptionRequest interruption)
         {
             return await _interruptionService.Create(interruption);
         }

--- a/api/Schema/Queries/InterruptionQuery.cs
+++ b/api/Schema/Queries/InterruptionQuery.cs
@@ -1,0 +1,20 @@
+using api.DTOs;
+using api.Requests;
+using api.Services;
+
+namespace api.Schema.Queries
+{
+    [ExtendObjectType("Query")]
+    public class InterruptionQuery
+    {
+        private readonly InterruptionService _interruptionService;
+        public InterruptionQuery(InterruptionService interruptionService)
+        {
+            _interruptionService = interruptionService;
+        }
+        public async Task<List<WorkInterruptionDTO>> GetInterruptionsByTimeEntryId(ShowInterruptionRequest interruption)
+        {
+            return await _interruptionService.Show(interruption);
+        }
+    }
+}

--- a/api/Services/InterruptionService.cs
+++ b/api/Services/InterruptionService.cs
@@ -1,4 +1,5 @@
 using api.Context;
+using api.DTOs;
 using api.Entities;
 using api.Requests;
 using Microsoft.EntityFrameworkCore;
@@ -13,7 +14,22 @@ namespace api.Services
             _contextFactory = contextFactory;
         }
 
-        public async Task<WorkInterruption> Create(CreateInterruptionRequest interruption)
+        public static WorkInterruptionDTO ToWorkInterruptionDTO(WorkInterruption interruption)
+        {
+            return new WorkInterruptionDTO(interruption);
+        }
+        public async Task<List<WorkInterruptionDTO>> Show(ShowInterruptionRequest interruption)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                return await context.WorkInterruptions
+                            .Include(i => i.WorkInterruptionType)
+                            .Where(i => i.TimeEntryId == interruption.TimeEntryId)
+                            .Select(x => ToWorkInterruptionDTO(x))
+                            .ToListAsync();
+            }
+        }
+        public async Task<WorkInterruptionDTO> Create(CreateInterruptionRequest interruption)
         {
             using (HrisContext context = _contextFactory.CreateDbContext())
             {
@@ -28,7 +44,7 @@ namespace api.Services
                 }).Entity;
                 await context.SaveChangesAsync();
 
-                return work;
+                return new WorkInterruptionDTO(work);
             }
         }
     }

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -9,7 +9,10 @@ module.exports = {
   },
   reactStrictMode: true,
   env: {
-    NEXT_PUBLIC_BACKEND_URL: process.env.NEXT_PUBLIC_BACKEND_URL
+    NEXT_PUBLIC_BACKEND_URL: process.env.NEXT_PUBLIC_BACKEND_URL,
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+    NEXT_PUBLIC_GOOGLE_CLIENT_SECRET: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET,
+    NEXT_PUBLIC_JWT_SECRET: process.env.NEXT_PUBLIC_JWT_SECRET
   },
   images: {
     domains: ['avatars.githubusercontent.com']

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse, NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 
 export default async function middleware(req: NextRequest): Promise<NextResponse | undefined> {
-  const session = await getToken({ req, secret: process.env.JWT_SECRET })
+  const session = await getToken({ req, secret: process.env.NEXT_PUBLIC_JWT_SECRET })
 
   if (session == null) {
     return NextResponse.rewrite(new URL('/sign-in', req.url))

--- a/client/src/pages/api/auth/[...nextauth].ts
+++ b/client/src/pages/api/auth/[...nextauth].ts
@@ -4,9 +4,9 @@ import GoogleProvider from 'next-auth/providers/google'
 export default NextAuth({
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID as string,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string
+      clientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID as string,
+      clientSecret: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET as string
     })
   ],
-  secret: process.env.JWT_SECRET
+  secret: process.env.NEXT_PUBLIC_JWT_SECRET
 })


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-56

## Definition of Done

- [x] Can display work interruptions based on time entry
- [x] Setup services, queries, mutation

## Notes

- This is a backend integration only
- You can access the graphql playground enpoint at http://localhost:5257/graphql/
- To run the query, use the following below:
```
query ($interruption:ShowInterruptionRequestInput!){
  interruptionsByTimeEntryId(interruption:$interruption){
    id
    timeOut
    timeIn
    otherReason
    workInterruptionType{
      id
      name
    }
  }
}
```
- And use this as your variables:
```
{
  "interruption": {
    "timeEntryId": 3
  }
}
```
## Pre-condition
- run the db service on docker first using docker desktop or `docker-compose up -d db`
- cd api
- `docker compose up`

## Expected Output
- You should receive the response below upon running the mutation:
```
{
  "data": {
    "interruptionsByTimeEntryId": [
      {
        "id": 1,
        "timeOut": "11:00:00",
        "timeIn": "11:30:00",
        "otherReason": null,
        "workInterruptionType": {
          "id": 1,
          "name": "Power Interruption"
        }
      },...]
}
```
## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/110364637/213145705-89e62c3c-c390-49c1-b02c-2c3257099449.png)


