### PR TITLE
HRIS-48 [BE] Implement GET data based on the filter options

### DIFF
--- a/api/DTOs/TimeEntryDTO.cs
+++ b/api/DTOs/TimeEntryDTO.cs
@@ -15,7 +15,7 @@ namespace api.DTOs
             TimeOutId = timeEntry.TimeOutId;
             StartTime = timeEntry.StartTime.ToString(@"hh\:mm");
             EndTime = timeEntry.EndTime.ToString(@"hh\:mm");
-            Date = timeEntry.Date;
+            Date = DateOnly.FromDateTime(timeEntry.Date);
             WorkedHours = timeEntry.WorkedHours.ToString(@"hh\:mm");
             TrackedHours = timeEntry.TrackedHours.ToString(@"hh\:mm");
             User = timeEntry.User;
@@ -58,6 +58,7 @@ namespace api.DTOs
         public new string? TrackedHours { get; set; }
         public new TimeDTO? TimeIn { get; set; }
         public new TimeDTO? TimeOut { get; set; }
+        public new DateOnly Date { get; set; }
 
         public int? Late { get; set; }
         public int? Undertime { get; set; }

--- a/api/Requests/TimesheetRequest.cs
+++ b/api/Requests/TimesheetRequest.cs
@@ -1,0 +1,8 @@
+namespace api.Requests
+{
+    public class TimeEntryFilter
+    {
+        public DateOnly StartDate { get; set; }
+        public DateOnly EndDate { get; set; }
+    }
+}

--- a/api/Schema/Queries/TimeSheetQuery.cs
+++ b/api/Schema/Queries/TimeSheetQuery.cs
@@ -1,5 +1,6 @@
 using api.DTOs;
 using api.Entities;
+using api.Requests;
 using api.Services;
 
 namespace api.Schema.Queries
@@ -28,9 +29,9 @@ namespace api.Schema.Queries
             return await _timeSheetService.GetTimeEntriesByEmployeeId(id);
         }
 
-        public async Task<List<TimeEntryDTO>> GetTimeEntries()
+        public async Task<List<TimeEntryDTO>> GetTimeEntries(TimeEntryFilter? filter)
         {
-            return await _timeSheetService.GetAll();
+            return await _timeSheetService.GetAll(filter);
         }
     }
 }

--- a/api/Services/TimeSheetService.cs
+++ b/api/Services/TimeSheetService.cs
@@ -1,6 +1,7 @@
 using api.Context;
 using api.DTOs;
 using api.Entities;
+using api.Requests;
 using Microsoft.EntityFrameworkCore;
 
 namespace api.Services
@@ -52,7 +53,7 @@ namespace api.Services
             }
         }
 
-        public async Task<List<TimeEntryDTO>> GetAll()
+        public async Task<List<TimeEntryDTO>> GetAll(TimeEntryFilter? filter)
         {
             using (HrisContext context = _contextFactory.CreateDbContext())
             {
@@ -60,8 +61,19 @@ namespace api.Services
                     .Include(entry => entry.TimeIn)
                     .Include(entry => entry.TimeOut)
                     .Include(entry => entry.User)
-                    .Select(x => ToTimeEntryDTO(x))
+                    .OrderByDescending(entry => entry.Date)
+                    .Select(entry => ToTimeEntryDTO(entry))
                     .ToListAsync();
+
+                if (filter != null)
+                {
+                    var filterDate = from entry in entries
+                                     where filter.StartDate.CompareTo(entry.Date) <= 0
+                                     && filter.EndDate.CompareTo(entry.Date) >= 0
+                                     select entry;
+
+                    entries = filterDate.ToList();
+                }
 
                 return entries;
             }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-48

## Definition of Done

- [x] Can query data according to the date filter
- [x] Users can use `startDate` and `endDate` as filter

## Notes
- Filtering is currently done after database query, which is inefficient.
- Filtering according to status and day will be done in the FE


## Pre-condition

Commands to run
- docker compose up --build
- go to `http://localhost:5257/graphql/`
- try this query
```
query Filter($filter: TimeEntryFilterInput!){
    timeEntries(
      filter: $filter
    ) {
      id
      date
  }
}
```
- with variables `startDate` and `endDate` which you can manually change:
```
{
  "filter": {
    "startDate": "2023-02-01",
    "endDate": "2023-02-15"
  }
}
```

## Expected Output
- The query should return time entries in between `startDate` and `endDate`, inclusive

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/111718037/213367685-94d8289a-9af9-42b9-9e63-a70f16d1285d.png)
