### PR TITLE
HRIS-47 [FE] Integrate GET summary data functionality

### DIFF
--- a/client/src/components/molecules/DTRSummaryTable/DesktopTable.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/DesktopTable.tsx
@@ -8,9 +8,10 @@ import { IDTRSummary } from '~/utils/interfaces'
 type Props = {
   table: Table<IDTRSummary>
   isLoading: boolean
+  error: unknown
 }
 
-const DesktopTable: FC<Props> = ({ table, isLoading }): JSX.Element => {
+const DesktopTable: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
   return (
     <table
       {...{
@@ -53,8 +54,9 @@ const DesktopTable: FC<Props> = ({ table, isLoading }): JSX.Element => {
               {table.getPageCount() === 0 ? (
                 <>
                   <TableMesagge message="No Data Available" />
-                  <TableError message="Something went wrong" />
                 </>
+              ) : error !== null ? (
+                <TableError message="Something went wrong" />
               ) : (
                 <>
                   {table.getRowModel().rows.map((row) => (

--- a/client/src/components/molecules/DTRSummaryTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/MobileDisclose.tsx
@@ -11,9 +11,10 @@ import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 type Props = {
   table: Table<IDTRSummary>
   isLoading: boolean
+  error: unknown
 }
 
-const MobileDisclose: FC<Props> = ({ table, isLoading }): JSX.Element => {
+const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
   return (
     <>
       {isLoading ? (
@@ -27,8 +28,9 @@ const MobileDisclose: FC<Props> = ({ table, isLoading }): JSX.Element => {
           {table.getPageCount() === 0 ? (
             <div className="h-[50vh]">
               <DiscloseMessage message="No Available Data" />
-              <DiscloseMessage message="Something went wrong" type="error" />
             </div>
+          ) : error !== null ? (
+            <DiscloseMessage message="Something went wrong" />
           ) : (
             <>
               {table.getRowModel().rows.map((row) => (

--- a/client/src/components/molecules/DTRSummaryTable/columns.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/columns.tsx
@@ -3,9 +3,9 @@ import { createColumnHelper } from '@tanstack/react-table'
 
 import SortIcon from '~/utils/icons/SortIcon'
 import Avatar from '~/components/atoms/Avatar'
-import { IDTRSummary } from '~/utils/interfaces'
+import { ITimesheetSummary } from '~/utils/types/timeEntryTypes'
 
-const columnHelper = createColumnHelper<IDTRSummary>()
+const columnHelper = createColumnHelper<ITimesheetSummary>()
 
 const CellHeader = ({ label }: { label: string }): JSX.Element => {
   return (
@@ -17,7 +17,7 @@ const CellHeader = ({ label }: { label: string }): JSX.Element => {
 }
 
 export const columns = [
-  columnHelper.accessor('name', {
+  columnHelper.accessor('user.name', {
     header: () => <CellHeader label="Name" />,
     footer: (info) => info.column.id,
     cell: (props) => (

--- a/client/src/components/molecules/DTRSummaryTable/index.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/index.tsx
@@ -13,16 +13,16 @@ import DesktopTable from './DesktopTable'
 import FooterTable from './../FooterTable'
 import MobileDisclose from './MobileDisclose'
 import { fuzzyFilter } from '~/utils/fuzzyFilter'
-import { IDTRSummary } from '~/utils/interfaces'
+import { ITimesheetSummary } from '~/utils/types/timeEntryTypes'
 
 type Props = {
   query: {
-    data: IDTRSummary[]
+    data: ITimesheetSummary[]
     isLoading: boolean
     error: unknown
   }
   table: {
-    columns: Array<ColumnDef<IDTRSummary, any>>
+    columns: Array<ColumnDef<ITimesheetSummary, any>>
     globalFilter: string
     setGlobalFilter: Dispatch<SetStateAction<string>>
   }
@@ -30,12 +30,11 @@ type Props = {
 
 const DTRSummaryTable: FC<Props> = (props): JSX.Element => {
   const {
-    query: { data: dtrSummaryData },
+    query: { data: dtrSummaryData, error },
     table: { columns, globalFilter, setGlobalFilter }
   } = props
 
   const [sorting, setSorting] = useState<SortingState>([])
-  // const [data] = useState(() => [...dtrSummaryData])
 
   const table = useReactTable({
     data: dtrSummaryData,
@@ -66,7 +65,8 @@ const DTRSummaryTable: FC<Props> = (props): JSX.Element => {
         <MobileDisclose
           {...{
             table,
-            isLoading: false
+            isLoading: false,
+            error
           }}
         />
       </div>
@@ -75,7 +75,8 @@ const DTRSummaryTable: FC<Props> = (props): JSX.Element => {
         <DesktopTable
           {...{
             table,
-            isLoading: false
+            isLoading: false,
+            error
           }}
         />
       </div>

--- a/client/src/components/molecules/TimeSheetFilterDropdown/index.tsx
+++ b/client/src/components/molecules/TimeSheetFilterDropdown/index.tsx
@@ -13,6 +13,7 @@ type Props = {
   filters: Filters
   setFilters: React.Dispatch<React.SetStateAction<any>>
   handleFilterUpdate: Function
+  isOpenSummaryTable: boolean
   children: ReactNode
 }
 
@@ -22,12 +23,19 @@ const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
     className = 'shrink-0 outline-none active:scale-95',
     filters,
     setFilters,
-    handleFilterUpdate
+    handleFilterUpdate,
+    isOpenSummaryTable
   } = props
 
   const dateSelectionRef = React.createRef<HTMLInputElement>()
 
+  const monthYearSelectionRef = React.createRef<HTMLInputElement>()
+
+  const daysRangeSelectionRef = React.createRef<HTMLSelectElement>()
+
   const statusOptions = ['All', 'On-Duty', 'Sick Leave', 'Vacation Leave', 'Absent']
+
+  const daysRangeOptions = ['1-15 Days Timesheet', '16-31 Days Timesheet']
 
   const filterStatusOptions = (statusList: string[]): JSX.Element[] => {
     return statusList.map((item) => <option key={item}>{item}</option>)
@@ -47,6 +55,32 @@ const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
     })
   }
 
+  const handleSummaryFilterChange = (): void => {
+    if (monthYearSelectionRef.current !== null) {
+      const monthyear = monthYearSelectionRef.current.value
+      daysRangeSelectionRef.current?.value === daysRangeOptions[0]
+        ? setFilters({
+            ...filters,
+            startDate: moment(`${monthyear}` + '-01').format('YYYY-MM-DD'),
+            endDate: moment(`${monthyear}` + '-15').format('YYYY-MM-DD')
+          })
+        : setFilters({
+            ...filters,
+            startDate: moment(`${monthyear}` + '-16').format('YYYY-MM-DD'),
+            endDate: moment(`${monthyear}` + '-16')
+              .endOf('month')
+              .format('YYYY-MM-DD')
+          })
+    }
+  }
+
+  const getDefaultStatus = (statusFilter: string): string => {
+    for (let i = 0; i < statusOptions.length; i++) {
+      if (statusOptions[i].toLowerCase() === statusFilter) return statusOptions[i]
+    }
+    return 'All'
+  }
+
   return (
     <Menu as="div" className="relative z-10 flex w-full">
       <Menu.Button className={className}>{children}</Menu.Button>
@@ -62,31 +96,65 @@ const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
             <Text theme="sm" weight="semibold" className="text-slate-500">
               Timesheet Filters
             </Text>
-            <div>
-              <input
-                type="date"
-                className={classNames(
-                  'w-full rounded-md border border-slate-300 text-xs shadow-sm',
-                  'focus:border-primary focus:ring-1 focus:ring-primary'
-                )}
-                defaultValue={filters.date}
-                ref={dateSelectionRef}
-                onChange={handleDateChange}
-              />
-            </div>
-            <label htmlFor="filterStatus" className="flex flex-col space-y-1">
-              <span className="text-xs text-slate-500">Filter Status</span>
-              <select
-                className={`
+            {isOpenSummaryTable ? (
+              <>
+                <input
+                  type="month"
+                  className={classNames(
+                    'w-full rounded-md border border-slate-300 text-xs shadow-sm',
+                    'focus:border-primary focus:ring-1 focus:ring-primary'
+                  )}
+                  ref={monthYearSelectionRef}
+                  defaultValue={moment().format('YYYY-MM')}
+                  onChange={handleSummaryFilterChange}
+                ></input>
+                <select
+                  className={classNames(
+                    'w-full rounded-md border border-slate-300 text-xs shadow-sm',
+                    'focus:border-primary focus:ring-1 focus:ring-primary'
+                  )}
+                  ref={daysRangeSelectionRef}
+                  onChange={handleSummaryFilterChange}
+                  defaultValue={
+                    new Date(filters.endDate).getDate() > 15
+                      ? daysRangeOptions[1]
+                      : daysRangeOptions[0]
+                  }
+                >
+                  <option>{daysRangeOptions[0]}</option>
+                  <option>{daysRangeOptions[1]}</option>
+                </select>
+              </>
+            ) : (
+              <>
+                <div>
+                  <input
+                    type="date"
+                    className={classNames(
+                      'w-full rounded-md border border-slate-300 text-xs shadow-sm',
+                      'focus:border-primary focus:ring-1 focus:ring-primary'
+                    )}
+                    defaultValue={filters.date}
+                    ref={dateSelectionRef}
+                    onChange={handleDateChange}
+                  />
+                </div>
+                <label htmlFor="filterStatus" className="flex flex-col space-y-1">
+                  <span className="text-xs text-slate-500">Filter Status</span>
+                  <select
+                    className={`
                   w-full rounded-md border border-slate-300 text-xs shadow-sm 
                 focus:border-primary focus:ring-1 focus:ring-primary
                 `}
-                id="filterStatus"
-                onChange={(e) => handleStatusChange(e)}
-              >
-                {filterStatusOptions(statusOptions)}
-              </select>
-            </label>
+                    id="filterStatus"
+                    defaultValue={getDefaultStatus(filters.status)}
+                    onChange={(e) => handleStatusChange(e)}
+                  >
+                    {filterStatusOptions(statusOptions)}
+                  </select>
+                </label>
+              </>
+            )}
           </main>
           <footer className="bg-slate-100 px-5 py-3">
             <Button

--- a/client/src/graphql/queries/timesheetQueries.ts
+++ b/client/src/graphql/queries/timesheetQueries.ts
@@ -74,3 +74,21 @@ export const GET_SPECIFIC_TIME_ENTRY = gql`
     }
   }
 `
+
+export const GET_TIMESHEET_SUMMARY = (input: string, argument: string): string => {
+  return gql`
+    query (${input}){
+      timesheetSummary (${argument}) {
+        user{
+          id
+          name
+        }
+        leave
+        absences
+        late
+        undertime
+        overtime
+      }
+    }
+  `
+}

--- a/client/src/hooks/useTimesheetQuery.ts
+++ b/client/src/hooks/useTimesheetQuery.ts
@@ -4,10 +4,16 @@ import { client } from '~/utils/shared/client'
 import {
   GET_ALL_EMPLOYEE_TIMESHEET,
   GET_EMPLOYEE_TIMESHEET,
-  GET_SPECIFIC_TIME_ENTRY
+  GET_SPECIFIC_TIME_ENTRY,
+  GET_TIMESHEET_SUMMARY
 } from '~/graphql/queries/timesheetQueries'
 import { QueryVariablesType } from '~/pages/dtr-management'
-import { ITimeEntry, IEmployeeTimeEntry, ITimeEntryById } from '~/utils/types/timeEntryTypes'
+import {
+  ITimeEntry,
+  IEmployeeTimeEntry,
+  ITimeEntryById,
+  ITimesheetSummary
+} from '~/utils/types/timeEntryTypes'
 
 export const getAllEmployeeTimesheet = (
   input: string = '',
@@ -58,6 +64,24 @@ export const getSpecificTimeEntry = (
     queryFn: async () => await client.request(GET_SPECIFIC_TIME_ENTRY, { id }),
     select: (data: { timeById: ITimeEntryById }) => data,
     enabled: !isNaN(id)
+  })
+  return result
+}
+
+export const getTimesheetSummary = (
+  input: string = '',
+  argument: string,
+  variables: QueryVariablesType
+): UseQueryResult<
+  {
+    timesheetSummary: ITimesheetSummary[]
+  },
+  unknown
+> => {
+  const result = useQuery({
+    queryKey: ['GET_TIMESHEET_SUMMARY'],
+    queryFn: async () => await client.request(GET_TIMESHEET_SUMMARY(input, argument), variables),
+    select: (data: { timesheetSummary: ITimesheetSummary[] }) => data
   })
   return result
 }

--- a/client/src/utils/types/timeEntryTypes.ts
+++ b/client/src/utils/types/timeEntryTypes.ts
@@ -61,3 +61,15 @@ export interface ITimeEntryById {
     }
   ]
 }
+
+export interface ITimesheetSummary {
+  user: {
+    id: number
+    name: string
+  }
+  leave: number
+  absences: number
+  late: number
+  undertime: number
+  overtime: number
+}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-47

## Definition of Done
- [x] Users can view timesheet summary of all employees
- [x] Users can filter the summary by half a month

## Notes
- all the displayed data are defaulted to in relation to current date

## Pre-condition
Commands to run
- `docker compose up --build`
- or `npm run dev` on `client` directory and `dotnet watch` on `api` directory
- go to `http://localhost:3000/dtr-management`
- open summary table by clicking `Summary` button on the right of `Filter` button

## Expected Output
- DTRManagement page should display summary of all employees (default data related to current date)
- User can filter to other date range using the `filter` button

## Screenshots/Recordings
[SummaryIntegration.webm](https://user-images.githubusercontent.com/111718037/214269806-605d141c-91b9-45c1-a7e0-bb63ac836035.webm)

