### PR TITLE
HRIS-41 [FE] Integrate GET specific Time Entry functionality

### DIFF
--- a/api/DTOs/TimeDTO.cs
+++ b/api/DTOs/TimeDTO.cs
@@ -8,6 +8,7 @@ namespace api.DTOs
         {
             if (time != null)
             {
+                Id = time.Id;
                 TimeHour = time.TimeHour.ToString(@"hh\:mm");
                 Remarks = time.Remarks;
             }

--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import Tooltip from 'rc-tooltip'
 import classNames from 'classnames'
 import { Clock, Edit } from 'react-feather'
@@ -45,24 +46,72 @@ export const columns = [
     header: () => <CellHeader label="Time In" />,
     footer: (info) => info.column.id,
     cell: (props) => (
-      <div className="relative flex">
-        {/* Actual Time In Data */}
-        <span>{props.row.original.timeIn?.timeHour ?? EMPTY}</span>
-        {/* Status */}
-        <span className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')} />
-      </div>
+      <>
+        {props.row.original.timeIn?.remarks !== undefined &&
+        props.row.original.timeIn?.remarks !== '' ? (
+          <Link
+            href={`dtr-management/?time_in=${props.row.original.timeIn?.id}`}
+            className="relative flex cursor-pointer active:scale-95"
+          >
+            {/* Actual Time In Data */}
+            <span>{props.row.original.timeIn?.timeHour ?? EMPTY}</span>
+            {/* Status */}
+            {props.row.original.startTime > props.row.original.timeIn?.timeHour ? (
+              <span
+                className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
+              />
+            ) : (
+              <>
+                {!Number.isNaN(props.row.original.timeIn?.id) && (
+                  <span
+                    className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')}
+                  />
+                )}
+              </>
+            )}
+          </Link>
+        ) : (
+          <div className="relative flex">
+            {/* Actual Time In Data */}
+            <span>{props.row.original.timeIn?.timeHour ?? EMPTY}</span>
+            {/* Status */}
+            {props.row.original.timeIn?.timeHour !== undefined &&
+            props.row.original.timeIn?.timeHour !== ''
+              ? !(props.row.original.startTime > props.row.original.timeIn?.timeHour) && (
+                  <span
+                    className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')}
+                  />
+                )
+              : ''}
+          </div>
+        )}
+      </>
     )
   }),
   columnHelper.accessor('timeOut.timeHour', {
     header: () => <CellHeader label="Time Out" />,
     footer: (info) => info.column.id,
     cell: (props) => (
-      <div className="relative flex">
-        {/* Actual Time In Data */}
-        <span>{props.row.original.timeOut?.timeHour ?? EMPTY}</span>
-        {/* Status */}
-        <span className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500')} />
-      </div>
+      <>
+        {props.row.original.timeOut?.remarks !== undefined &&
+        props.row.original.timeOut?.remarks !== '' ? (
+          <Link
+            href={`dtr-management/?time_out=${props.row.original.timeOut?.id}`}
+            className="relative flex cursor-pointer active:scale-95"
+          >
+            {/* Actual Time In Data */}
+            <span>{props.row.original.timeOut?.timeHour ?? EMPTY}</span>
+            {/* Status */}
+            {!Number.isNaN(props.row.original.timeOut?.id) && (
+              <span
+                className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
+              />
+            )}
+          </Link>
+        ) : (
+          <span>{props.row.original.timeOut?.timeHour ?? EMPTY}</span>
+        )}
+      </>
     )
   }),
   columnHelper.accessor('startTime', {

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import moment from 'moment'
+import Link from 'next/link'
 import Tooltip from 'rc-tooltip'
 import classNames from 'classnames'
 import { Clock, Edit } from 'react-feather'
@@ -33,24 +34,72 @@ export const columns = [
     header: () => <CellHeader label="Time In" />,
     footer: (info) => info.column.id,
     cell: (props) => (
-      <div className="relative flex ">
-        {/* Actual Time In Data */}
-        <span>{props.row.original.timeIn?.timeHour ?? EMPTY}</span>
-        {/* Status */}
-        <span className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')} />
-      </div>
+      <>
+        {props.row.original.timeIn?.remarks !== undefined &&
+        props.row.original.timeIn?.remarks !== '' ? (
+          <Link
+            href={`my-daily-time-record/?time_in=${props.row.original.timeIn?.id}`}
+            className="relative flex cursor-pointer active:scale-95"
+          >
+            {/* Actual Time In Data */}
+            <span>{props.row.original.timeIn?.timeHour ?? EMPTY}</span>
+            {/* Status */}
+            {props.row.original.startTime > props.row.original.timeIn?.timeHour ? (
+              <span
+                className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
+              />
+            ) : (
+              <>
+                {!Number.isNaN(props.row.original.timeIn?.id) && (
+                  <span
+                    className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')}
+                  />
+                )}
+              </>
+            )}
+          </Link>
+        ) : (
+          <div className="relative flex">
+            {/* Actual Time In Data */}
+            <span>{props.row.original.timeIn?.timeHour ?? EMPTY}</span>
+            {/* Status */}
+            {props.row.original.timeIn?.timeHour !== undefined &&
+            props.row.original.timeIn?.timeHour !== ''
+              ? !(props.row.original.startTime > props.row.original.timeIn?.timeHour) && (
+                  <span
+                    className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')}
+                  />
+                )
+              : ''}
+          </div>
+        )}
+      </>
     )
   }),
   columnHelper.accessor('timeOut', {
     header: () => <CellHeader label="Time Out" />,
     footer: (info) => info.column.id,
     cell: (props) => (
-      <div className="relative flex">
-        {/* Actual Time In Data */}
-        <span>{props.row.original.timeOut?.timeHour ?? EMPTY}</span>
-        {/* Status */}
-        <span className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500')} />
-      </div>
+      <>
+        {props.row.original.timeOut?.remarks !== undefined &&
+        props.row.original.timeOut?.remarks !== '' ? (
+          <Link
+            href={`my-daily-time-record/?time_out=${props.row.original.timeOut?.id}`}
+            className="relative flex cursor-pointer active:scale-95"
+          >
+            {/* Actual Time In Data */}
+            <span>{props.row.original.timeOut?.timeHour ?? EMPTY}</span>
+            {/* Status */}
+            {!Number.isNaN(props.row.original.timeOut?.id) && (
+              <span
+                className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
+              />
+            )}
+          </Link>
+        ) : (
+          <span>{props.row.original.timeOut?.timeHour ?? EMPTY}</span>
+        )}
+      </>
     )
   }),
   columnHelper.accessor('startTime', {

--- a/client/src/components/organisms/TimeInDrawer/index.tsx
+++ b/client/src/components/organisms/TimeInDrawer/index.tsx
@@ -3,6 +3,7 @@ import { X } from 'react-feather'
 import classNames from 'classnames'
 import TextareaAutosize from 'react-textarea-autosize'
 import moment from 'moment'
+import { useRouter } from 'next/router'
 import { serialize } from 'tinyduration'
 import { toast } from 'react-hot-toast'
 import { parse } from 'iso8601-duration'
@@ -13,6 +14,7 @@ import DrawerTemplate from '~/components/templates/DrawerTemplate'
 import SpinnerIcon from '~/utils/icons/SpinnerIcon'
 import useTimeInMutation from '~/hooks/useTimeInMutation'
 import useUserQuery from '~/hooks/useUserQuery'
+import { getSpecificTimeEntry } from '~/hooks/useTimesheetQuery'
 
 type Props = {
   isOpenTimeInDrawer: boolean
@@ -22,10 +24,15 @@ type Props = {
 }
 
 const TimeInDrawer: FC<Props> = (props): JSX.Element => {
+  const router = useRouter()
+  const timeInId = router.query.time_in
+  const res = getSpecificTimeEntry(Number(timeInId)).data?.timeById.remarks
+
   const {
     isOpenTimeInDrawer,
     actions: { handleToggleTimeInDrawer }
   } = props
+
   const [remarks, setRemarks] = useState('')
   const [files, setFiles] = useState<FileList | null>(null)
   const [afterStartTime, setAfterStartTime] = useState(false)
@@ -72,6 +79,14 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
     })
   }
 
+  const handleToggleDrawer = (): void => {
+    if (timeInId !== null && timeInId !== undefined) {
+      void router.back()
+    } else {
+      handleToggleTimeInDrawer()
+    }
+  }
+
   useEffect(() => {
     if (timeInMutation.isSuccess) {
       setRemarks('')
@@ -83,7 +98,7 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
   return (
     <DrawerTemplate
       {...{
-        isOpen: isOpenTimeInDrawer,
+        isOpen: timeInId?.length !== undefined ? false : isOpenTimeInDrawer,
         actions: {
           handleToggle: handleToggleTimeInDrawer
         }
@@ -94,7 +109,7 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
         <h1 className="text-base font-medium text-slate-900">
           Confirm {afterStartTime ? 'Late' : ''} Time In
         </h1>
-        <button onClick={handleToggleTimeInDrawer} className="active:scale-95">
+        <button onClick={() => handleToggleDrawer()} className="active:scale-95">
           <X className="h-6 w-6 stroke-0.5 text-slate-400" />
         </button>
       </header>
@@ -142,7 +157,7 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
             <label htmlFor="remarks" className="space-y-0.5">
               <span className="text-xs text-slate-500">Remarks</span>
               <TextareaAutosize
-                value={remarks}
+                value={res ?? remarks}
                 id="remarks"
                 disabled={timeInMutation.isLoading}
                 onChange={(e) => setRemarks(e.target.value)}
@@ -156,7 +171,7 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
               />
             </label>
           </div>
-          {afterStartTime && (
+          {!(timeInId !== undefined && timeInId !== null) && afterStartTime && (
             <div>
               <label htmlFor="screenshots">
                 <span className="text-xs">Screenshots/Proof</span>
@@ -179,34 +194,36 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
         </div>
       </div>
       {/* Footer Options */}
-      <section className="mt-auto border-t border-slate-200">
-        <div className="flex justify-end py-2 px-6">
-          <button
-            type="button"
-            onClick={handleToggleTimeInDrawer}
-            className={classNames(
-              'flex items-center justify-center border-slate-200 text-xs active:scale-95',
-              'w-24 border-dark-primary py-2 text-dark-primary outline-none'
-            )}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            disabled={timeInMutation.isLoading}
-            onClick={handleSaveTimeIn}
-            className={classNames(
-              'flex items-center justify-center rounded-md border active:scale-95',
-              `w-24 border-dark-primary ${
-                !timeInMutation.isLoading ? 'bg-primary hover:bg-dark-primary' : 'bg-slate-400'
-              } text-xs text-white outline-none `
-            )}
-          >
-            {timeInMutation.isLoading && <SpinnerIcon className=" mr-2 fill-gray-500" />}
-            Save
-          </button>
-        </div>
-      </section>
+      {!(timeInId !== undefined && timeInId !== null) && (
+        <section className="mt-auto border-t border-slate-200">
+          <div className="flex justify-end py-2 px-6">
+            <button
+              type="button"
+              onClick={handleToggleTimeInDrawer}
+              className={classNames(
+                'flex items-center justify-center border-slate-200 text-xs active:scale-95',
+                'w-24 border-dark-primary py-2 text-dark-primary outline-none'
+              )}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={timeInMutation.isLoading}
+              onClick={handleSaveTimeIn}
+              className={classNames(
+                'flex items-center justify-center rounded-md border active:scale-95',
+                `w-24 border-dark-primary ${
+                  !timeInMutation.isLoading ? 'bg-primary hover:bg-dark-primary' : 'bg-slate-400'
+                } text-xs text-white outline-none `
+              )}
+            >
+              {timeInMutation.isLoading && <SpinnerIcon className=" mr-2 fill-gray-500" />}
+              Save
+            </button>
+          </div>
+        </section>
+      )}
     </DrawerTemplate>
   )
 }

--- a/client/src/components/organisms/TimeOutDrawer/index.tsx
+++ b/client/src/components/organisms/TimeOutDrawer/index.tsx
@@ -1,17 +1,19 @@
-import React, { FC, useEffect, useState } from 'react'
+import moment from 'moment'
 import { X } from 'react-feather'
 import classNames from 'classnames'
-import TextareaAutosize from 'react-textarea-autosize'
-import { serialize } from 'tinyduration'
 import { toast } from 'react-hot-toast'
-import moment from 'moment'
+import { useRouter } from 'next/router'
+import { serialize } from 'tinyduration'
+import TextareaAutosize from 'react-textarea-autosize'
+import React, { FC, useEffect, useState } from 'react'
 
 import Text from '~/components/atoms/Text'
 import Avatar from '~/components/atoms/Avatar'
-import DrawerTemplate from '~/components/templates/DrawerTemplate'
 import useUserQuery from '~/hooks/useUserQuery'
-import useTimeOutMutation from '~/hooks/useTimeOutMutation'
 import SpinnerIcon from '~/utils/icons/SpinnerIcon'
+import useTimeOutMutation from '~/hooks/useTimeOutMutation'
+import { getSpecificTimeEntry } from '~/hooks/useTimesheetQuery'
+import DrawerTemplate from '~/components/templates/DrawerTemplate'
 
 type Props = {
   isOpenTimeOutDrawer: boolean
@@ -21,6 +23,10 @@ type Props = {
 }
 
 const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
+  const router = useRouter()
+  const timeOutId = router.query.time_out
+  const res = getSpecificTimeEntry(Number(timeOutId)).data?.timeById.remarks
+
   const {
     isOpenTimeOutDrawer,
     actions: { handleToggleTimeOutDrawer }
@@ -47,6 +53,14 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
     })
   }
 
+  const handleToggleDrawer = (): void => {
+    if (timeOutId !== null && timeOutId !== undefined) {
+      void router.back()
+    } else {
+      handleToggleTimeOutDrawer()
+    }
+  }
+
   useEffect(() => {
     if (timeOutMutation.isSuccess) {
       setRemarks('')
@@ -58,7 +72,7 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
   return (
     <DrawerTemplate
       {...{
-        isOpen: isOpenTimeOutDrawer,
+        isOpen: timeOutId?.length !== undefined ? false : isOpenTimeOutDrawer,
         actions: {
           handleToggle: handleToggleTimeOutDrawer
         }
@@ -67,7 +81,7 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
       {/* Header */}
       <header className="flex items-center justify-between border-b border-slate-200 px-6 py-3">
         <h1 className="text-base font-medium text-slate-900">Confirm Time Out</h1>
-        <button onClick={handleToggleTimeOutDrawer} className="active:scale-95">
+        <button onClick={() => handleToggleDrawer()} className="active:scale-95">
           <X className="h-6 w-6 stroke-0.5 text-slate-400" />
         </button>
       </header>
@@ -115,7 +129,7 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
               <span className="text-xs text-slate-500">Remarks</span>
               <TextareaAutosize
                 id="remarks"
-                value={remarks}
+                value={res ?? remarks}
                 disabled={timeOutMutation.isLoading}
                 onChange={(e) => setRemarks(e.target.value)}
                 className={classNames(
@@ -131,32 +145,34 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
         </div>
       </div>
       {/* Footer Options */}
-      <section className="mt-auto border-t border-slate-200">
-        <div className="flex justify-end py-2 px-6">
-          <button
-            type="button"
-            onClick={handleToggleTimeOutDrawer}
-            className={classNames(
-              'flex items-center justify-center border-slate-200 text-xs active:scale-95',
-              'w-24 border-dark-primary py-2 text-dark-primary outline-none'
-            )}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            disabled={timeOutMutation.isLoading}
-            onClick={handleSaveTimeOut}
-            className={classNames(
-              'flex items-center justify-center rounded-md border active:scale-95',
-              'w-24 border-dark-primary bg-primary text-xs text-white outline-none hover:bg-dark-primary'
-            )}
-          >
-            {timeOutMutation.isLoading && <SpinnerIcon className=" mr-2 fill-gray-500" />}
-            Save
-          </button>
-        </div>
-      </section>
+      {!(timeOutId !== undefined && timeOutId !== null) && (
+        <section className="mt-auto border-t border-slate-200">
+          <div className="flex justify-end py-2 px-6">
+            <button
+              type="button"
+              onClick={handleToggleTimeOutDrawer}
+              className={classNames(
+                'flex items-center justify-center border-slate-200 text-xs active:scale-95',
+                'w-24 border-dark-primary py-2 text-dark-primary outline-none'
+              )}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={timeOutMutation.isLoading}
+              onClick={handleSaveTimeOut}
+              className={classNames(
+                'flex items-center justify-center rounded-md border active:scale-95',
+                'w-24 border-dark-primary bg-primary text-xs text-white outline-none hover:bg-dark-primary'
+              )}
+            >
+              {timeOutMutation.isLoading && <SpinnerIcon className=" mr-2 fill-gray-500" />}
+              Save
+            </button>
+          </div>
+        </section>
+      )}
     </DrawerTemplate>
   )
 }

--- a/client/src/components/templates/DrawerTemplate/index.tsx
+++ b/client/src/components/templates/DrawerTemplate/index.tsx
@@ -1,5 +1,6 @@
-import React, { FC, ReactNode } from 'react'
 import classNames from 'classnames'
+import { useRouter } from 'next/router'
+import React, { FC, ReactNode } from 'react'
 
 type Props = {
   children: ReactNode
@@ -10,11 +11,22 @@ type Props = {
 }
 
 const DrawerTemplate: FC<Props> = (props): JSX.Element => {
+  const router = useRouter()
+  const timeIdExists = router.query.time_out !== undefined || router.query.time_in !== undefined
+
   const {
     children,
     isOpen,
     actions: { handleToggle }
   } = props
+
+  const handleTimeIdExists = (): void => {
+    if (timeIdExists) {
+      void router.back()
+    } else {
+      handleToggle()
+    }
+  }
 
   return (
     <aside className="h-screen">
@@ -31,7 +43,7 @@ const DrawerTemplate: FC<Props> = (props): JSX.Element => {
         {/* This will served as the background of the drawer */}
         {!isOpen && (
           <div
-            onClick={handleToggle}
+            onClick={() => handleTimeIdExists()}
             className="fixed inset-0 z-40 cursor-default bg-slate-900/10"
           ></div>
         )}

--- a/client/src/graphql/queries/timesheetQueries.ts
+++ b/client/src/graphql/queries/timesheetQueries.ts
@@ -10,10 +10,12 @@ export const GET_ALL_EMPLOYEE_TIMESHEET = gql`
         name
       }
       timeIn {
+        id
         timeHour
         remarks
       }
       timeOut {
+        id
         timeHour
         remarks
       }
@@ -35,10 +37,14 @@ export const GET_EMPLOYEE_TIMESHEET = gql`
       id
       date
       timeIn {
+        id
         timeHour
+        remarks
       }
       timeOut {
+        id
         timeHour
+        remarks
       }
       startTime
       endTime
@@ -48,6 +54,14 @@ export const GET_EMPLOYEE_TIMESHEET = gql`
       undertime
       overtime
       status
+    }
+  }
+`
+export const GET_SPECIFIC_TIME_ENTRY = gql`
+  query ($id: Int!) {
+    timeById(id: $id) {
+      timeHour
+      remarks
     }
   }
 `

--- a/client/src/hooks/useTimesheetQuery.ts
+++ b/client/src/hooks/useTimesheetQuery.ts
@@ -2,9 +2,10 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import { client } from '~/utils/shared/client'
 import {
   GET_ALL_EMPLOYEE_TIMESHEET,
-  GET_EMPLOYEE_TIMESHEET
+  GET_EMPLOYEE_TIMESHEET,
+  GET_SPECIFIC_TIME_ENTRY
 } from '~/graphql/queries/timesheetQueries'
-import { ITimeEntry, IEmployeeTimeEntry } from '~/utils/types/timeEntryTypes'
+import { ITimeEntry, IEmployeeTimeEntry, ITimeEntryById } from '~/utils/types/timeEntryTypes'
 
 export const getAllEmployeeTimesheet = (): UseQueryResult<
   {
@@ -33,6 +34,23 @@ export const getEmployeeTimesheet = (
     queryFn: async () => await client.request(GET_EMPLOYEE_TIMESHEET, { id: userId }),
     select: (data: { timeEntriesByEmployeeId: IEmployeeTimeEntry[] }) => data,
     enabled: !isNaN(userId)
+  })
+  return result
+}
+
+export const getSpecificTimeEntry = (
+  id: number
+): UseQueryResult<
+  {
+    timeById: ITimeEntryById
+  },
+  unknown
+> => {
+  const result = useQuery({
+    queryKey: ['GET_SPECIFIC_TIME_ENTRY', id],
+    queryFn: async () => await client.request(GET_SPECIFIC_TIME_ENTRY, { id }),
+    select: (data: { timeById: ITimeEntryById }) => data,
+    enabled: !isNaN(id)
   })
   return result
 }

--- a/client/src/utils/types/timeEntryTypes.ts
+++ b/client/src/utils/types/timeEntryTypes.ts
@@ -2,10 +2,12 @@ export interface IEmployeeTimeEntry {
   id: number
   date: string
   timeIn: {
+    id: number
     timeHour: string
     remarks: string
   }
   timeOut: {
+    id: number
     timeHour: string
     remarks: string
   }
@@ -27,10 +29,12 @@ export interface ITimeEntry {
     name: string
   }
   timeIn: {
+    id: number
     timeHour: string
     remarks: string
   }
   timeOut: {
+    id: number
     timeHour: string
     remarks: string
   }
@@ -42,4 +46,9 @@ export interface ITimeEntry {
   undertime: number
   overtime: number
   status: string
+}
+
+export interface ITimeEntryById {
+  timeHour: string
+  remarks: string
 }


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-41

## Definition of Done

- [x] Users can click the time with dots in Time In column and a drawer will appear to check the remarks
- [x] Users can click the time with dots in Time Out column and a drawer will appear to check the remarks
- [x] If a Time In is late, it will reflect a red dot
- [x] If a Time In is with remark, it will reflect a purple dot
- [x] If a Time In does not have a remark nor late, it will not be clickable but if late it will reflect a red dot

## Notes
- FE Integration

## Pre-condition
- Go to the root directory and run ``` docker compose up --build ```
- Pre existing Time Entries

## Expected Output
- If you click a specific Time In time with a dot, it will show a drawer with its remark
- If you click a specific Time In time with a dot, it will show a drawer with its remark

## Screenshots/Recordings
DTR Management Page
![chrome_2z5GUzYKlo](https://user-images.githubusercontent.com/109492180/213620767-417bc235-728e-46a3-94ae-81600e2e3133.gif)

My DTR
![chrome_nZvZtim55H](https://user-images.githubusercontent.com/109492180/213628810-b8141102-3f17-4f85-aaec-66f7c6e24759.gif)


