### PR TITLE
HRIS-82 [BE] Implement Edit time entry functionality

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -27,7 +27,8 @@ builder.Services.AddGraphQLServer()
     .AddType<TimeOutMutation>()
     .AddType<SigninMutation>()
     .AddType<LogoutMutation>()
-    .AddType<InterruptionMutation>();
+    .AddType<InterruptionMutation>()
+    .AddType<TimeEntryMutation>();
 
 builder.Services.AddGraphQLServer().AddProjections().AddFiltering().AddSorting();
 

--- a/api/Requests/TimeEntryRequest.cs
+++ b/api/Requests/TimeEntryRequest.cs
@@ -1,0 +1,10 @@
+namespace api.Requests
+{
+    public class UpdateTimeEntry
+    {
+        public int UserId { get; set; }
+        public int TimeEntryId { get; set; }
+        public string? TimeIn { get; set; }
+        public string? TimeOut { get; set; }
+    }
+}

--- a/api/Schema/Mutations/TimeEntryMutation.cs
+++ b/api/Schema/Mutations/TimeEntryMutation.cs
@@ -1,0 +1,19 @@
+using api.Requests;
+using api.Services;
+
+namespace api.Schema.Mutations
+{
+    [ExtendObjectType("Mutation")]
+    public class TimeEntryMutation
+    {
+        private readonly TimeSheetService _timeSheetService;
+        public TimeEntryMutation(TimeSheetService timeSheetService)
+        {
+            _timeSheetService = timeSheetService;
+        }
+        public async Task<string> UpdateOneTimeEntry(UpdateTimeEntry updatedTimeEntry)
+        {
+            return await _timeSheetService.UpdateOneTimeEntry(updatedTimeEntry);
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-82

## Definition of Done
- [x] Created mutation and service for updating/editing one time entry

## Pre-condition
- `docker compose up --build` or `dotnet run` in `api` directory
- go to `http://localhost:5257/graphql/`
- use this mutation
```
mutation ($updatedTimeEntry: UpdateTimeEntryInput!){
  updateOneTimeEntry(updatedTimeEntry: $updatedTimeEntry)
}
```
- and edit these variables (userId is the id of user doing the editing)
```
{
 "updatedTimeEntry": {
    "userId": 3,
    "timeEntryId" : 1004,
    "timeIn": "11:16:59",
    "timeOut": "17:59:59"
 } 
}
```

## Expected Output
- HR Admin can edit `Time In` and `Time Out` of a `Time Entry`
- Only HR Admin should be able to edit/update
- It should create new `Time` entity if the selected `TimeEntry` has no `TimeInId` or `TimeOutId`, otherwise, just update the existing entity for `TimeIn` and `TimeOut`

## Screenshots/Recordings
[edit timeentry.webm](https://user-images.githubusercontent.com/111718037/215932781-1f616cf6-3b3b-4e06-a3fa-e6c270818da8.webm)
