### PR TITLE
HRIS-53 [BE] Implement Edit and Delete Work Interruption Request functionality

### DIFF
--- a/api/Requests/UpdateInterruptionRequest.cs
+++ b/api/Requests/UpdateInterruptionRequest.cs
@@ -1,0 +1,13 @@
+namespace api.Requests
+{
+    public class UpdateInterruptionRequest
+    {
+        public int Id { get; set; }
+        public int WorkInterruptionTypeId { get; set; }
+        public string? TimeOut { get; set; }
+        public string? TimeIn { get; set; }
+        public string? Remarks { get; set; }
+        public string? OtherReason { get; set; }
+
+    }
+}

--- a/api/Schema/Mutations/InterruptionMutation.cs
+++ b/api/Schema/Mutations/InterruptionMutation.cs
@@ -16,6 +16,14 @@ namespace api.Schema.Mutations
         {
             return await _interruptionService.Create(interruption);
         }
+        public async Task<bool> UpdateWorkInterruption(UpdateInterruptionRequest interruption)
+        {
+            return await _interruptionService.Update(interruption);
+        }
+        public async Task<bool> DeleteWorkInterruption(int id)
+        {
+            return await _interruptionService.Delete(id);
+        }
 
     }
 }

--- a/api/Services/InterruptionService.cs
+++ b/api/Services/InterruptionService.cs
@@ -17,6 +17,18 @@ namespace api.Services
         {
             return new WorkInterruptionDTO(interruption);
         }
+        private static WorkInterruption ToWorkInterruption(UpdateInterruptionRequest interruption)
+        {
+            return new WorkInterruption
+            {
+                Id = interruption.Id,
+                WorkInterruptionTypeId = interruption.WorkInterruptionTypeId,
+                TimeOut = interruption.TimeOut != null ? TimeSpan.Parse(interruption.TimeOut) : null,
+                TimeIn = interruption.TimeIn != null ? TimeSpan.Parse(interruption.TimeIn) : null,
+                Remarks = interruption.Remarks,
+                OtherReason = interruption.OtherReason
+            };
+        }
         public async Task<List<WorkInterruptionType>> Index()
         {
             using (HrisContext context = _contextFactory.CreateDbContext())
@@ -33,6 +45,24 @@ namespace api.Services
                             .Where(i => i.TimeEntryId == interruption.TimeEntryId)
                             .Select(x => ToWorkInterruptionDTO(x))
                             .ToListAsync();
+            }
+        }
+        public async Task<bool> Update(UpdateInterruptionRequest interruption)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                WorkInterruption work = ToWorkInterruption(interruption);
+                context.Update(work);
+                context.Entry(work).Property(x => x.TimeEntryId).IsModified = false;
+                return await context.SaveChangesAsync() > 0;
+            }
+        }
+        public async Task<bool> Delete(int Id)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                context.Entry(new WorkInterruption { Id = Id }).State = EntityState.Deleted;
+                return await context.SaveChangesAsync() > 0;
             }
         }
         public async Task<WorkInterruptionDTO> Create(CreateInterruptionRequest interruption)


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-53

## Definition of Done

- [x] Can Update a work interruption based on Id
- [x] Can Delete a work interruption based on Id

## Notes
- This is a backend integration only
- Please create a time entry first if not yet created and use its Id on the variables
- You can access the graphql playground enpoint at http://localhost:5257/graphql/
- To run the update and delete mutation, use the following below:
```
mutation($interruption: UpdateInterruptionRequestInput!){
  updateWorkInterruption(interruption:$interruption)
}

mutation($id:Int!){
  deleteWorkInterruption(id:$id)
}
```
- And use this as your variables respectively:
```
{
  "interruption": {
    "id": 24,
    "otherReason":"Update NEW REASON",
    "remarks":"Update remarks",
    "timeIn":"13:51:00",
    "timeOut":"13:01:00",
    "workInterruptionTypeId": 5
  }
}

{
  "id":24
}
```

## Pre-condition

- `docker compose up --build`
- Create a time entry first if not yet created

## Expected Output
- Should be able to update and delete a work interruption based on the given mutations and variables

## Screenshots/Recordings
- UPDATE
![image](https://user-images.githubusercontent.com/110364637/213663856-dfc6c0cb-970a-4742-beb4-d5f0761c0e55.png)

-DELETE
![image](https://user-images.githubusercontent.com/110364637/213663939-394c7809-90b0-49a4-a7df-5aeddc97a0bf.png)

