### PR TITLE
HRIS-54 [FE] Integrate Edit and Delete Work Interruption Request functionality

### DIFF
--- a/api/Context/HrisContext.cs
+++ b/api/Context/HrisContext.cs
@@ -20,6 +20,7 @@ public partial class HrisContext : DbContext
     public DbSet<Media> Medias { get; set; } = default!;
     public DbSet<WorkInterruptionType> WorkInterruptionTypes { get; set; } = default!;
     public DbSet<WorkInterruption> WorkInterruptions { get; set; } = default!;
+    public DbSet<Role> Roles { get; set; } = default!;
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<EmployeeSchedule>().HasData(
@@ -39,6 +40,9 @@ public partial class HrisContext : DbContext
         );
         modelBuilder.Entity<WorkInterruptionType>().HasData(
             DatabaseSeeder.workInterruptionType
+        );
+        modelBuilder.Entity<Role>().HasData(
+            DatabaseSeeder.roles
         );
     }
 

--- a/api/DTOs/UserDTO.cs
+++ b/api/DTOs/UserDTO.cs
@@ -14,6 +14,7 @@ namespace api.DTOs
             EmployeeScheduleId = user.EmployeeScheduleId;
             IsOnline = user.IsOnline;
             EmployeeSchedule = user.EmployeeSchedule;
+            Role = user.Role;
             TimeEntry = user.TimeEntries.FirstOrDefault();
         }
     }

--- a/api/Entities/Role.cs
+++ b/api/Entities/Role.cs
@@ -1,0 +1,10 @@
+namespace api.Entities
+{
+    public class Role : BaseEntity
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public ICollection<User> Users { get; set; } = default!;
+
+    }
+}

--- a/api/Entities/User.cs
+++ b/api/Entities/User.cs
@@ -13,6 +13,7 @@ namespace api.Entities
         public int RoleId { get; set; }
         public int EmployeeScheduleId { get; set; }
         public bool IsOnline { get; set; }
+        public Role Role { get; set; } = default!;
         public EmployeeSchedule EmployeeSchedule { get; set; } = default!;
         public ICollection<TimeEntry> TimeEntries { get; set; } = default!;
     }

--- a/api/Enums/RoleEnum.cs
+++ b/api/Enums/RoleEnum.cs
@@ -1,0 +1,9 @@
+namespace api.Enums
+{
+    public class RoleEnum
+    {
+        public static readonly string HR_ADMIN = "HR Admin";
+        public static readonly string MANAGER = "Manager";
+        public static readonly string EMPLOYEE = "Employee";
+    }
+}

--- a/api/Migrations/20230125101948_AddRoles.Designer.cs
+++ b/api/Migrations/20230125101948_AddRoles.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
@@ -11,9 +12,11 @@ using api.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(HrisContext))]
-    partial class HrisContextModelSnapshot : ModelSnapshot
+    [Migration("20230125101948_AddRoles")]
+    partial class AddRoles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20230125101948_AddRoles.cs
+++ b/api/Migrations/20230125101948_AddRoles.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRoles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Roles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Roles", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Roles",
+                columns: new[] { "Id", "CreatedAt", "Name", "UpdatedAt" },
+                values: new object[,]
+                {
+                    { 1, new DateTime(2023, 1, 25, 18, 19, 47, 629, DateTimeKind.Local).AddTicks(1782), "Manager", new DateTime(2023, 1, 25, 18, 19, 47, 629, DateTimeKind.Local).AddTicks(1783) },
+                    { 2, new DateTime(2023, 1, 25, 18, 19, 47, 629, DateTimeKind.Local).AddTicks(2255), "HR Admin", new DateTime(2023, 1, 25, 18, 19, 47, 629, DateTimeKind.Local).AddTicks(2256) }
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "RoleId", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 25, 18, 19, 47, 999, DateTimeKind.Local).AddTicks(973), 2, new DateTime(2023, 1, 25, 18, 19, 47, 999, DateTimeKind.Local).AddTicks(991) });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "RoleId", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 25, 18, 19, 47, 999, DateTimeKind.Local).AddTicks(994), 1, new DateTime(2023, 1, 25, 18, 19, 47, 999, DateTimeKind.Local).AddTicks(995) });
+
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_RoleId",
+                table: "Users",
+                column: "RoleId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Users_Roles_RoleId",
+                table: "Users",
+                column: "RoleId",
+                principalTable: "Roles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Users_Roles_RoleId",
+                table: "Users");
+
+            migrationBuilder.DropTable(
+                name: "Roles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Users_RoleId",
+                table: "Users");
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "RoleId", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3507), 0, new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3524) });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "RoleId", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3528), 0, new DateTime(2023, 1, 17, 17, 18, 58, 121, DateTimeKind.Local).AddTicks(3529) });
+        }
+    }
+}

