### PR TITLE
HRIS-92 [BE] Implement fetch all requested leaves functionality

### DIFF
--- a/api/Context/HrisContext.cs
+++ b/api/Context/HrisContext.cs
@@ -55,6 +55,12 @@ public partial class HrisContext : DbContext
         modelBuilder.Entity<Project>().HasData(
             DatabaseSeeder.projects
         );
+        modelBuilder.Entity<Leave>().HasData(
+            DatabaseSeeder.leaves
+        );
+        modelBuilder.Entity<Undertime>().HasData(
+            DatabaseSeeder.undertimes
+        );
     }
 
     partial void OnModelCreatingPartial(ModelBuilder modelBuilder);

--- a/api/Migrations/20230201065141_LeaveSeeder.Designer.cs
+++ b/api/Migrations/20230201065141_LeaveSeeder.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
@@ -11,9 +12,11 @@ using api.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(HrisContext))]
-    partial class HrisContextModelSnapshot : ModelSnapshot
+    [Migration("20230201065141_LeaveSeeder")]
+    partial class LeaveSeeder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -753,38 +756,6 @@ namespace api.Migrations
                     b.HasIndex("UserId");
 
                     b.ToTable("Undertimes");
-
-                    b.HasData(
-                        new
-                        {
-                            Id = 1,
-                            CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                            From = new TimeSpan(0, 9, 30, 0, 0),
-                            IsLeaderApproved = true,
-                            IsManagerApproved = true,
-                            ManagerId = 1,
-                            OtherProject = "None",
-                            ProjectId = 1,
-                            Reason = "Leave lang guds",
-                            To = new TimeSpan(0, 18, 30, 0, 0),
-                            UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                            UserId = 1
-                        },
-                        new
-                        {
-                            Id = 2,
-                            CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                            From = new TimeSpan(0, 9, 30, 0, 0),
-                            IsLeaderApproved = true,
-                            IsManagerApproved = true,
-                            ManagerId = 1,
-                            OtherProject = "None",
-                            ProjectId = 1,
-                            Reason = "Under lang guds",
-                            To = new TimeSpan(0, 18, 30, 0, 0),
-                            UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                            UserId = 1
-                        });
                 });
 
             modelBuilder.Entity("api.Entities.User", b =>

--- a/api/Migrations/20230201065141_LeaveSeeder.cs
+++ b/api/Migrations/20230201065141_LeaveSeeder.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class LeaveSeeder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Leaves",
+                columns: new[] { "Id", "CreatedAt", "IsLeaderApproved", "IsManagerApproved", "IsWithPay", "LeaveDate", "LeaveTypeId", "ManagerId", "OtherProject", "ProjectId", "Reason", "UpdatedAt", "UserId" },
+                values: new object[,]
+                {
+                    { 1, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), true, true, false, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), 1, 1, "None", 1, "Leave lang guds", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), 1 },
+                    { 2, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), true, true, true, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), 4, 1, "None", 3, "Vacation leave", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), 1 }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Leaves",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Leaves",
+                keyColumn: "Id",
+                keyValue: 2);
+        }
+    }
+}

--- a/api/Migrations/20230201072040_UndertimeSeeder.Designer.cs
+++ b/api/Migrations/20230201072040_UndertimeSeeder.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
@@ -11,9 +12,11 @@ using api.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(HrisContext))]
-    partial class HrisContextModelSnapshot : ModelSnapshot
+    [Migration("20230201072040_UndertimeSeeder")]
+    partial class UndertimeSeeder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20230201072040_UndertimeSeeder.cs
+++ b/api/Migrations/20230201072040_UndertimeSeeder.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class UndertimeSeeder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Undertimes",
+                columns: new[] { "Id", "CreatedAt", "From", "IsLeaderApproved", "IsManagerApproved", "ManagerId", "OtherProject", "ProjectId", "Reason", "To", "UpdatedAt", "UserId" },
+                values: new object[,]
+                {
+                    { 1, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), new TimeSpan(0, 9, 30, 0, 0), true, true, 1, "None", 1, "Leave lang guds", new TimeSpan(0, 18, 30, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), 1 },
+                    { 2, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), new TimeSpan(0, 9, 30, 0, 0), true, true, 1, "None", 1, "Under lang guds", new TimeSpan(0, 18, 30, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), 1 }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Undertimes",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Undertimes",
+                keyColumn: "Id",
+                keyValue: 2);
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -19,7 +19,8 @@ builder.Services.AddGraphQLServer()
     .AddQueryType(q => q.Name("Query"))
     .AddType<UserQuery>()
     .AddType<TimeSheetQuery>()
