### PR TITLE
HRIS-44 [FE] Integrate GET remarks and uploaded files on the time entry

### DIFF
--- a/client/src/components/organisms/TimeInDrawer/index.tsx
+++ b/client/src/components/organisms/TimeInDrawer/index.tsx
@@ -3,7 +3,6 @@ import { X } from 'react-feather'
 import classNames from 'classnames'
 import TextareaAutosize from 'react-textarea-autosize'
 import moment from 'moment'
-import { useRouter } from 'next/router'
 import { serialize } from 'tinyduration'
 import { toast } from 'react-hot-toast'
 import { parse } from 'iso8601-duration'
@@ -15,7 +14,6 @@ import DrawerTemplate from '~/components/templates/DrawerTemplate'
 import SpinnerIcon from '~/utils/icons/SpinnerIcon'
 import useTimeInMutation from '~/hooks/useTimeInMutation'
 import useUserQuery from '~/hooks/useUserQuery'
-import { getSpecificTimeEntry } from '~/hooks/useTimesheetQuery'
 
 type Props = {
   isOpenTimeInDrawer: boolean
@@ -25,10 +23,6 @@ type Props = {
 }
 
 const TimeInDrawer: FC<Props> = (props): JSX.Element => {
-  const router = useRouter()
-  const timeInId = router.query.time_in
-  const res = getSpecificTimeEntry(Number(timeInId)).data?.timeById.remarks
-
   const {
     isOpenTimeInDrawer,
     actions: { handleToggleTimeInDrawer }
@@ -80,14 +74,6 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
     })
   }
 