--- a/api/Migrations/20230126020829_UpdateRolesSeeder.Designer.cs
+++ b/api/Migrations/20230126020829_UpdateRolesSeeder.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
@@ -11,9 +12,11 @@ using api.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(HrisContext))]
-    partial class HrisContextModelSnapshot : ModelSnapshot
+    [Migration("20230126020829_UpdateRolesSeeder")]
+    partial class UpdateRolesSeeder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20230126020829_UpdateRolesSeeder.cs
+++ b/api/Migrations/20230126020829_UpdateRolesSeeder.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateRolesSeeder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Roles",
+                columns: new[] { "Id", "CreatedAt", "Name", "UpdatedAt" },
+                values: new object[] { 3, new DateTime(2023, 1, 26, 10, 8, 28, 99, DateTimeKind.Local).AddTicks(3772), "Employee", new DateTime(2023, 1, 26, 10, 8, 28, 99, DateTimeKind.Local).AddTicks(3773) });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: 3);
+        }
+    }
+}

--- a/api/Seeders/DatabaseSeeder.cs
+++ b/api/Seeders/DatabaseSeeder.cs
@@ -77,6 +77,10 @@ namespace api.Seeders
             new Role {
                 Id = 2,
                 Name = RoleEnum.HR_ADMIN
+            },
+            new Role {
+                Id = 3,
+                Name = RoleEnum.EMPLOYEE
             }
         };
         public static User[] users()

--- a/api/Seeders/DatabaseSeeder.cs
+++ b/api/Seeders/DatabaseSeeder.cs
@@ -69,6 +69,16 @@ namespace api.Seeders
                 Name = WorkInterruptionEnum.OTHERS
             },
         };
+        public static List<Role> roles = new List<Role>(){
+            new Role {
+                Id = 1,
+                Name = RoleEnum.MANAGER
+            },
+            new Role {
+                Id = 2,
+                Name = RoleEnum.HR_ADMIN
+            }
+        };
         public static User[] users()
         {
             User[] users = {
@@ -77,6 +87,7 @@ namespace api.Seeders
                     Id = 1,
                     Name = "John Doe",
                     Email = "johndoe@sun-asterisk.com",
+                    RoleId = 2,
                     EmployeeScheduleId = employeeSchedule.Id,
                     IsOnline = false
                 },
@@ -84,6 +95,7 @@ namespace api.Seeders
                 {
                     Id = 2,
                     Name = "Rean Schwarzer",
+                    RoleId = 1,
                     Email = "reanschwarzer@sun-asterisk.com",
                     EmployeeScheduleId = employeeSchedule.Id,
                     IsOnline = false

--- a/api/Services/InterruptionService.cs
+++ b/api/Services/InterruptionService.cs
@@ -54,6 +54,7 @@ namespace api.Services
                 WorkInterruption work = ToWorkInterruption(interruption);
                 context.Update(work);
                 context.Entry(work).Property(x => x.TimeEntryId).IsModified = false;
+                context.Entry(work).Property(x => x.CreatedAt).IsModified = false;
                 return await context.SaveChangesAsync() > 0;
             }
         }

