### PR TITLE
HRIS-49 [FE] Integrate GET data based on the filter options

### DIFF
--- a/api/Requests/TimesheetRequest.cs
+++ b/api/Requests/TimesheetRequest.cs
@@ -1,8 +1,0 @@
-namespace api.Requests
-{
-    public class TimeEntryFilter
-    {
-        public DateOnly StartDate { get; set; }
-        public DateOnly EndDate { get; set; }
-    }
-}

--- a/api/Schema/Queries/TimeSheetQuery.cs
+++ b/api/Schema/Queries/TimeSheetQuery.cs
@@ -1,6 +1,5 @@
 using api.DTOs;
 using api.Entities;
-using api.Requests;
 using api.Services;
 
 namespace api.Schema.Queries
@@ -29,9 +28,9 @@ namespace api.Schema.Queries
             return await _timeSheetService.GetTimeEntriesByEmployeeId(id);
         }
 
-        public async Task<List<TimeEntryDTO>> GetTimeEntries(TimeEntryFilter? filter)
+        public async Task<List<TimeEntryDTO>> GetTimeEntries(String? date, String? status)
         {
-            return await _timeSheetService.GetAll(filter);
+            return await _timeSheetService.GetAll(date, status);
         }
     }
 }

--- a/api/Services/TimeSheetService.cs
+++ b/api/Services/TimeSheetService.cs
@@ -1,7 +1,6 @@
 using api.Context;
 using api.DTOs;
 using api.Entities;
-using api.Requests;
 using Microsoft.EntityFrameworkCore;
 
 namespace api.Services
@@ -54,7 +53,7 @@ namespace api.Services
             }
         }
 