-    .AddType<InterruptionQuery>();
+    .AddType<InterruptionQuery>()
+    .AddType<LeaveQuery>();
 
 builder.Services.AddGraphQLServer()
     .AddMutationType(q => q.Name("Mutation"))

--- a/api/Schema/Queries/LeaveQuery.cs
+++ b/api/Schema/Queries/LeaveQuery.cs
@@ -1,0 +1,20 @@
+using api.Entities;
+using api.Services;
+
+namespace api.Schema.Queries
+{
+    [ExtendObjectType("Query")]
+    public class LeaveQuery
+    {
+        private readonly LeaveService _leaveService;
+        public LeaveQuery(LeaveService leaveService)
+        {
+            _leaveService = leaveService;
+        }
+
+        public async Task<List<Leave>> GetAllLeaves()
+        {
+            return await _leaveService.Index();
+        }
+    }
+}

--- a/api/Seeders/DatabaseSeeder.cs
+++ b/api/Seeders/DatabaseSeeder.cs
@@ -417,5 +417,67 @@ namespace api.Seeders
                 UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
             },
         };
+        public static List<Leave> leaves = new List<Leave>(){
+            new Leave {
+                Id = 1,
+                UserId = 1,
+                ProjectId = 1,
+                LeaveTypeId = 1,
+                ManagerId = 1,
+                OtherProject = "None",
+                Reason = "Leave lang guds",
+                LeaveDate = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                IsWithPay = false,
+                IsLeaderApproved = true,
+                IsManagerApproved = true,
+                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+            },
+            new Leave {
+                Id = 2,
+                UserId = 1,
+                ProjectId = 3,
+                LeaveTypeId = 4,
+                ManagerId = 1,
+                OtherProject = "None",
+                Reason = "Vacation leave",
+                LeaveDate = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                IsWithPay = true,
+                IsLeaderApproved = true,
+                IsManagerApproved = true,
+                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+            },
+        };
+        public static List<Undertime> undertimes = new List<Undertime>(){
+            new Undertime {
+                Id = 1,
+                UserId = 1,
+                ProjectId = 1,
+                ManagerId = 1,
+                OtherProject = "None",
+                Reason = "Leave lang guds",
+                From = new TimeSpan(9, 30, 0),
+                To = new TimeSpan(18, 30, 0),
+                IsLeaderApproved = true,
+                IsManagerApproved = true,
+                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+            },
+            new Undertime {
+                Id = 2,
+                UserId = 1,
+                ProjectId = 1,
+                ManagerId = 1,
+                OtherProject = "None",
+                Reason = "Under lang guds",
+                From = new TimeSpan(9, 30, 0),
+                To = new TimeSpan(18, 30, 0),
+                IsLeaderApproved = true,
+                IsManagerApproved = true,
+                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+            },
+        };
     }
 }

--- a/api/Services/LeaveService.cs
+++ b/api/Services/LeaveService.cs
@@ -44,5 +44,12 @@ namespace api.Services
                 .Build());
             }
         }
+        public async Task<List<Leave>> Index()
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                return await context.Leaves.ToListAsync();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-92

## Definition of Done

- [x] Users can query all requested leaves inside leaves table

## Notes
- BE integration only

## Pre-condition
- From the root directory, go to api directory
- run ``` dotnet ef database update ```
- If the seeder does not work, you can run ``` dotnet ef database update 0 ``` to reset the migrations before running ``` dotnet ef database update ```
- In the root directory, run ``` docker compose up --build ```
- Access ``` http://localhost:5257/graphql/ ```
- Run this sample query
``` query {
  allLeaves {
  id
  userId
  projectId
  leaveTypeId
  managerId
  otherProject
  reason
  leaveDate
  isWithPay
  isLeaderApproved
  isManagerApproved
  createdAt
  updatedAt
  }
}
```

## Expected Output
- It should return all requested employee leaves

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/109492180/216008076-ecdb9050-e2e4-43e1-907d-4b56b0bc65da.png)