-  const handleToggleDrawer = (): void => {
-    if (timeInId !== null && timeInId !== undefined) {
-      void router.back()
-    } else {
-      handleToggleTimeInDrawer()
-    }
-  }
-
   useEffect(() => {
     if (timeInMutation.isSuccess) {
       setRemarks('')
@@ -99,7 +85,7 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
   return (
     <DrawerTemplate
       {...{
-        isOpen: timeInId?.length !== undefined ? false : isOpenTimeInDrawer,
+        isOpen: isOpenTimeInDrawer,
         actions: {
           handleToggle: handleToggleTimeInDrawer
         }
@@ -110,7 +96,7 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
         <h1 className="text-base font-medium text-slate-900">
           Confirm {afterStartTime ? 'Late' : ''} Time In
         </h1>
-        <button onClick={() => handleToggleDrawer()} className="active:scale-95">
+        <button onClick={handleToggleTimeInDrawer} className="active:scale-95">
           <X className="h-6 w-6 stroke-0.5 text-slate-400" />
         </button>
       </header>
@@ -148,7 +134,7 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
             <label htmlFor="remarks" className="space-y-0.5">
               <span className="text-xs text-slate-500">Remarks</span>
               <TextareaAutosize
-                value={res ?? remarks}
+                value={remarks}
                 id="remarks"
                 disabled={timeInMutation.isLoading}
                 onChange={(e) => setRemarks(e.target.value)}
@@ -162,7 +148,7 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
               />
             </label>
           </div>
-          {!(timeInId !== undefined && timeInId !== null) && afterStartTime && (
+          {afterStartTime && (
             <div>
               <label htmlFor="screenshots">
                 <span className="text-xs">Screenshots/Proof</span>
@@ -185,36 +171,34 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
         </div>
       </div>
       {/* Footer Options */}
-      {!(timeInId !== undefined && timeInId !== null) && (
-        <section className="mt-auto border-t border-slate-200">
-          <div className="flex justify-end py-2 px-6">
-            <button
-              type="button"
-              onClick={handleToggleTimeInDrawer}
-              className={classNames(
-                'flex items-center justify-center border-slate-200 text-xs active:scale-95',
-                'w-24 border-dark-primary py-2 text-dark-primary outline-none'
-              )}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              disabled={timeInMutation.isLoading}
-              onClick={handleSaveTimeIn}
-              className={classNames(
-                'flex items-center justify-center rounded-md border active:scale-95',
-                `w-24 border-dark-primary ${
-                  !timeInMutation.isLoading ? 'bg-primary hover:bg-dark-primary' : 'bg-slate-400'
-                } text-xs text-white outline-none `
-              )}
-            >
-              {timeInMutation.isLoading && <SpinnerIcon className=" mr-2 fill-gray-500" />}
-              Save
-            </button>
-          </div>
-        </section>
-      )}
+      <section className="mt-auto border-t border-slate-200">
+        <div className="flex justify-end py-2 px-6">
+          <button
+            type="button"
+            onClick={handleToggleTimeInDrawer}
+            className={classNames(
+              'flex items-center justify-center border-slate-200 text-xs active:scale-95',
+              'w-24 border-dark-primary py-2 text-dark-primary outline-none'
+            )}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={timeInMutation.isLoading}
+            onClick={handleSaveTimeIn}
+            className={classNames(
+              'flex items-center justify-center rounded-md border active:scale-95',
+              `w-24 border-dark-primary ${
+                !timeInMutation.isLoading ? 'bg-primary hover:bg-dark-primary' : 'bg-slate-400'
+              } text-xs text-white outline-none `
+            )}
+          >
+            {timeInMutation.isLoading && <SpinnerIcon className=" mr-2 fill-gray-500" />}
+            Save
+          </button>
+        </div>
+      </section>
     </DrawerTemplate>
   )
 }

--- a/client/src/components/organisms/TimeOutDrawer/index.tsx
+++ b/client/src/components/organisms/TimeOutDrawer/index.tsx
@@ -2,7 +2,6 @@ import moment from 'moment'
 import { X } from 'react-feather'
 import classNames from 'classnames'
 import { toast } from 'react-hot-toast'
-import { useRouter } from 'next/router'
 import { serialize } from 'tinyduration'
 import TextareaAutosize from 'react-textarea-autosize'
 import React, { FC, useEffect, useState } from 'react'
@@ -13,7 +12,6 @@ import Avatar from '~/components/atoms/Avatar'
 import useUserQuery from '~/hooks/useUserQuery'
 import SpinnerIcon from '~/utils/icons/SpinnerIcon'
 import useTimeOutMutation from '~/hooks/useTimeOutMutation'
-import { getSpecificTimeEntry } from '~/hooks/useTimesheetQuery'
 import DrawerTemplate from '~/components/templates/DrawerTemplate'
 
 type Props = {
@@ -24,10 +22,6 @@ type Props = {
 }
 
 const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
-  const router = useRouter()
-  const timeOutId = router.query.time_out
-  const res = getSpecificTimeEntry(Number(timeOutId)).data?.timeById.remarks
-
   const {
     isOpenTimeOutDrawer,
     actions: { handleToggleTimeOutDrawer }
@@ -54,14 +48,6 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
     })
   }
 
-  const handleToggleDrawer = (): void => {
-    if (timeOutId !== null && timeOutId !== undefined) {
-      void router.back()
-    } else {
-      handleToggleTimeOutDrawer()
-    }
-  }
-
   useEffect(() => {
     if (timeOutMutation.isSuccess) {
       setRemarks('')
@@ -73,7 +59,7 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
   return (
     <DrawerTemplate
       {...{
-        isOpen: timeOutId?.length !== undefined ? false : isOpenTimeOutDrawer,
+        isOpen: isOpenTimeOutDrawer,
         actions: {
           handleToggle: handleToggleTimeOutDrawer
         }
@@ -82,7 +68,7 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
       {/* Header */}
       <header className="flex items-center justify-between border-b border-slate-200 px-6 py-3">
         <h1 className="text-base font-medium text-slate-900">Confirm Time Out</h1>
-        <button onClick={() => handleToggleDrawer()} className="active:scale-95">
+        <button onClick={handleToggleTimeOutDrawer} className="active:scale-95">
           <X className="h-6 w-6 stroke-0.5 text-slate-400" />
         </button>
       </header>
@@ -120,7 +106,7 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
               <span className="text-xs text-slate-500">Remarks</span>
               <TextareaAutosize
                 id="remarks"
-                value={res ?? remarks}
+                value={remarks}
                 disabled={timeOutMutation.isLoading}
                 onChange={(e) => setRemarks(e.target.value)}
                 className={classNames(
@@ -136,34 +122,32 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
         </div>
       </div>
       {/* Footer Options */}
-      {!(timeOutId !== undefined && timeOutId !== null) && (
-        <section className="mt-auto border-t border-slate-200">
-          <div className="flex justify-end py-2 px-6">
-            <button
-              type="button"
-              onClick={handleToggleTimeOutDrawer}
-              className={classNames(
-                'flex items-center justify-center border-slate-200 text-xs active:scale-95',
-                'w-24 border-dark-primary py-2 text-dark-primary outline-none'
-              )}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              disabled={timeOutMutation.isLoading}
-              onClick={handleSaveTimeOut}
-              className={classNames(
-                'flex items-center justify-center rounded-md border active:scale-95',
-                'w-24 border-dark-primary bg-primary text-xs text-white outline-none hover:bg-dark-primary'
-              )}
-            >
-              {timeOutMutation.isLoading && <SpinnerIcon className=" mr-2 fill-gray-500" />}
-              Save
-            </button>
-          </div>
-        </section>
-      )}
+      <section className="mt-auto border-t border-slate-200">
+        <div className="flex justify-end py-2 px-6">
+          <button
+            type="button"
+            onClick={handleToggleTimeOutDrawer}
+            className={classNames(
+              'flex items-center justify-center border-slate-200 text-xs active:scale-95',
+              'w-24 border-dark-primary py-2 text-dark-primary outline-none'
+            )}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={timeOutMutation.isLoading}
+            onClick={handleSaveTimeOut}
+            className={classNames(
+              'flex items-center justify-center rounded-md border active:scale-95',
+              'w-24 border-dark-primary bg-primary text-xs text-white outline-none hover:bg-dark-primary'
+            )}
+          >
+            {timeOutMutation.isLoading && <SpinnerIcon className=" mr-2 fill-gray-500" />}
+            Save
+          </button>
+        </div>
+      </section>
     </DrawerTemplate>
   )
 }

--- a/client/src/components/templates/DrawerTemplate/index.tsx
+++ b/client/src/components/templates/DrawerTemplate/index.tsx
@@ -22,7 +22,7 @@ const DrawerTemplate: FC<Props> = (props): JSX.Element => {
 
   const handleTimeIdExists = (): void => {
     if (timeIdExists) {
-      void router.back()
+      void router.replace(router.pathname, undefined, { shallow: false })
     } else {
       handleToggle()
     }

--- a/client/src/graphql/queries/timesheetQueries.ts
+++ b/client/src/graphql/queries/timesheetQueries.ts
@@ -64,6 +64,13 @@ export const GET_SPECIFIC_TIME_ENTRY = gql`
     timeById(id: $id) {
       timeHour
       remarks
+      createdAt
+      media {
+        collectionName
+        name
+        fileName
+        mimeType
+      }
     }
   }
 `

--- a/client/src/utils/types/timeEntryTypes.ts
+++ b/client/src/utils/types/timeEntryTypes.ts
@@ -51,4 +51,13 @@ export interface ITimeEntry {
 export interface ITimeEntryById {
   timeHour: string
   remarks: string
+  createdAt: string
+  media: [
+    {
+      collectionName: string
+      name: string
+      fileName: string
+      mimeType: string
+    }
+  ]
 }


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-44

## Definition of Done

- [x] Users can view the details on their login and logout in My DTR page
- [x] Users can view the details on their login and logout in DTR Management page
- [x] Users can view the files uploaded as proof on their login in My DTR page
- [x] Users can view the files uploaded as proof on their login in DTR Management page

## Notes
- There's a fix on the timeEntryDTO file on sir Arden's next pr 🙇 

## Pre-condition
- Open a cmd terminal > go to the root directory and run the command ``` docker compose up --build ```
- Go to ``` http://localhost:3000/my-daily-time-record ``` & ``` http://localhost:3000/dtr-management ``` 

## Expected Output
- The time itself on the login and logout should be clickable and displays  the details of the login or logout

## Screenshots/Recordings
My DTR page:
![chrome_asDyjQNZhu](https://user-images.githubusercontent.com/109492180/214200662-bcc8de2d-cc4d-4a58-ba17-55eddc125a4f.gif)


DTR Management page:
![chrome_m0gh6xERah](https://user-images.githubusercontent.com/109492180/214200874-430b54dc-adfc-428c-a338-ebefa7809fae.gif)


Checking:
![chrome_kBvMaZJQOO](https://user-images.githubusercontent.com/109492180/214201217-77c6920b-7723-4b56-8347-994fd44d42c7.gif)