-        public async Task<List<TimeEntryDTO>> GetAll(TimeEntryFilter? filter)
+        public async Task<List<TimeEntryDTO>> GetAll(String? date = null, String? status = null)
         {
             using (HrisContext context = _contextFactory.CreateDbContext())
             {
@@ -66,14 +65,23 @@ namespace api.Services
                     .Select(entry => ToTimeEntryDTO(entry))
                     .ToListAsync();
 
-                if (filter != null)
+                if (date != null)
                 {
                     var filterDate = from entry in entries
-                                     where filter.StartDate.CompareTo(entry.Date) <= 0
-                                     && filter.EndDate.CompareTo(entry.Date) >= 0
+                                     where DateOnly.Parse(date).CompareTo(entry.Date) == 0
                                      select entry;
 
                     entries = filterDate.ToList();
+
+                }
+
+                if (status != null)
+                {
+                    var filterStatus = from entry in entries
+                                       where entry.Status == status
+                                       select entry;
+
+                    entries = filterStatus.ToList();
                 }
 
                 return entries;

--- a/client/src/components/molecules/DTRManagementTable/index.tsx
+++ b/client/src/components/molecules/DTRManagementTable/index.tsx
@@ -17,7 +17,7 @@ import { ITimeEntry } from '~/utils/types/timeEntryTypes'
 
 type Props = {
   query: {
-    data: ITimeEntry[] | undefined
+    data: ITimeEntry[]
     isLoading: boolean
     error: unknown
   }
@@ -35,10 +35,9 @@ const DTRTable: FC<Props> = (props): JSX.Element => {
   } = props
 
   const [sorting, setSorting] = useState<SortingState>([])
-  const [data] = useState(() => [...(dtrManagementData as ITimeEntry[])])
 
   const table = useReactTable({
-    data,
+    data: dtrManagementData,
     columns,
     // Options
     state: {

--- a/client/src/components/molecules/TimeSheetFilterDropdown/index.tsx
+++ b/client/src/components/molecules/TimeSheetFilterDropdown/index.tsx
@@ -1,21 +1,50 @@
+import moment from 'moment'
 import classNames from 'classnames'
 import { Menu } from '@headlessui/react'
 import React, { FC, ReactNode } from 'react'
 
 import Text from '~/components/atoms/Text'
+import { Filters } from '~/pages/dtr-management'
 import Button from '~/components/atoms/Buttons/Button'
 import MenuTransition from '~/components/templates/MenuTransition'
 
 type Props = {
   className?: string
+  filters: Filters
+  setFilters: React.Dispatch<React.SetStateAction<any>>
+  handleFilterUpdate: Function
   children: ReactNode
 }
 
 const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
-  const { children, className = 'shrink-0 outline-none active:scale-95' } = props
+  const {
+    children,
+    className = 'shrink-0 outline-none active:scale-95',
+    filters,
+    setFilters,
+    handleFilterUpdate
+  } = props
+
+  const dateSelectionRef = React.createRef<HTMLInputElement>()
+
+  const statusOptions = ['All', 'On-Duty', 'Sick Leave', 'Vacation Leave', 'Absent']
 
   const filterStatusOptions = (statusList: string[]): JSX.Element[] => {
     return statusList.map((item) => <option key={item}>{item}</option>)
+  }
+
+  const handleDateChange = (): void => {
+    const selectedDate =
+      dateSelectionRef.current != null ? new Date(dateSelectionRef.current.value) : new Date()
+
+    setFilters({ ...filters, date: moment(selectedDate).format('YYYY-MM-DD') })
+  }
+
+  const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    setFilters({
+      ...filters,
+      status: e.currentTarget.value !== 'All' ? e.currentTarget.value.toLowerCase() : ''
+    })
   }
 
   return (
@@ -34,24 +63,15 @@ const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
               Timesheet Filters
             </Text>
             <div>
-              <select
-                className={classNames(
-                  'w-full rounded-md border border-slate-300 text-xs shadow-sm',
-                  'focus:border-primary focus:ring-1 focus:ring-primary'
-                )}
-              >
-                <option>1-15 Days Timesheet</option>
-                <option>16-31 Days Timesheet</option>
-              </select>
-            </div>
-            <div>
               <input
                 type="date"
                 className={classNames(
                   'w-full rounded-md border border-slate-300 text-xs shadow-sm',
                   'focus:border-primary focus:ring-1 focus:ring-primary'
                 )}
-                defaultValue={new Date().toISOString().substr(0, 10)}
+                defaultValue={filters.date}
+                ref={dateSelectionRef}
+                onChange={handleDateChange}
               />
             </div>
             <label htmlFor="filterStatus" className="flex flex-col space-y-1">
@@ -62,8 +82,9 @@ const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
                 focus:border-primary focus:ring-1 focus:ring-primary
                 `}
                 id="filterStatus"
+                onChange={(e) => handleStatusChange(e)}
               >
-                {filterStatusOptions(['All', 'On-Duty', 'Sick Leave', 'Vacation Leave', 'Absent'])}
+                {filterStatusOptions(statusOptions)}
               </select>
             </label>
           </main>
@@ -75,6 +96,7 @@ const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
                 'w-full border border-dark-primary bg-primary py-2 text-xs text-white',
                 'transition duration-150 ease-in-out hover:bg-dark-primary active:bg-primary'
               )}
+              onClick={(): React.MouseEvent<HTMLInputElement> => handleFilterUpdate()}
             >
               Update Results
             </Button>

--- a/client/src/graphql/queries/timesheetQueries.ts
+++ b/client/src/graphql/queries/timesheetQueries.ts
@@ -1,35 +1,37 @@
 import { gql } from 'graphql-request'
 
-export const GET_ALL_EMPLOYEE_TIMESHEET = gql`
-  query {
-    timeEntries {
-      id
-      date
-      user {
+export const GET_ALL_EMPLOYEE_TIMESHEET = (input: string, argument: string): string => {
+  return gql`
+    query (${input}){
+      timeEntries (${argument}) {
         id
-        name
+        date
+        user {
+          id
+          name
+        }
+        timeIn {
+          id
+          timeHour
+          remarks
+        }
+        timeOut {
+          id
+          timeHour
+          remarks
+        }
+        startTime
+        endTime
+        workedHours
+        trackedHours
+        late
+        undertime
+        overtime
+        status
       }
-      timeIn {
-        id
-        timeHour
-        remarks
-      }
-      timeOut {
-        id
-        timeHour
-        remarks
-      }
-      startTime
-      endTime
-      workedHours
-      trackedHours
-      late
-      undertime
-      overtime
-      status
     }
-  }
-`
+  `
+}
 
 export const GET_EMPLOYEE_TIMESHEET = gql`
   query ($id: Int!) {

--- a/client/src/hooks/useTimesheetQuery.ts
+++ b/client/src/hooks/useTimesheetQuery.ts
@@ -1,13 +1,19 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
+
 import { client } from '~/utils/shared/client'
 import {
   GET_ALL_EMPLOYEE_TIMESHEET,
   GET_EMPLOYEE_TIMESHEET,
   GET_SPECIFIC_TIME_ENTRY
 } from '~/graphql/queries/timesheetQueries'
+import { QueryVariablesType } from '~/pages/dtr-management'
 import { ITimeEntry, IEmployeeTimeEntry, ITimeEntryById } from '~/utils/types/timeEntryTypes'
 
-export const getAllEmployeeTimesheet = (): UseQueryResult<
+export const getAllEmployeeTimesheet = (
+  input: string = '',
+  argument: string,
+  variables: QueryVariablesType
+): UseQueryResult<
   {
     timeEntries: ITimeEntry[]
   },
@@ -15,7 +21,8 @@ export const getAllEmployeeTimesheet = (): UseQueryResult<
 > => {
   const result = useQuery({
     queryKey: ['GET_ALL_EMPLOYEE_TIMESHEET'],
-    queryFn: async () => await client.request(GET_ALL_EMPLOYEE_TIMESHEET),
+    queryFn: async () =>
+      await client.request(GET_ALL_EMPLOYEE_TIMESHEET(input, argument), variables),
     select: (data: { timeEntries: ITimeEntry[] }) => data
   })
   return result


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-49

## Definition of Done
- [x] Users can view time entries by date
- [x] Users can filter result according to date and status


## Notes
- There were changes in the filtering. Previously, 15-days filter is included but is now removed

## Pre-condition
Commands to run
- docker compose up --build
- go to `http://localhost:3000/dtr-management`

## Expected Output
- At first load, it should show all time entries of the current date
- Clicking "Update Results" in Timesheet Filters, it will make a query to the backend according to the selected filters

## Screenshots/Recordings
- New Timesheet Filters UI
![image](https://user-images.githubusercontent.com/111718037/213949574-f31f912f-edb3-4109-b399-2222bfd5bcb5.png)

- Filtering

https://user-images.githubusercontent.com/111718037/213950634-1b439494-d335-4e9d-94f7-ac4645e92dca.mp4