--- a/api/Services/TimeInService.cs
+++ b/api/Services/TimeInService.cs
@@ -27,6 +27,7 @@ namespace api.Services
             {
                 var personal_token = await context.Personal_Access_Tokens.Where(x => x.Token == token).FirstAsync();
                 return await context.Users
+                    .Include(i => i.Role)
                     .Include(i => i.EmployeeSchedule)
                         .ThenInclude(i => i.WorkingDayTimes.Where(p => p.Day == schedule))
                     .Include(i => i.TimeEntries.OrderByDescending(o => o.CreatedAt))

--- a/client/src/components/molecules/InterruptionTimeEntriesModal/UpdateInterruptionTimeEntriesModal.tsx
+++ b/client/src/components/molecules/InterruptionTimeEntriesModal/UpdateInterruptionTimeEntriesModal.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames'
-import toast from 'react-hot-toast'
 import React, { FC, useEffect } from 'react'
 import { Edit, Save, X } from 'react-feather'
 import { yupResolver } from '@hookform/resolvers/yup'
@@ -9,6 +8,7 @@ import ReactTextareaAutosize from 'react-textarea-autosize'
 import { TimeEntrySchema } from '~/utils/validation'
 import Button from '~/components/atoms/Buttons/Button'
 import { IInterruptionTimeEntry } from '~/utils/interfaces'
+import useInterruptionType from '~/hooks/useInterruptionType'
 import ModalTemplate from '~/components/templates/ModalTemplate'
 import { TimeEntryFormValues } from '~/utils/types/formValues'
 import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
@@ -22,7 +22,10 @@ type Props = {
 
 const UpdateInterruptionTimeEntriesModal: FC<Props> = (props): JSX.Element => {
   const { isOpen, closeModal, remarks } = props
-
+  const { handleUpdateInterruptionMutation } = useInterruptionType()
+  const updateInterruption = handleUpdateInterruptionMutation({
+    timeEntryId: remarks?.timeEntryId as number
+  })
   const {
     reset,
     register,
@@ -34,7 +37,14 @@ const UpdateInterruptionTimeEntriesModal: FC<Props> = (props): JSX.Element => {
   })
 
   const handleUpdateInterruption = (data: TimeEntryFormValues): void => {
-    toast.success('Successfully Saved')
+    updateInterruption.mutate({
+      id: remarks?.id as number,
+      otherReason: remarks?.otherReason as string,
+      remarks: data.remarks,
+      timeIn: data.time_in,
+      timeOut: data.time_out,
+      workInterruptionTypeId: remarks?.workInterruptionTypeId as number
+    })
     closeModal()
   }
 

--- a/client/src/graphql/mutations/workInterruptionMutation.ts
+++ b/client/src/graphql/mutations/workInterruptionMutation.ts
@@ -6,3 +6,13 @@ export const CREATE_INTERRUPTION_MUTATION = gql`
     }
   }
 `
+export const UPDATE_INTERRUPTION_MUTATION = gql`
+  mutation ($interruption: UpdateInterruptionRequestInput!) {
+    updateWorkInterruption(interruption: $interruption)
+  }
+`
+export const DELETE_INTERRUPTION_MUTATION = gql`
+  mutation ($id: Int!) {
+    deleteWorkInterruption(id: $id)
+  }
+`

--- a/client/src/graphql/queries/UserQuery.ts
+++ b/client/src/graphql/queries/UserQuery.ts
@@ -20,6 +20,10 @@ export const GET_USER_QUERY = gql`
           timeHour
         }
       }
+      role {
+        id
+        name
+      }
       employeeSchedule {
         id
         name

--- a/client/src/graphql/queries/workInterruptionQuery.ts
+++ b/client/src/graphql/queries/workInterruptionQuery.ts
@@ -19,6 +19,8 @@ export const GET_ALL_WORK_INTERRUPTIONS_QUERY = gql`
         id
         name
       }
+      workInterruptionTypeId
+      timeEntryId
       createdAt
     }
   }

--- a/client/src/hooks/useInterruptionType.ts
+++ b/client/src/hooks/useInterruptionType.ts
@@ -1,11 +1,22 @@
-import { useMutation, UseMutationResult, useQuery, UseQueryResult } from '@tanstack/react-query'
+import {
+  useMutation,
+  UseMutationResult,
+  useQuery,
+  useQueryClient,
+  UseQueryResult
+} from '@tanstack/react-query'
+import { toast } from 'react-hot-toast'
 
 import { client } from '~/utils/shared/client'
 import {
   GET_ALL_WORK_INTERRUPTIONS_QUERY,
   GET_INTERRUPTION_TYPES_QUERY
 } from '~/graphql/queries/workInterruptionQuery'
