### PR TITLE
HRIS-62 [BugTask] Filter should not reset when refresh

### DIFF
--- a/client/src/components/molecules/TimeSheetFilterDropdown/index.tsx
+++ b/client/src/components/molecules/TimeSheetFilterDropdown/index.tsx
@@ -105,7 +105,7 @@ const TimeSheetFilterDropdown: FC<Props> = (props): JSX.Element => {
                     'focus:border-primary focus:ring-1 focus:ring-primary'
                   )}
                   ref={monthYearSelectionRef}
-                  defaultValue={moment().format('YYYY-MM')}
+                  defaultValue={moment(filters.startDate).format('YYYY-MM')}
                   onChange={handleSummaryFilterChange}
                 ></input>
                 <select

--- a/client/src/hooks/useTimesheetQuery.ts
+++ b/client/src/hooks/useTimesheetQuery.ts
@@ -18,7 +18,8 @@ import {
 export const getAllEmployeeTimesheet = (
   input: string = '',
   argument: string,
-  variables: QueryVariablesType
+  variables: QueryVariablesType,
+  ready: boolean
 ): UseQueryResult<
   {
     timeEntries: ITimeEntry[]
@@ -29,7 +30,8 @@ export const getAllEmployeeTimesheet = (
     queryKey: ['GET_ALL_EMPLOYEE_TIMESHEET'],
     queryFn: async () =>
       await client.request(GET_ALL_EMPLOYEE_TIMESHEET(input, argument), variables),
-    select: (data: { timeEntries: ITimeEntry[] }) => data
+    select: (data: { timeEntries: ITimeEntry[] }) => data,
+    enabled: ready
   })
   return result
 }
@@ -71,7 +73,8 @@ export const getSpecificTimeEntry = (
 export const getTimesheetSummary = (
   input: string = '',
   argument: string,
-  variables: QueryVariablesType
+  variables: QueryVariablesType,
+  ready: boolean
 ): UseQueryResult<
   {
     timesheetSummary: ITimesheetSummary[]
@@ -81,7 +84,8 @@ export const getTimesheetSummary = (
   const result = useQuery({
     queryKey: ['GET_TIMESHEET_SUMMARY'],
     queryFn: async () => await client.request(GET_TIMESHEET_SUMMARY(input, argument), variables),
-    select: (data: { timesheetSummary: ITimesheetSummary[] }) => data
+    select: (data: { timesheetSummary: ITimesheetSummary[] }) => data,
+    enabled: ready
   })
   return result
 }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-62

## Definition of Done
- [x] Filters on DTRManagament page now persists on refresh
- [x] User will stay on which table it was on refresh, on DTR Management table or Summary table

## Pre-condition

Commands to run
- `docker compose up --build`
- go to DTR Management page

## Expected Output
- After reloading the page, the tables should still display the same result on the same table from the same filter.

## Screenshots/Recordings
[Filter Persist.webm](https://user-images.githubusercontent.com/111718037/215006963-f7583cce-01e5-4c53-8b0c-aaf4a0e34db8.webm)
