### PR TITLE
HRIS-45 [Markup] Create DTR Table Summary Markup

### DIFF
--- a/client/src/components/molecules/DTRSummaryTable/DesktopTable.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/DesktopTable.tsx
@@ -1,0 +1,104 @@
+import React, { FC } from 'react'
+import classNames from 'classnames'
+import { flexRender, Table } from '@tanstack/react-table'
+
+import TableSkeleton from './../SkeletonTable'
+import { IDTRSummary } from '~/utils/interfaces'
+
+type Props = {
+  table: Table<IDTRSummary>
+  isLoading: boolean
+}
+
+const DesktopTable: FC<Props> = ({ table, isLoading }): JSX.Element => {
+  return (
+    <table
+      {...{
+        style: {
+          width: table.getCenterTotalSize()
+        }
+      }}
+    >
+      <thead className="border-b border-slate-200">
+        {table.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <th key={header.id} colSpan={header.colSpan} className="px-4 py-3 text-left">
+                {header.isPlaceholder ? null : (
+                  <div
+                    {...{
+                      className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
+                      onClick: header.column.getToggleSortingHandler()
+                    }}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                  </div>
+                )}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody
+        className={classNames(
+          'w-full divide-y divide-slate-200 border-b border-slate-200',
+          table.getPageCount() === 0 ? 'h-[50vh]' : ''
+        )}
+      >
+        <>
+          {isLoading ? (
+            <TableSkeleton rows={11} column={10} />
+          ) : (
+            <>
+              {table.getPageCount() === 0 ? (
+                <>
+                  <TableMesagge message="No Data Available" />
+                  <TableError message="Something went wrong" />
+                </>
+              ) : (
+                <>
+                  {table.getRowModel().rows.map((row) => (
+                    <tr
+                      key={row.id}
+                      className={classNames(
+                        'group hover:bg-white hover:shadow-md hover:shadow-slate-200'
+                      )}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <td key={cell.id} className="flex-wrap px-4 py-2 capitalize">
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </>
+              )}
+            </>
+          )}
+        </>
+      </tbody>
+    </table>
+  )
+}
+
+const TableMesagge = ({ message }: { message: string }): JSX.Element => {
+  return (
+    <tr className="absolute inset-x-0 left-0 right-0 w-full flex-1">
+      <td className="py-2"></td>
+      <td className="w-full py-2 text-center font-medium text-slate-500">{message}</td>
+      <td className="py-2"></td>
+    </tr>
+  )
+}
+
+const TableError = ({ message }: { message: string }): JSX.Element => {
+  return (
+    <tr className="absolute inset-x-0 left-0 right-0 w-full flex-1 bg-rose-50">
+      <td className="py-2"></td>
+      <td className="w-full py-2 text-center font-medium  text-rose-500">{message}</td>
+      <td className="py-2"></td>
+    </tr>
+  )
+}
+
+export default DesktopTable

--- a/client/src/components/molecules/DTRSummaryTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/MobileDisclose.tsx
@@ -1,0 +1,120 @@
+import React, { FC } from 'react'
+import classNames from 'classnames'
+import { Table } from '@tanstack/react-table'
+import { Disclosure } from '@headlessui/react'
+import { ChevronRight } from 'react-feather'
+
+import Avatar from '~/components/atoms/Avatar'
+import { IDTRSummary } from '~/utils/interfaces'
+import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
+
+type Props = {
+  table: Table<IDTRSummary>
+  isLoading: boolean
+}
+
+const MobileDisclose: FC<Props> = ({ table, isLoading }): JSX.Element => {
+  return (
+    <>
+      {isLoading ? (
+        <div className="flex flex-col px-4 py-3">
+          {Array.from({ length: 30 }, (_, i) => (
+            <LineSkeleton key={i} className="py-1" />
+          ))}
+        </div>
+      ) : (
+        <>
+          {table.getPageCount() === 0 ? (
+            <div className="h-[50vh]">
+              <DiscloseMessage message="No Available Data" />
+              <DiscloseMessage message="Something went wrong" type="error" />
+            </div>
+          ) : (
+            <>
+              {table.getRowModel().rows.map((row) => (
+                <Disclosure key={row.id}>
+                  {({ open }) => (
+                    <>
+                      <Disclosure.Button
+                        className={classNames(
+                          'w-full border-b border-slate-200 py-2 px-4 hover:bg-white',
+                          open ? 'bg-white' : 'hover:shadow-md hover:shadow-slate-200'
+                        )}
+                      >
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center space-x-2">
+                            <div className="flex items-center space-x-2">
+                              <Avatar
+                                src={`https://placeimg.com/640/480/abstract/${row.id}`}
+                                size="base"
+                                rounded="full"
+                              />
+                              <div className="flex flex-col items-start">
+                                <h1 className="font-semibold">{row.original.name}</h1>
+                                <small className="text-slate-500">Web Developer</small>
+                              </div>
+                            </div>
+                          </div>
+                          <ChevronRight
+                            className={classNames(
+                              'h-4 w-4 text-slate-600',
+                              open ? 'rotate-90' : ''
+                            )}
+                          />
+                        </div>
+                      </Disclosure.Button>
+                      <Disclosure.Panel
+                        className={classNames('text-slate-600', open ? 'bg-white shadow-md' : '')}
+                      >
+                        <ul className="flex flex-col divide-y divide-slate-200">
+                          <li className="px-4 py-2">
+                            Leave: <span className="font-semibold">{row.original.leave}</span>
+                          </li>
+                          <li className="px-4 py-2">
+                            Absences: <span className="font-semibold">{row.original.absences}</span>
+                          </li>
+                          <li className="px-4 py-2">
+                            Late: <span className="font-semibold">{row.original.late}</span>
+                          </li>
+                          <li className="px-4 py-2">
+                            Undertime:{' '}
+                            <span className="font-semibold">{row.original.undertime}</span>
+                          </li>
+                          <li className="px-4 py-2">
+                            Overtime: <span className="font-semibold">{row.original.overtime}</span>
+                          </li>
+                        </ul>
+                      </Disclosure.Panel>
+                    </>
+                  )}
+                </Disclosure>
+              ))}
+            </>
+          )}
+        </>
+      )}
+    </>
+  )
+}
+
+const DiscloseMessage = ({
+  message,
+  type = 'default'
+}: {
+  message: string
+  type?: string
+}): JSX.Element => {
+  return (
+    <p
+      className={classNames(
+        'py-2 text-center font-medium',
+        type === 'default' && 'text-slate-500',
+        type === 'error' && 'bg-rose-50 text-rose-500'
+      )}
+    >
+      {message}
+    </p>
+  )
+}
+
+export default MobileDisclose

--- a/client/src/components/molecules/DTRSummaryTable/columns.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/columns.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { createColumnHelper } from '@tanstack/react-table'
+
+import SortIcon from '~/utils/icons/SortIcon'
+import Avatar from '~/components/atoms/Avatar'
+import { IDTRSummary } from '~/utils/interfaces'
+
+const columnHelper = createColumnHelper<IDTRSummary>()
+
+const CellHeader = ({ label }: { label: string }): JSX.Element => {
+  return (
+    <span className="group flex w-[13vw] items-center font-normal text-slate-500">
+      {label}
+      <SortIcon className="ml-2 h-3 w-3 shrink-0 fill-current group-active:scale-95" />
+    </span>
+  )
+}
+
+export const columns = [
+  columnHelper.accessor('name', {
+    header: () => <CellHeader label="Name" />,
+    footer: (info) => info.column.id,
+    cell: (props) => (
+      <div className="flex items-center space-x-2">
+        <Avatar
+          src={`https://placeimg.com/640/480/abstract/${props.row.id}`}
+          size="base"
+          rounded="full"
+        />
+        <div className="flex flex-col items-start">
+          <h1 className="font-semibold">{props.getValue()}</h1>
+          <small className="text-slate-500">Web Developer</small>
+        </div>
+      </div>
+    )
+  }),
+  columnHelper.accessor('leave', {
+    header: () => <CellHeader label="Leave" />,
+    footer: (info) => info.column.id
+  }),
+  columnHelper.accessor('absences', {
+    header: () => <CellHeader label="Absences" />,
+    footer: (info) => info.column.id
+  }),
+  columnHelper.accessor('late', {
+    header: () => <CellHeader label="Late" />,
+    footer: (info) => info.column.id
+  }),
+  columnHelper.accessor('undertime', {
+    header: () => <CellHeader label="Undertime" />,
+    footer: (info) => info.column.id
+  }),
+  columnHelper.accessor('overtime', {
+    header: () => <CellHeader label="Overtime" />,
+    footer: (info) => info.column.id
+  })
+]

--- a/client/src/components/molecules/DTRSummaryTable/index.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/index.tsx
@@ -1,0 +1,94 @@
+import {
+  ColumnDef,
+  SortingState,
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel
+} from '@tanstack/react-table'
+import React, { Dispatch, FC, SetStateAction, useState } from 'react'
+
+import DesktopTable from './DesktopTable'
+import FooterTable from './../FooterTable'
+import MobileDisclose from './MobileDisclose'
+import { fuzzyFilter } from '~/utils/fuzzyFilter'
+import { IDTRSummary } from '~/utils/interfaces'
+
+type Props = {
+  query: {
+    data: IDTRSummary[]
+    isLoading: boolean
+    error: unknown
+  }
+  table: {
+    columns: Array<ColumnDef<IDTRSummary, any>>
+    globalFilter: string
+    setGlobalFilter: Dispatch<SetStateAction<string>>
+  }
+}
+
+const DTRSummaryTable: FC<Props> = (props): JSX.Element => {
+  const {
+    query: { data: dtrSummaryData },
+    table: { columns, globalFilter, setGlobalFilter }
+  } = props
+
+  const [sorting, setSorting] = useState<SortingState>([])
+  // const [data] = useState(() => [...dtrSummaryData])
+
+  const table = useReactTable({
+    data: dtrSummaryData,
+    columns,
+    // Options
+    state: {
+      sorting,
+      globalFilter
+    },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: fuzzyFilter,
+    // Pipeline
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    // Debugger
+    debugTable: false,
+    debugHeaders: false,
+    debugColumns: false
+  })
+
+  return (
+    <>
+      {/* Show only on mobile size */}
+      <div className="block md:hidden">
+        <MobileDisclose
+          {...{
+            table,
+            isLoading: false
+          }}
+        />
+      </div>
+      {/* Show on medium size and beyond */}
+      <div className="mx-auto hidden w-full max-w-fit md:block">
+        <DesktopTable
+          {...{
+            table,
+            isLoading: false
+          }}
+        />
+      </div>
+      {/* Table Pagination & Filtering */}
+      {table.getPageCount() >= 1 && (
+        <FooterTable
+          {...{
+            table
+          }}
+        />
+      )}
+    </>
+  )
+}
+
+export default DTRSummaryTable

--- a/client/src/components/molecules/SummaryMenuDropdown/index.tsx
+++ b/client/src/components/molecules/SummaryMenuDropdown/index.tsx
@@ -6,12 +6,21 @@ import React, { FC, ReactNode } from 'react'
 import MenuTransition from '~/components/templates/MenuTransition'
 
 type Props = {
+  isOpenSummaryTable: boolean
   className?: string
   children: ReactNode
+  actions: {
+    handleToggleSummaryTable: () => void
+  }
 }
 
 const SummaryMenuDropdown: FC<Props> = (props): JSX.Element => {
-  const { children, className = 'shrink-0 outline-none active:scale-95' } = props
+  const {
+    isOpenSummaryTable,
+    children,
+    actions: { handleToggleSummaryTable },
+    className = 'shrink-0 outline-none active:scale-95'
+  } = props
 
   const menuItems = classNames(
     'absolute flex w-44 flex-col divide-y divide-slate-200 overflow-hidden rounded-md',
@@ -24,9 +33,12 @@ const SummaryMenuDropdown: FC<Props> = (props): JSX.Element => {
       <MenuTransition>
         <Menu.Items className={menuItems}>
           <Menu.Item>
-            <button className="relative flex items-center justify-center space-x-2 px-3 py-2 text-xs hover:text-slate-700">
+            <button
+              className="relative flex items-center justify-center space-x-2 px-3 py-2 text-xs hover:text-slate-700"
+              onClick={handleToggleSummaryTable}
+            >
               <FileText className="absolute left-3 h-4 w-4 stroke-0.5" aria-hidden="true" />
-              <span>Summary</span>
+              {isOpenSummaryTable ? <span>DTR Management</span> : <span>Summary</span>}
             </button>
           </Menu.Item>
         </Menu.Items>

--- a/client/src/pages/dtr-management.tsx
+++ b/client/src/pages/dtr-management.tsx
@@ -5,14 +5,17 @@ import { MoreHorizontal } from 'react-feather'
 import React, { useEffect, useState } from 'react'
 
 import FilterIcon from '~/utils/icons/FilterIcon'
+import { dtrSummaryData } from '~/utils/constants'
 import Layout from '~/components/templates/Layout'
 import BarsLoadingIcon from '~/utils/icons/BarsLoadingIcon'
-import DTRTable from '~/components/molecules/DTRManagementTable'
 import LegendTooltip from '~/components/molecules/LegendTooltip'
+import DTRTable from '~/components/molecules/DTRManagementTable'
 import { getAllEmployeeTimesheet } from '~/hooks/useTimesheetQuery'
+import DTRSummaryTable from '~/components/molecules/DTRSummaryTable'
 import GlobalSearchFilter from '~/components/molecules/GlobalSearchFilter'
-import { columns } from '~/components/molecules/DTRManagementTable/columns'
 import SummaryMenuDropdown from '~/components/molecules/SummaryMenuDropdown'
+import { columns } from '~/components/molecules/DTRManagementTable/columns'
+import { columns as dtrSummaryColumns } from '~/components/molecules/DTRSummaryTable/columns'
 import TimeSheetFilterDropdown from '~/components/molecules/TimeSheetFilterDropdown'
 
 export type Filters = {
@@ -26,6 +29,8 @@ export type QueryVariablesType = {
 }
 
 const DTRManagement: NextPage = (): JSX.Element => {
+  const [isOpenSummaryTable, setIsOpenSummaryTable] = useState<boolean>(false)
+  const handleToggleSummaryTable = (): void => setIsOpenSummaryTable(!isOpenSummaryTable)
   const [globalFilter, setGlobalFilter] = useState<string>('')
   const [filters, setFilters] = useState({
     date: moment().format('YYYY-MM-DD'),
@@ -104,6 +109,12 @@ const DTRManagement: NextPage = (): JSX.Element => {
               <span>Filters</span>
             </TimeSheetFilterDropdown>
             <SummaryMenuDropdown
+              {...{
+                isOpenSummaryTable,
+                actions: {
+                  handleToggleSummaryTable
+                }
+              }}
               className={classNames(
                 'rounded border border-slate-200 bg-white py-0.5 px-2 outline-none',
                 'shadow-sm hover:bg-white hover:text-slate-600 active:scale-95'
@@ -114,20 +125,39 @@ const DTRManagement: NextPage = (): JSX.Element => {
           </div>
         </header>
         {!fetchedData.isLoading && fetchedData.data !== undefined ? (
-          <DTRTable
-            {...{
-              query: {
-                data: fetchedData.data.timeEntries,
-                isLoading: fetchedData.isLoading,
-                error
-              },
-              table: {
-                columns,
-                globalFilter,
-                setGlobalFilter
-              }
-            }}
-          />
+          <div>
+            {!isOpenSummaryTable ? (
+              <DTRTable
+                {...{
+                  query: {
+                    data: fetchedData.data.timeEntries,
+                    isLoading: fetchedData.isLoading,
+                    error
+                  },
+                  table: {
+                    columns,
+                    globalFilter,
+                    setGlobalFilter
+                  }
+                }}
+              />
+            ) : (
+              <DTRSummaryTable
+                {...{
+                  query: {
+                    data: dtrSummaryData,
+                    isLoading: fetchedData.isLoading,
+                    error
+                  },
+                  table: {
+                    columns: dtrSummaryColumns,
+                    globalFilter,
+                    setGlobalFilter
+                  }
+                }}
+              />
+            )}
+          </div>
         ) : (
           <div className="flex min-h-[50vh] items-center justify-center">
             <BarsLoadingIcon className="h-7 w-7 fill-current text-amber-500" />

--- a/client/src/utils/constants/index.ts
+++ b/client/src/utils/constants/index.ts
@@ -1,7 +1,7 @@
 import { Clock, FileText, Home, Layers, Sunrise, Users } from 'react-feather'
 
 import MyOvertimeIcon from './../icons/MyOvertimeIcon'
-import { IDTRManagement, IMyDTR, ISidebarLink } from './../interfaces'
+import { IDTRManagement, IMyDTR, ISidebarLink, IDTRSummary } from './../interfaces'
 
 export const sidebarLinks = {
   my_nav: [
@@ -1396,5 +1396,43 @@ export const myDTRData: IMyDTR[] = [
     undertime: 0,
     overtime: 0,
     status: 'On-Duty'
+  }
+]
+export const dtrSummaryData: IDTRSummary[] = [
+  {
+    id: 1,
+    name: 'joshua galit',
+    leave: 0,
+    absences: 0,
+    late: 0,
+    undertime: 1,
+    overtime: 0
+  },
+  {
+    id: 2,
+    name: 'rojelio david',
+    leave: 0,
+    absences: 0,
+    late: 3,
+    undertime: 0,
+    overtime: 0
+  },
+  {
+    id: 3,
+    name: 'Basesos Bergson',
+    leave: 0,
+    absences: 3,
+    late: 0,
+    undertime: 0,
+    overtime: 0
+  },
+  {
+    id: 4,
+    name: 'John Doe',
+    leave: 1,
+    absences: 0,
+    late: 0,
+    undertime: 0,
+    overtime: 0
   }
 ]

--- a/client/src/utils/interfaces/index.tsx
+++ b/client/src/utils/interfaces/index.tsx
@@ -22,6 +22,16 @@ export interface IDTRManagement {
   status: string
 }
 
+export interface IDTRSummary {
+  id: number
+  name: string
+  leave: number
+  absences: number
+  late: number
+  undertime: number
+  overtime: number
+}
+
 export interface IMyDTR {
   id: number
   date: string


### PR DESCRIPTION
## Issue Link

[Backlog Link](https://framgiaph.backlog.com/view/HRIS-45)

## Definition of Done

- [x] Users can view the DTR Summary table

## Notes

## Pre-condition

cd client
npm run dev

or 

run docker

http://localhost:3000/dtr-management

## Expected Output

It should allow the users to change from DTR management table to DTR Summary table and vice versa. 

## Screenshots/Recordings

Title: DTR Summary Table
![image](https://user-images.githubusercontent.com/109579325/214001515-f692f37f-8156-4279-8a8c-cbfcfe9ee165.png)
Title: Mobile DTR Summary Table with button to switch back to DTR management table
![image](https://user-images.githubusercontent.com/109579325/214002808-58869d3f-7b38-4443-8737-ef91050fb15a.png)

