### PR TITLE
HRIS-64 [BugTask] Integrate dot remarks in mobile view

### DIFF
--- a/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import Tippy from '@tippyjs/react'
 import classNames from 'classnames'
 import React, { FC, useState } from 'react'
@@ -98,27 +99,87 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                             <li className="flex items-center space-x-1 px-4 py-2">
                               <p>Time In:</p>
                               <div className="relative flex">
-                                <span className="font-semibold">
-                                  {row.original.timeIn?.timeHour ?? EMPTY}
-                                </span>
-                                <span
-                                  className={classNames(
-                                    'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500'
-                                  )}
-                                />
+                                {row.original.timeIn?.remarks !== undefined &&
+                                row.original.timeIn?.remarks !== '' ? (
+                                  <>
+                                    <Link
+                                      href={`dtr-management/?time_in=${row.original.timeIn?.id}`}
+                                      className="relative flex cursor-pointer active:scale-95"
+                                    >
+                                      {/* Actual Time In Data */}
+                                      <span className="font-semibold">
+                                        {row.original.timeIn?.timeHour ?? EMPTY}
+                                      </span>
+                                      {/* Status */}
+                                      {row.original.startTime > row.original.timeIn?.timeHour ? (
+                                        <span
+                                          className={classNames(
+                                            'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500'
+                                          )}
+                                        />
+                                      ) : (
+                                        <>
+                                          {!Number.isNaN(row.original.timeIn?.id) && (
+                                            <span
+                                              className={classNames(
+                                                'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500'
+                                              )}
+                                            />
+                                          )}
+                                        </>
+                                      )}
+                                    </Link>
+                                  </>
+                                ) : (
+                                  <>
+                                    {/* Actual Time In Data */}
+                                    <span className="font-semibold">
+                                      {row.original.timeIn?.timeHour ?? EMPTY}
+                                    </span>
+                                    {/* Status */}
+                                    {row.original.timeIn?.timeHour !== undefined &&
+                                    row.original.timeIn?.timeHour !== ''
+                                      ? !(
+                                          row.original.startTime > row.original.timeIn?.timeHour
+                                        ) && (
+                                          <span
+                                            className={classNames(
+                                              'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500'
+                                            )}
+                                          />
+                                        )
+                                      : ''}
+                                  </>
+                                )}
                               </div>
                             </li>
                             <li className="flex items-center space-x-2 px-4 py-2">
                               <p>Time Out:</p>
                               <div className="relative flex">
-                                <span className="font-semibold">
-                                  {row.original.timeOut?.timeHour ?? EMPTY}
-                                </span>
-                                <span
-                                  className={classNames(
-                                    'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500'
-                                  )}
-                                />
+                                {row.original.timeOut?.remarks !== undefined &&
+                                row.original.timeOut?.remarks !== '' ? (
+                                  <Link
+                                    href={`dtr-management/?time_out=${row.original.timeOut?.id}`}
+                                    className="relative flex cursor-pointer active:scale-95"
+                                  >
+                                    {/* Actual Time Out Data */}
+                                    <span className="font-semibold">
+                                      {row.original.timeOut?.timeHour ?? EMPTY}
+                                    </span>
+                                    {/* Status */}
+                                    {!Number.isNaN(row.original.timeOut?.id) && (
+                                      <span
+                                        className={classNames(
+                                          'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500'
+                                        )}
+                                      />
+                                    )}
+                                  </Link>
+                                ) : (
+                                  <span className="font-semibold">
+                                    {row.original.timeOut?.timeHour ?? EMPTY}
+                                  </span>
+                                )}
                               </div>
                             </li>
                             <li className="px-4 py-2">

--- a/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
@@ -1,4 +1,5 @@
 import moment from 'moment'
+import Link from 'next/link'
 import Tooltip from 'rc-tooltip'
 import React, { FC, useState } from 'react'
 import classNames from 'classnames'