-import { CREATE_INTERRUPTION_MUTATION } from '~/graphql/mutations/workInterruptionMutation'
+import {
+  CREATE_INTERRUPTION_MUTATION,
+  DELETE_INTERRUPTION_MUTATION,
+  UPDATE_INTERRUPTION_MUTATION
+} from '~/graphql/mutations/workInterruptionMutation'
 import { WorkInterruptions, WorkInterruptionType } from '~/utils/types/workInterruptionTypes'
 
 type CreateInterruptionRequest = {
@@ -15,6 +26,17 @@ type CreateInterruptionRequest = {
   timeIn: string
   remarks: string
   otherReason: string | null
+}
+type UpdateInterruptionRequest = {
+  id: number
+  otherReason: string
+  remarks: string
+  timeIn: string
+  timeOut: string
+  workInterruptionTypeId: number
+}
+type DeleteInterruptionRequest = {
+  id: number
 }
 type ShowInterruptionRequest = {
   timeEntryId: number
@@ -30,6 +52,15 @@ type returnType = {
   handleGetAllWorkInterruptionsQuery: (
     interruption: ShowInterruptionRequest
   ) => UseQueryResult<WorkInterruptions, unknown>
+  handleUpdateInterruptionMutation: (
+    interruption: ShowInterruptionRequest
+  ) => UseMutationResult<any, unknown, UpdateInterruptionRequest, unknown>
+  handleDeleteInterruptionMutation: () => UseMutationResult<
+    any,
+    unknown,
+    DeleteInterruptionRequest,
+    unknown
+  >
 }
 type handleInterruptionTypeQueryType = UseQueryResult<WorkInterruptionType, unknown>
 type handleGetAllWorkInterruptionsQueryType = UseQueryResult<WorkInterruptions, unknown>
@@ -40,8 +71,21 @@ type handleInterruptionMutationReturnType = UseMutationResult<
   CreateInterruptionRequest,
   unknown
 >
+type handleUpdateInterruptionMutationReturnType = UseMutationResult<
+  any,
+  unknown,
+  UpdateInterruptionRequest,
+  unknown
+>
+type handleDeleteInterruptionMutationReturnType = UseMutationResult<
+  any,
+  unknown,
+  DeleteInterruptionRequest,
+  unknown
+>
 
 const useInterruptionType = (): returnType => {
+  const queryClient = useQueryClient()
   const handleInterruptionTypeQuery = (): handleInterruptionTypeQueryType =>
     useQuery({
       queryKey: ['GET_INTERRUPTION_TYPES_QUERY'],
@@ -60,14 +104,50 @@ const useInterruptionType = (): returnType => {
     interruption: ShowInterruptionRequest
   ): handleGetAllWorkInterruptionsQueryType =>
     useQuery({
-      queryKey: ['GET_ALL_WORK_INTERRUPTIONS_QUERY', interruption],
+      queryKey: ['GET_ALL_WORK_INTERRUPTIONS_QUERY'],
       queryFn: async () => await client.request(GET_ALL_WORK_INTERRUPTIONS_QUERY, { interruption }),
       select: (data: WorkInterruptions) => data
+    })
+  const handleUpdateInterruptionMutation = (
+    interruption: ShowInterruptionRequest
+  ): handleUpdateInterruptionMutationReturnType =>
+    useMutation({
+      mutationFn: async (interruption: UpdateInterruptionRequest) => {
+        return await client.request(UPDATE_INTERRUPTION_MUTATION, {
+          interruption
+        })
+      },
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: ['GET_ALL_WORK_INTERRUPTIONS_QUERY']
+        })
+        toast.success('Successfully Saved')
+      },
+      onError: async () => {
+        toast.error('Something went wrong')
+      }
+    })
+  const handleDeleteInterruptionMutation = (): handleDeleteInterruptionMutationReturnType =>
+    useMutation({
+      mutationFn: async (interruption: DeleteInterruptionRequest) => {
+        return await client.request(DELETE_INTERRUPTION_MUTATION, interruption)
+      },
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: ['GET_ALL_WORK_INTERRUPTIONS_QUERY']
+        })
+        toast.success('Successfully Deleted')
+      },
+      onError: async () => {
+        toast.error('Something went wrong')
+      }
     })
   return {
     handleInterruptionTypeQuery,
     handleInterruptionMutation,
-    handleGetAllWorkInterruptionsQuery
+    handleGetAllWorkInterruptionsQuery,
+    handleUpdateInterruptionMutation,
+    handleDeleteInterruptionMutation
   }
 }
 

