### PR TITLE
HRIS-46 [BE] Implement GET summary data functionality

### DIFF
--- a/api/DTOs/TimeEntriesSummaryDTO.cs
+++ b/api/DTOs/TimeEntriesSummaryDTO.cs
@@ -1,0 +1,48 @@
+using api.Entities;
+
+namespace api.DTOs
+{
+    public class TimeEntriesSummaryDTO
+    {
+        public TimeEntriesSummaryDTO(TimeEntryDTO timeEntry)
+        {
+            User = timeEntry.User;
+            Leave = 0;
+            Absences = 0;
+            Late = 0;
+            Undertime = 0;
+            Overtime = 0;
+        }
+
+        // override
+        public User User { get; set; }
+        public int Leave { get; set; }
+        public int Absences { get; set; }
+
+        public int? Late { get; set; }
+        public int? Undertime { get; set; }
+        public int? Overtime { get; set; }
+
+        // methods
+        public void AddLeave()
+        {
+            this.Leave++;
+        }
+        public void AddAbsences()
+        {
+            this.Absences++;
+        }
+        public void AddLate(int minutes)
+        {
+            this.Late = this.Late + minutes;
+        }
+        public void AddUndertime(int minutes)
+        {
+            this.Undertime = this.Undertime + minutes;
+        }
+        public void AddOvertime(int minutes)
+        {
+            this.Overtime = this.Overtime + minutes;
+        }
+    }
+}

--- a/api/DTOs/TimeEntryDTO.cs
+++ b/api/DTOs/TimeEntryDTO.cs
@@ -60,9 +60,9 @@ namespace api.DTOs
         public new TimeDTO? TimeOut { get; set; }
         public new DateOnly Date { get; set; }
 
-        public int? Late { get; set; }
-        public int? Undertime { get; set; }
-        public int? Overtime { get; set; }
+        public int Late { get; set; }
+        public int Undertime { get; set; }
+        public int Overtime { get; set; }
 
         public string Status { get; set; }
     }

--- a/api/DTOs/TimeEntryDTO.cs
+++ b/api/DTOs/TimeEntryDTO.cs
@@ -22,6 +22,7 @@ namespace api.DTOs
             TimeIn = timeEntry.TimeIn != null ? new TimeDTO(timeEntry.TimeIn) : null;
             TimeOut = timeEntry.TimeOut != null ? new TimeDTO(timeEntry.TimeOut) : null;
             Overtime = 0;   // for now, default to 0
+            Undertime = 0;
 
             if (timeEntry.TimeIn != null && TimeSpan.Compare(timeEntry.TimeIn.TimeHour, timeEntry.StartTime) > ONTIME)
             {
@@ -32,13 +33,20 @@ namespace api.DTOs
                 Late = 0;
             }
 
+            //  Handle early logout
             if (timeEntry.TimeOut != null && TimeSpan.Compare(timeEntry.EndTime, timeEntry.TimeOut.TimeHour) > ONTIME)
             {
-                Undertime = (int)timeEntry.EndTime.Subtract(timeEntry.TimeOut.TimeHour).TotalMinutes;
+                this.Undertime = Undertime + (int)timeEntry.EndTime.Subtract(timeEntry.TimeOut.TimeHour).TotalMinutes;
             }
-            else
+
+            // Handle work interruptions undertime
+            if (timeEntry.WorkInterruptions.Count > 0)
             {
-                Undertime = 0;
+                foreach (var interruptions in timeEntry.WorkInterruptions)
+                {
+                    var difference = interruptions.TimeIn != null && interruptions.TimeOut != null ? (interruptions.TimeIn - interruptions.TimeOut).Value.TotalMinutes : 0;
+                    this.Undertime = this.Undertime + (int)difference;
+                }
             }
 
             if (timeEntry.TimeIn == null && timeEntry.TimeOut == null)

--- a/api/Schema/Queries/TimeSheetQuery.cs
+++ b/api/Schema/Queries/TimeSheetQuery.cs
@@ -32,5 +32,10 @@ namespace api.Schema.Queries
         {
             return await _timeSheetService.GetAll(date, status);
         }
+
+        public async Task<List<TimeEntriesSummaryDTO>> GetTimesheetSummary(String? startDate, String? endDate)
+        {
+            return await _timeSheetService.GetSummary(startDate, endDate);
+        }
     }
 }

--- a/api/Services/TimeSheetService.cs
+++ b/api/Services/TimeSheetService.cs
@@ -61,6 +61,7 @@ namespace api.Services
                     .Include(entry => entry.TimeIn)
                     .Include(entry => entry.TimeOut)
                     .Include(entry => entry.User)
+                    .Include(entry => entry.WorkInterruptions)
                     .OrderByDescending(entry => entry.Date)
                     .Select(entry => ToTimeEntryDTO(entry))
                     .ToListAsync();
@@ -98,6 +99,7 @@ namespace api.Services
                     .Include(entry => entry.TimeIn)
                     .Include(entry => entry.TimeOut)
                     .Include(entry => entry.User)
+                    .Include(entry => entry.WorkInterruptions)
                     .OrderByDescending(entry => entry.Date)
                     .Select(entry => ToTimeEntryDTO(entry))
                     .ToListAsync();


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-46

## Definition of Done

- [x] Users can get the summary of timesheet of all employee on specific date range

## Notes
- Added computation for undertime when there's work interruption, it affects the whole DTRManagement table

## Pre-condition
Commands to run
- `docker compose up --build` or `dotnet run` on `api` directory
- go to `http://localhost:5257/graphql/`
- use this query and adjust according to need
```
query Summary($startDate: String, $endDate:String){
  timesheetSummary(
    startDate: $startDate
    endDate: $endDate
  ) {
    user{
      name
    }
    leave
    absences
    late
    undertime
    overtime
  }
}
```
- Use and/or adjust these query variables
```
{
  "startDate": "2023-01-01",
  "endDate": "2023-01-30"
}
```

## Expected Output
- The query should return the timesheet summary of all employees between `startDate` and `endDate` inclusively.
- The result should show the number of `absences`, number of `leaves`, minutes of `late`, minutes of `undertime`, minutes of `overtime` and name of an employee.

## Screenshots/Recordings
- Sample Query
![image](https://user-images.githubusercontent.com/111718037/213976032-4c09d72a-233a-45e1-9094-d17c76fc5759.png)

- Sample Data
![image](https://user-images.githubusercontent.com/111718037/213976067-ffc541d8-3f57-49b4-a6af-f8de214a75e5.png)
