### PR TITLE
HRIS-62-01 [BugTask] Search keyword persists on page reload

### DIFF
--- a/client/src/pages/my-daily-time-record.tsx
+++ b/client/src/pages/my-daily-time-record.tsx
@@ -1,5 +1,6 @@
 import { NextPage } from 'next'
 import classNames from 'classnames'
+import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'
 
 import useUserQuery from '~/hooks/useUserQuery'
@@ -9,7 +10,6 @@ import { getEmployeeTimesheet } from '~/hooks/useTimesheetQuery'
 import MyDTRTable from '~/components/molecules/MyDailyTimeRecordTable'
 import GlobalSearchFilter from '~/components/molecules/GlobalSearchFilter'
 import { columns } from '~/components/molecules/MyDailyTimeRecordTable/columns'
-import { useRouter } from 'next/router'
 
 const MyDailyTimeRecord: NextPage = (): JSX.Element => {
   const router = useRouter()

--- a/client/src/pages/my-daily-time-record.tsx
+++ b/client/src/pages/my-daily-time-record.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from 'next'
 import classNames from 'classnames'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import useUserQuery from '~/hooks/useUserQuery'
 import Layout from '~/components/templates/Layout'
@@ -9,14 +9,36 @@ import { getEmployeeTimesheet } from '~/hooks/useTimesheetQuery'
 import MyDTRTable from '~/components/molecules/MyDailyTimeRecordTable'
 import GlobalSearchFilter from '~/components/molecules/GlobalSearchFilter'
 import { columns } from '~/components/molecules/MyDailyTimeRecordTable/columns'
+import { useRouter } from 'next/router'
 
 const MyDailyTimeRecord: NextPage = (): JSX.Element => {
+  const router = useRouter()
+
   const [globalFilter, setGlobalFilter] = useState<string>('')
 
   const { handleUserQuery } = useUserQuery()
   const user = handleUserQuery()
 
   const { data, isLoading, error } = getEmployeeTimesheet(user.data?.userById.id as number)
+
+  useEffect(() => {
+    const params = new URL(window.location.href).searchParams
+    setGlobalFilter(params.get('searchKey') as string)
+  }, [])
+
+  useEffect(() => {
+    if (router.isReady) {
+      void router.replace({
+        pathname: '/my-daily-time-record',
+        query:
+          globalFilter !== ''
+            ? {
+                searchKey: globalFilter
+              }
+            : null
+      })
+    }
+  }, [globalFilter])
 
   return (
     <Layout metaTitle="My Daily Time Record">


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-62

## Definition of Done

- [x] Search keyword persists on page reload on tables MyDTR, DTRManagement and Summary table

## Pre-condition
- `docker compose up --build`
- go to MyDTR page and DTR Management page

## Expected Output
- Search keyword should remain the same on every page reload

## Screenshots/Recordings
[searchKey.webm](https://user-images.githubusercontent.com/111718037/215380625-bb5c2428-d065-4ebc-a9e2-6dcb28fd8721.webm)