@@ -88,27 +89,87 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                             <li className="flex items-center space-x-1 px-4 py-2">
                               <p>Time In:</p>
                               <div className="relative flex">
-                                <span className="font-semibold">
-                                  {row.original.timeIn?.timeHour ?? EMPTY}
-                                </span>
-                                <span
-                                  className={classNames(
-                                    'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500'
-                                  )}
-                                />
+                                {row.original.timeIn?.remarks !== undefined &&
+                                row.original.timeIn?.remarks !== '' ? (
+                                  <>
+                                    <Link
+                                      href={`my-daily-time-record/?time_in=${row.original.timeIn?.id}`}
+                                      className="relative flex cursor-pointer active:scale-95"
+                                    >
+                                      {/* Actual Time In Data */}
+                                      <span className="font-semibold">
+                                        {row.original.timeIn?.timeHour ?? EMPTY}
+                                      </span>
+                                      {/* Status */}
+                                      {row.original.startTime > row.original.timeIn?.timeHour ? (
+                                        <span
+                                          className={classNames(
+                                            'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500'
+                                          )}
+                                        />
+                                      ) : (
+                                        <>
+                                          {!Number.isNaN(row.original.timeIn?.id) && (
+                                            <span
+                                              className={classNames(
+                                                'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500'
+                                              )}
+                                            />
+                                          )}
+                                        </>
+                                      )}
+                                    </Link>
+                                  </>
+                                ) : (
+                                  <>
+                                    {/* Actual Time In Data */}
+                                    <span className="font-semibold">
+                                      {row.original.timeIn?.timeHour ?? EMPTY}
+                                    </span>
+                                    {/* Status */}
+                                    {row.original.timeIn?.timeHour !== undefined &&
+                                    row.original.timeIn?.timeHour !== ''
+                                      ? !(
+                                          row.original.startTime > row.original.timeIn?.timeHour
+                                        ) && (
+                                          <span
+                                            className={classNames(
+                                              'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500'
+                                            )}
+                                          />
+                                        )
+                                      : ''}
+                                  </>
+                                )}
                               </div>
                             </li>
                             <li className="flex items-center space-x-2 px-4 py-2">
                               <p>Time Out:</p>
                               <div className="relative flex">
-                                <span className="font-semibold">
-                                  {row.original.timeOut?.timeHour ?? EMPTY}
-                                </span>
-                                <span
-                                  className={classNames(
-                                    'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500'
-                                  )}
-                                />
+                                {row.original.timeOut?.remarks !== undefined &&
+                                row.original.timeOut?.remarks !== '' ? (
+                                  <Link
+                                    href={`my-daily-time-record/?time_out=${row.original.timeOut?.id}`}
+                                    className="relative flex cursor-pointer active:scale-95"
+                                  >
+                                    {/* Actual Time Out Data */}
+                                    <span className="font-semibold">
+                                      {row.original.timeOut?.timeHour ?? EMPTY}
+                                    </span>
+                                    {/* Status */}
+                                    {!Number.isNaN(row.original.timeOut?.id) && (
+                                      <span
+                                        className={classNames(
+                                          'ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500'
+                                        )}
+                                      />
+                                    )}
+                                  </Link>
+                                ) : (
+                                  <span className="font-semibold">
+                                    {row.original.timeOut?.timeHour ?? EMPTY}
+                                  </span>
+                                )}
                               </div>
                             </li>
                             <li className="px-4 py-2">


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-64

## Definition of Done
- [x] The dot remarks is now integrated in the my DTR and DTR Management in mobile view

## Pre-condition
- `docker compose up --build`
- go to MyDTR page and DTR Management page

## Expected Output
- Correct dot icon should be beside `Time In` and `Time Out` on both pages
- `Time In` and `Time Out` with `remarks` is now clickable and will open the remarks drawer

## Screenshots/Recordings
[DotMobileView.webm](https://user-images.githubusercontent.com/111718037/215399258-51fb5412-ce40-47c9-9760-ac8af862fe40.webm)

