### PR TITLE
HRIS-57 [FE] Integrate GET list of work interruptions for a specific employee functionality

### DIFF
--- a/api/DTOs/TimeEntryDTO.cs
+++ b/api/DTOs/TimeEntryDTO.cs
@@ -40,7 +40,7 @@ namespace api.DTOs
             }
 
             // Handle work interruptions undertime
-            if (timeEntry.WorkInterruptions.Count > 0)
+            if (timeEntry.WorkInterruptions?.Count > 0)
             {
                 foreach (var interruptions in timeEntry.WorkInterruptions)
                 {

--- a/api/DTOs/WorkInterruptionDTO.cs
+++ b/api/DTOs/WorkInterruptionDTO.cs
@@ -16,6 +16,8 @@ namespace api.DTOs
             TimeOut = interruption.TimeOut.HasValue ? interruption.TimeOut.Value.ToString(@"hh\:mm\:ss") : null;
             TimeIn = interruption.TimeIn.HasValue ? interruption.TimeIn.Value.ToString(@"hh\:mm\:ss") : null;
             WorkInterruptionType = interruption.WorkInterruptionType;
+            CreatedAt = interruption.CreatedAt;
+            UpdatedAt = interruption.UpdatedAt;
         }
     }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1285,8 +1285,7 @@
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4613,7 +4612,8 @@
     "@graphql-typed-document-node/core": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg=="
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "requires": {}
     },
     "@headlessui/react": {
       "version": "1.7.7",
@@ -4626,7 +4626,8 @@
     "@hookform/resolvers": {
       "version": "2.9.10",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.9.10.tgz",
-      "integrity": "sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A=="
+      "integrity": "sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -4791,7 +4792,8 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz",
       "integrity": "sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tanstack/match-sorter-utils": {
       "version": "8.7.6",
@@ -5024,7 +5026,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -5355,8 +5358,7 @@
     "csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "debug": {
       "version": "4.3.4",
@@ -5580,13 +5582,15 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
       "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard-with-typescript": {
       "version": "24.0.0",
@@ -5733,7 +5737,8 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
       "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.31.11",
@@ -6082,7 +6087,8 @@
     "goober": {
       "version": "2.1.11",
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.11.tgz",
-      "integrity": "sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A=="
+      "integrity": "sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A==",
+      "requires": {}
     },
     "gopd": {
       "version": "1.0.1",
@@ -6936,7 +6942,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.1.tgz",
       "integrity": "sha512-aIO8IguumORyRsmT+E7JfJ3A9FEoyhqZR7Au7TBOege3VZkgMvHJMkufeYp4zjnDK2iq4ktkvGMNOQR9T8lisQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "pretty-format": {
       "version": "3.8.0",
@@ -7041,7 +7048,8 @@
     "react-confirm-alert": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-3.0.6.tgz",
-      "integrity": "sha512-rplP6Ed9ZSNd0KFV5BUzk4EPQ77BxsrayllBXGFuA8xPXc7sbBjgU5KUrNpl7aWFmP7mXRlVXfuy1IT5DbffYw=="
+      "integrity": "sha512-rplP6Ed9ZSNd0KFV5BUzk4EPQ77BxsrayllBXGFuA8xPXc7sbBjgU5KUrNpl7aWFmP7mXRlVXfuy1IT5DbffYw==",
+      "requires": {}
     },
     "react-dom": {
       "version": "18.2.0",
@@ -7063,7 +7071,8 @@
     "react-hook-form": {
       "version": "7.42.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.42.1.tgz",
-      "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ=="
+      "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==",
+      "requires": {}
     },
     "react-hot-toast": {
       "version": "2.4.0",
@@ -7076,7 +7085,8 @@
     "react-icons": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
-      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw=="
+      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",
@@ -7335,7 +7345,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-2.0.1.tgz",
       "integrity": "sha512-OcR7qHBbux4k+k6bWqnEQFYFooLK/F4dhkBz6nvswIoaA9ancZ5h20e0tyV7ifSWLDCUBtpG+1NHRA8HMRH/wg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "tailwindcss": {
       "version": "3.2.4",
@@ -7372,7 +7383,8 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/tailwindcss-labeled-groups/-/tailwindcss-labeled-groups-0.0.2.tgz",
       "integrity": "sha512-leOVv9h2K9WDHoXPXVBOmTJgWECVkpVFc/hjrwuqGUEtNxvRvuOtCjenu9ppY+pJtky5INJUqDCNa8pS3AbYmw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "text-table": {
       "version": "0.2.0",
@@ -7502,12 +7514,14 @@
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.1",
@@ -7520,12 +7534,14 @@
     "use-local-storage-state": {
       "version": "18.1.2",
       "resolved": "https://registry.npmjs.org/use-local-storage-state/-/use-local-storage-state-18.1.2.tgz",
-      "integrity": "sha512-V+kYQNC5R0N/JDpsg6b4ED5UaItKJcSvbne68DwJDZWHxGMQBiF41ATktFIOyet3PIq30d2qtzVp/2aB6hQ8Bg=="
+      "integrity": "sha512-V+kYQNC5R0N/JDpsg6b4ED5UaItKJcSvbne68DwJDZWHxGMQBiF41ATktFIOyet3PIq30d2qtzVp/2aB6hQ8Bg==",
+      "requires": {}
     },
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -7577,7 +7593,8 @@
     "windstitch": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/windstitch/-/windstitch-0.3.0.tgz",
-      "integrity": "sha512-xn48NPYKCcj8QHfn2/sQGF/zWRuHfSweRkUnSQnL6Szoyp7L2D6b+XbjlQY8FW8BIzc2Rq3ltx0Z5KpfFLyJkw=="
+      "integrity": "sha512-xn48NPYKCcj8QHfn2/sQGF/zWRuHfSweRkUnSQnL6Szoyp7L2D6b+XbjlQY8FW8BIzc2Rq3ltx0Z5KpfFLyJkw==",
+      "requires": {}
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
@@ -21,9 +21,13 @@ type Props = {
 
 const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
   const [isOpenTimeEntry, setIsOpenTimeEntry] = useState<boolean>(false)
+  const [timeEntryId, setTimeEntryId] = useState<number>(-1)
+  const [user, setUser] = useState<string>('')
 
-  const handleIsOpenTimeEntryToggle = (id?: string | undefined): void => {
+  const handleIsOpenTimeEntryToggle = (id?: string | undefined, name?: string): void => {
     setIsOpenTimeEntry(!isOpenTimeEntry)
+    setTimeEntryId(parseInt(id as string))
+    setUser(name as string)
   }
 
   const EMPTY = 'N/A'
@@ -137,19 +141,16 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                               <div className="inline-flex items-center divide-x divide-slate-300 rounded border border-slate-300">
                                 <Tippy placement="left" content="Time Entries" className="!text-xs">
                                   <Button
-                                    onClick={() => handleIsOpenTimeEntryToggle(row.id)}
+                                    onClick={() =>
+                                      handleIsOpenTimeEntryToggle(
+                                        row.original.id.toString(),
+                                        row.original.user.name
+                                      )
+                                    }
                                     rounded="none"
                                     className="py-0.5 px-1 text-slate-500"
                                   >
                                     <Clock className="h-4 w-4" />
-                                    {isOpenTimeEntry ? (
-                                      <InterruptionTimeEntriesModal
-                                        {...{
-                                          isOpen: isOpenTimeEntry,
-                                          closeModal: handleIsOpenTimeEntryToggle
-                                        }}
-                                      />
-                                    ) : null}
                                   </Button>
                                 </Tippy>
                                 <Tippy placement="left" content="Edit" className="!text-xs">
@@ -169,6 +170,17 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                     )}
                   </Disclosure>
                 ))}
+
+                {isOpenTimeEntry ? (
+                  <InterruptionTimeEntriesModal
+                    {...{
+                      isOpen: isOpenTimeEntry,
+                      timeEntryId,
+                      user,
+                      closeModal: handleIsOpenTimeEntryToggle
+                    }}
+                  />
+                ) : null}
               </>
             )}
           </>

--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -158,6 +158,8 @@ export const columns = [
                 <InterruptionTimeEntriesModal
                   {...{
                     isOpen: isOpenTimeEntry,
+                    user: props.row.original.user.name,
+                    timeEntryId: props.row.original.id,
                     closeModal: handleIsOpenTimeEntryToggle
                   }}
                 />

--- a/client/src/components/molecules/InterruptionTimeEntriesModal/Table.tsx
+++ b/client/src/components/molecules/InterruptionTimeEntriesModal/Table.tsx
@@ -2,13 +2,21 @@ import React, { FC } from 'react'
 import classNames from 'classnames'
 import { flexRender, Table } from '@tanstack/react-table'
 
+import TableSkeleton from '../SkeletonTable'
 import { IInterruptionTimeEntry } from '~/utils/interfaces'
 
 type Props = {
   table: Table<IInterruptionTimeEntry>
+  query: {
+    isLoading: boolean
+    isError: boolean
+  }
 }
 
-const InterruptionTimeEntriesTable: FC<Props> = ({ table }) => {
+const InterruptionTimeEntriesTable: FC<Props> = ({
+  table,
+  query: { isLoading = false, isError = false }
+}) => {
   return (
     <table className="w-full">
       <thead className="border-b border-slate-200">
@@ -34,29 +42,35 @@ const InterruptionTimeEntriesTable: FC<Props> = ({ table }) => {
       <tbody
         className={classNames(
           'h-full min-h-[80vh] w-full divide-y divide-slate-200 border-b border-slate-200',
-          table.getPageCount() === 0 ? 'h-[20vh]' : ''
+          table.getPageCount() === 0 || isError ? 'h-[20vh]' : ''
         )}
       >
         <>
-          {table.getPageCount() === 0 ? (
-            <TableMesagge message="No Data Available" />
+          {!isError ? (
+            isLoading ? (
+              <TableSkeleton rows={4} column={4} />
+            ) : table.getPageCount() === 0 ? (
+              <TableMesagge message="No Data Available" />
+            ) : (
+              <>
+                {table.getRowModel().rows.map((row) => (
+                  <tr
+                    key={row.id}
+                    className={classNames(
+                      'group hover:bg-white hover:shadow-md hover:shadow-slate-200'
+                    )}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id} className="z-20 flex-wrap px-4 py-2 text-xs capitalize">
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </>
+            )
           ) : (
-            <>
-              {table.getRowModel().rows.map((row) => (
-                <tr
-                  key={row.id}
-                  className={classNames(
-                    'group hover:bg-white hover:shadow-md hover:shadow-slate-200'
-                  )}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id} className="z-20 flex-wrap px-4 py-2 text-xs capitalize">
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </>
+            <TableError message="Something went wrong" />
           )}
         </>
       </tbody>
@@ -73,5 +87,13 @@ const TableMesagge = ({ message }: { message: string }): JSX.Element => {
     </tr>
   )
 }
-
+const TableError = ({ message }: { message: string }): JSX.Element => {
+  return (
+    <tr className="absolute inset-x-0 left-0 right-0 w-full flex-1 bg-rose-50">
+      <td className="py-2"></td>
+      <td className="w-full py-2 text-center font-medium  text-rose-500">{message}</td>
+      <td className="py-2"></td>
+    </tr>
+  )
+}
 export default InterruptionTimeEntriesTable

--- a/client/src/components/molecules/InterruptionTimeEntriesModal/columns.tsx
+++ b/client/src/components/molecules/InterruptionTimeEntriesModal/columns.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import Tippy from '@tippyjs/react'
 import toast from 'react-hot-toast'
 import React, { useRef, useState } from 'react'
@@ -14,15 +15,16 @@ import UpdateInterruptionTimeEntriesModal from './UpdateInterruptionTimeEntriesM
 const columnHelper = createColumnHelper<IInterruptionTimeEntry>()
 
 export const columns = [
-  columnHelper.accessor('date', {
+  columnHelper.accessor('createdAt', {
     header: () => <CellHeader label="Date" className="!font-medium" />,
-    footer: (info) => info.column.id
-  }),
-  columnHelper.accessor('timeIn', {
-    header: () => <CellHeader label="Time Out" className="!font-medium" />,
+    cell: (props) => moment(props.getValue()).format('MMMM DD, YYYY'),
     footer: (info) => info.column.id
   }),
   columnHelper.accessor('timeOut', {
+    header: () => <CellHeader label="Time Out" className="!font-medium" />,
+    footer: (info) => info.column.id
+  }),
+  columnHelper.accessor('timeIn', {
     header: () => <CellHeader label="Time In" className="!font-medium" />,
     footer: (info) => info.column.id
   }),

--- a/client/src/components/molecules/InterruptionTimeEntriesModal/index.tsx
+++ b/client/src/components/molecules/InterruptionTimeEntriesModal/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import { Clock } from 'react-feather'
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import {
   SortingState,
   useReactTable,
@@ -15,22 +15,40 @@ import { columns } from './columns'
 import InterruptionTimeEntriesTable from './Table'
 import Button from '~/components/atoms/Buttons/Button'
 import GlobalSearchFilter from './../GlobalSearchFilter'
+import useInterruptionType from '~/hooks/useInterruptionType'
 import ModalTemplate from '~/components/templates/ModalTemplate'
 import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
 import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
-import { interruptions } from '~/utils/constants/interruptionDummyTimeEntries'
 
 type Props = {
   isOpen: boolean
+  timeEntryId: number
+  user: string
   closeModal: () => void
 }
 
-const InterruptionTimeEntriesModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
+const InterruptionTimeEntriesModal: FC<Props> = ({
+  isOpen,
+  closeModal,
+  user,
+  timeEntryId
+}): JSX.Element => {
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState<string>('')
+  const { handleGetAllWorkInterruptionsQuery } = useInterruptionType()
+  const {
+    data: interruptions,
+    refetch,
+    isLoading,
+    isError
+  } = handleGetAllWorkInterruptionsQuery({ timeEntryId })
+
+  useEffect(() => {
+    void refetch()
+  }, [timeEntryId])
 
   const table = useReactTable({
-    data: interruptions,
+    data: interruptions?.interruptionsByTimeEntryId ?? [],
     columns,
     // Options
     state: {
@@ -57,7 +75,7 @@ const InterruptionTimeEntriesModal: FC<Props> = ({ isOpen, closeModal }): JSX.El
       {/* Custom Modal Header */}
       <ModalHeader
         {...{
-          title: 'Joshua Galit’s Interruption Time Entries',
+          title: `${user}'s Interruption Time Entries`,
           Icon: Clock,
           closeModal
         }}
@@ -71,7 +89,11 @@ const InterruptionTimeEntriesModal: FC<Props> = ({ isOpen, closeModal }): JSX.El
       {/* Actual Data Table for Interruption Time Entries */}
       <InterruptionTimeEntriesTable
         {...{
-          table
+          table,
+          query: {
+            isLoading,
+            isError
+          }
         }}
       />
       {/* Custom Modal Footer Style */}

--- a/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
@@ -1,16 +1,18 @@
 import moment from 'moment'
 import Tooltip from 'rc-tooltip'
-import React, { FC } from 'react'
+import React, { FC, useState } from 'react'
 import classNames from 'classnames'
 import { Table } from '@tanstack/react-table'
 import { Disclosure } from '@headlessui/react'
 import { ChevronRight, Clock, Edit } from 'react-feather'
 
 import Chip from '~/components/atoms/Chip'
+import useUserQuery from '~/hooks/useUserQuery'
 import Button from '~/components/atoms/Buttons/Button'
 import { WorkStatus } from '~/utils/constants/work-status'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import { IEmployeeTimeEntry } from '~/utils/types/timeEntryTypes'
+import InterruptionTimeEntriesModal from '../InterruptionTimeEntriesModal'
 
 type Props = {
   table: Table<IEmployeeTimeEntry>
@@ -19,6 +21,16 @@ type Props = {
 }
 
 const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
+  const [isOpenTimeEntry, setIsOpenTimeEntry] = useState<boolean>(false)
+  const [timeEntryId, setTimeEntryId] = useState<number>(-1)
+  const { handleUserQuery } = useUserQuery()
+  const { data: user } = handleUserQuery()
+
+  const handleIsOpenTimeEntryToggle = (id?: string | undefined): void => {
+    setIsOpenTimeEntry(!isOpenTimeEntry)
+    setTimeEntryId(parseInt(id as string))
+  }
+
   const EMPTY = 'N/A'
 
   return (
@@ -123,7 +135,9 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                   arrowContent={<div className="rc-tooltip-arrow-inner"></div>}
                                 >
                                   <Button
-                                    onClick={() => alert(row.original.id)}
+                                    onClick={() =>
+                                      handleIsOpenTimeEntryToggle(row.original.id.toString())
+                                    }
                                     rounded="none"
                                     className="py-0.5 px-1 text-slate-500"
                                   >
@@ -151,6 +165,17 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                     )}
                   </Disclosure>
                 ))}
+
+                {isOpenTimeEntry ? (
+                  <InterruptionTimeEntriesModal
+                    {...{
+                      isOpen: isOpenTimeEntry,
+                      timeEntryId,
+                      user: user?.userById.name as string,
+                      closeModal: handleIsOpenTimeEntryToggle
+                    }}
+                  />
+                ) : null}
               </>
             )}
           </>

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -7,6 +7,7 @@ import { Clock, Edit } from 'react-feather'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import Chip from '~/components/atoms/Chip'
+import useUserQuery from '~/hooks/useUserQuery'
 import Button from '~/components/atoms/Buttons/Button'
 import CellHeader from '~/components/atoms/CellHeader'
 import { IEmployeeTimeEntry } from '~/utils/types/timeEntryTypes'
@@ -128,6 +129,8 @@ export const columns = [
     header: () => <span className="font-normal text-slate-500">Actions</span>,
     cell: (props) => {
       const [isOpenTimeEntry, setIsOpenTimeEntry] = useState<boolean>(false)
+      const { handleUserQuery } = useUserQuery()
+      const { data: user } = handleUserQuery()
 
       const handleIsOpenTimeEntryToggle = (id?: string | undefined): void => {
         setIsOpenTimeEntry(!isOpenTimeEntry)
@@ -146,6 +149,8 @@ export const columns = [
                 <InterruptionTimeEntriesModal
                   {...{
                     isOpen: isOpenTimeEntry,
+                    timeEntryId: props.row.original.id,
+                    user: user?.userById.name as string,
                     closeModal: handleIsOpenTimeEntryToggle
                   }}
                 />

--- a/client/src/components/templates/ModalTemplate/index.tsx
+++ b/client/src/components/templates/ModalTemplate/index.tsx
@@ -14,7 +14,7 @@ const ModalTemplate: FC<Props> = (props): JSX.Element => {
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50" onClose={() => closeModal}>
+      <Dialog as="div" className="relative z-50" onClose={() => closeModal()}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/client/src/graphql/queries/workInterruptionQuery.ts
+++ b/client/src/graphql/queries/workInterruptionQuery.ts
@@ -7,3 +7,19 @@ export const GET_INTERRUPTION_TYPES_QUERY = gql`
     }
   }
 `
+export const GET_ALL_WORK_INTERRUPTIONS_QUERY = gql`
+  query ($interruption: ShowInterruptionRequestInput!) {
+    interruptionsByTimeEntryId(interruption: $interruption) {
+      id
+      timeOut
+      timeIn
+      otherReason
+      remarks
+      workInterruptionType {
+        id
+        name
+      }
+      createdAt
+    }
+  }
+`

--- a/client/src/hooks/useInterruptionType.ts
+++ b/client/src/hooks/useInterruptionType.ts
@@ -1,9 +1,12 @@
 import { useMutation, UseMutationResult, useQuery, UseQueryResult } from '@tanstack/react-query'
 
 import { client } from '~/utils/shared/client'
-import { GET_INTERRUPTION_TYPES_QUERY } from '~/graphql/queries/workInterruptionQuery'
-import { WorkInterruptionType } from '~/utils/types/workInterruptionTypes'
+import {
+  GET_ALL_WORK_INTERRUPTIONS_QUERY,
+  GET_INTERRUPTION_TYPES_QUERY
+} from '~/graphql/queries/workInterruptionQuery'
 import { CREATE_INTERRUPTION_MUTATION } from '~/graphql/mutations/workInterruptionMutation'
+import { WorkInterruptions, WorkInterruptionType } from '~/utils/types/workInterruptionTypes'
 
 type CreateInterruptionRequest = {
   timeEntryId: number
@@ -13,6 +16,9 @@ type CreateInterruptionRequest = {
   remarks: string
   otherReason: string | null
 }
+type ShowInterruptionRequest = {
+  timeEntryId: number
+}
 type returnType = {
   handleInterruptionTypeQuery: () => UseQueryResult<WorkInterruptionType, unknown>
   handleInterruptionMutation: () => UseMutationResult<
@@ -21,8 +27,12 @@ type returnType = {
     CreateInterruptionRequest,
     unknown
   >
+  handleGetAllWorkInterruptionsQuery: (
+    interruption: ShowInterruptionRequest
+  ) => UseQueryResult<WorkInterruptions, unknown>
 }
 type handleInterruptionTypeQueryType = UseQueryResult<WorkInterruptionType, unknown>
+type handleGetAllWorkInterruptionsQueryType = UseQueryResult<WorkInterruptions, unknown>
 
 type handleInterruptionMutationReturnType = UseMutationResult<
   any,
@@ -46,9 +56,18 @@ const useInterruptionType = (): returnType => {
         })
       }
     })
+  const handleGetAllWorkInterruptionsQuery = (
+    interruption: ShowInterruptionRequest
+  ): handleGetAllWorkInterruptionsQueryType =>
+    useQuery({
+      queryKey: ['GET_ALL_WORK_INTERRUPTIONS_QUERY', interruption],
+      queryFn: async () => await client.request(GET_ALL_WORK_INTERRUPTIONS_QUERY, { interruption }),
+      select: (data: WorkInterruptions) => data
+    })
   return {
     handleInterruptionTypeQuery,
-    handleInterruptionMutation
+    handleInterruptionMutation,
+    handleGetAllWorkInterruptionsQuery
   }
 }
 

--- a/client/src/utils/constants/interruptionDummyTimeEntries.ts
+++ b/client/src/utils/constants/interruptionDummyTimeEntries.ts
@@ -3,7 +3,7 @@ import { IInterruptionTimeEntry } from '../interfaces'
 export const interruptions: IInterruptionTimeEntry[] = [
   {
     id: 1,
-    date: 'January 20, 2023',
+    createdAt: 'January 20, 2023',
     timeOut: '13:30',
     timeIn: '16:30',
     remarks:
@@ -11,21 +11,21 @@ export const interruptions: IInterruptionTimeEntry[] = [
   },
   {
     id: 2,
-    date: 'January 20, 2023',
+    createdAt: 'January 20, 2023',
     timeOut: '17:00',
     timeIn: '17:00',
     remarks: 'We are currently experiencing power flood interruption'
   },
   {
     id: 3,
-    date: 'January 20, 2023',
+    createdAt: 'January 20, 2023',
     timeOut: '17:00',
     timeIn: '117:00',
     remarks: 'We are currently experiencing super power'
   },
   {
     id: 4,
-    date: 'January 20, 2023',
+    createdAt: 'January 20, 2023',
     timeOut: '17:00',
     timeIn: '17:00',
     remarks: 'We are currently experiencing power kilikili'

--- a/client/src/utils/interfaces/index.tsx
+++ b/client/src/utils/interfaces/index.tsx
@@ -48,7 +48,7 @@ export interface IMyDTR {
 
 export interface IInterruptionTimeEntry {
   id: number | string
-  date: string
+  createdAt: string
   timeOut: string
   timeIn: string
   remarks?: string

--- a/client/src/utils/types/workInterruptionTypes.ts
+++ b/client/src/utils/types/workInterruptionTypes.ts
@@ -1,3 +1,5 @@
+import { IInterruptionTimeEntry } from '../interfaces'
+
 export type InterruptionType = {
   id: number
   name: string
@@ -5,4 +7,16 @@ export type InterruptionType = {
 
 export type WorkInterruptionType = {
   allWorkInterruptionTypes: InterruptionType[]
+}
+
+export type WorkInterruption = {
+  id: number
+  timeOut: string
+  timeIn: string
+  otherReason: string
+  remarks: string
+  workInterruptionType: InterruptionType
+}
+export type WorkInterruptions = {
+  interruptionsByTimeEntryId: IInterruptionTimeEntry[]
 }


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-57
https://framgiaph.backlog.com/view/HRIS-59


## Definition of Done

- [x] User can view his/her work interruption time entries on the modal in the My DTR Page
- [x] User can view other's work interruption time entries on the modal in the DTR Management Page
- [x] Added loading and error status

## Notes
- I have already combined 2 tasks for this PR since the modal component is already reusable for each My DTR and DTR Management Pages and would be difficult to check if I separate these into different PRs.


## Pre-condition
- Login
- Go to My DTR page
- Click the Clock Icon (Time Entry Icon) 
- Go to DTR Management page
- Click the Clock Icon (Time Entry Icon) 

## Expected Output

- It should be able to display the work interuption entries on the modal based on the user's time entry

## Screenshots/Recordings
My DTR Page

https://user-images.githubusercontent.com/110364637/214267827-d0ae5947-f999-4308-aee0-c9dc268e3d6c.mp4

DTR Manangement Page

https://user-images.githubusercontent.com/110364637/214267900-237cbfdd-fbdf-4c92-adc9-12e689fe5530.mp4


