### PR TITLE
HRIS-47-01 [FE] Fix Mobile view of Summary Table

### DIFF
--- a/client/src/components/molecules/DTRSummaryTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/MobileDisclose.tsx
@@ -52,7 +52,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                 rounded="full"
                               />
                               <div className="flex flex-col items-start">
-                                <h1 className="font-semibold">{row.original.name}</h1>
+                                <h1 className="font-semibold">{row.original.user.name}</h1>
                                 <small className="text-slate-500">Web Developer</small>
                               </div>
                             </div>

--- a/client/src/utils/constants/index.ts
+++ b/client/src/utils/constants/index.ts
@@ -1401,7 +1401,9 @@ export const myDTRData: IMyDTR[] = [
 export const dtrSummaryData: IDTRSummary[] = [
   {
     id: 1,
-    name: 'joshua galit',
+    user: {
+      name: 'joshua galit'
+    },
     leave: 0,
     absences: 0,
     late: 0,
@@ -1410,7 +1412,9 @@ export const dtrSummaryData: IDTRSummary[] = [
   },
   {
     id: 2,
-    name: 'rojelio david',
+    user: {
+      name: 'rojelio david'
+    },
     leave: 0,
     absences: 0,
     late: 3,
@@ -1419,7 +1423,9 @@ export const dtrSummaryData: IDTRSummary[] = [
   },
   {
     id: 3,
-    name: 'Basesos Bergson',
+    user: {
+      name: 'Basesos Bergson'
+    },
     leave: 0,
     absences: 3,
     late: 0,
@@ -1428,7 +1434,9 @@ export const dtrSummaryData: IDTRSummary[] = [
   },
   {
     id: 4,
-    name: 'John Doe',
+    user: {
+      name: 'John Doe'
+    },
     leave: 1,
     absences: 0,
     late: 0,

--- a/client/src/utils/interfaces/index.tsx
+++ b/client/src/utils/interfaces/index.tsx
@@ -24,7 +24,9 @@ export interface IDTRManagement {
 
 export interface IDTRSummary {
   id: number
-  name: string
+  user: {
+    name: string
+  }
   leave: number
   absences: number
   late: number


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-47

## Definition of Done
- [x] Fixed mobile view of summary table where employees name are not displayed

## Pre-condition
- `docker compose up --build`
- go to DTRManagement page and set it to mobile view

## Expected Output
- Mobile view of Summary Table should now properly display employees name

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/111718037/214470533-e117441d-e217-48fc-b793-f0e45e73cdb8.png)