--- a/client/src/utils/constants/interruptionDummyTimeEntries.ts
+++ b/client/src/utils/constants/interruptionDummyTimeEntries.ts
@@ -6,6 +6,9 @@ export const interruptions: IInterruptionTimeEntry[] = [
     createdAt: 'January 20, 2023',
     timeOut: '13:30',
     timeIn: '16:30',
+    workInterruptionTypeId: 1,
+    timeEntryId: 1,
+    otherReason: '',
     remarks:
       'We are currently experiencing power interruption at our place. I will find a co-working space to continue my tasks. Sorry for the inconvenience it may have caused.'
   },
@@ -14,6 +17,9 @@ export const interruptions: IInterruptionTimeEntry[] = [
     createdAt: 'January 20, 2023',
     timeOut: '17:00',
     timeIn: '17:00',
+    workInterruptionTypeId: 1,
+    timeEntryId: 1,
+    otherReason: '',
     remarks: 'We are currently experiencing power flood interruption'
   },
   {
@@ -21,6 +27,9 @@ export const interruptions: IInterruptionTimeEntry[] = [
     createdAt: 'January 20, 2023',
     timeOut: '17:00',
     timeIn: '117:00',
+    workInterruptionTypeId: 1,
+    timeEntryId: 1,
+    otherReason: '',
     remarks: 'We are currently experiencing super power'
   },
   {
@@ -28,6 +37,9 @@ export const interruptions: IInterruptionTimeEntry[] = [
     createdAt: 'January 20, 2023',
     timeOut: '17:00',
     timeIn: '17:00',
+    workInterruptionTypeId: 1,
+    timeEntryId: 1,
+    otherReason: '',
     remarks: 'We are currently experiencing power kilikili'
   }
 ]

--- a/client/src/utils/constants/roles.ts
+++ b/client/src/utils/constants/roles.ts
@@ -1,0 +1,4 @@
+export const Roles = {
+  HR_ADMIN: 'HR Admin',
+  MANAGER: 'Manager'
+}

--- a/client/src/utils/interfaces/index.tsx
+++ b/client/src/utils/interfaces/index.tsx
@@ -53,5 +53,8 @@ export interface IInterruptionTimeEntry {
   createdAt: string
   timeOut: string
   timeIn: string
+  workInterruptionTypeId: number
+  timeEntryId: number
+  otherReason: string
   remarks?: string
 }

--- a/client/src/utils/types/userTypes.ts
+++ b/client/src/utils/types/userTypes.ts
@@ -1,10 +1,14 @@
 export type User = {
   id: number
   name: string
+  role: Role
   timeEntry: TimeEntry
   employeeSchedule: EmployeeSchedule
 }
-
+export type Role = {
+  id: number
+  name: string
+}
 // MARK: - EmployeeSchedule
 export type EmployeeSchedule = {
   id: number


### PR DESCRIPTION


## Issue Link

https://framgiaph.backlog.com/view/HRIS-54

## Definition of Done

- [x] HR Admins can update the work interruption in both  My DTR and DTR Management Page while others can only update on My DTR
- [x] HR Admins can delete the work interruption in My DTR and DTR Management Page while others can only delete on My DTR
- [x] User have the ability to edit and delete his work interruption for a day
- [x] Added restriction based on roles

## Notes
- Please run the migrations using `dotnet ef database update`
- You can play around the user by changing roles to determine restrictions

## Pre-condition
- `cd api`
- `dotnet ef database update`
- `docker compose up --build`
- go to `http://localhost:3000/my-daily-time-record` and `http://localhost:3000/dtr-management`
- and click on the time entries button
- update or delete some entries


## Expected Output

- User should be able to Edit and Delete Work Interruptions based on roles and should be able to edit or delete one with 1 day leniency

## Screenshots/Recordings
- Other Roles (not an HR Admin)

https://user-images.githubusercontent.com/110364637/214570673-26636fa3-0366-49d7-816f-c7dcd0bd17e2.mp4

- HR Admin


https://user-images.githubusercontent.com/110364637/214570761-e5fc8ef6-7d74-4f7d-aea7-e0b6ad20d3e7.mp4

