### PR TITLE
HRIS-83 [FE] Integrate Edit time entry functionality

### DIFF
--- a/api/Services/TimeSheetService.cs
+++ b/api/Services/TimeSheetService.cs
@@ -146,7 +146,9 @@ namespace api.Services
             using (HrisContext context = _contextFactory.CreateDbContext())
             {
                 var user = context.Users.SingleOrDefault(user => user.Id == updatedTimeEntry.UserId);
-                if (user == null || user.RoleId != 2) return "Operation not allowed for this user";
+                if (user == null || user.RoleId != 2) throw new GraphQLException(ErrorBuilder.New()
+                .SetMessage("Operation not allowed for this user")
+                .Build());
 
                 var currentTimeEntry = context.TimeEntries
                     .SingleOrDefault(entry => entry.Id == updatedTimeEntry.TimeEntryId);
@@ -195,7 +197,9 @@ namespace api.Services
                     return "Updated Successfully!";
                 }
 
-                return "Something went wrong";
+                throw new GraphQLException(ErrorBuilder.New()
+                .SetMessage("Something went wrong")
+                .Build());
             }
         }
     }

--- a/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
@@ -9,6 +9,7 @@ import { ChevronRight, Clock, Edit } from 'react-feather'
 import Chip from '~/components/atoms/Chip'
 import Avatar from '~/components/atoms/Avatar'
 import Button from '~/components/atoms/Buttons/Button'
+import EditTimeEntriesModal from '../EditTimeEntryModal'
 import { ITimeEntry } from '~/utils/types/timeEntryTypes'
 import { WorkStatus } from '~/utils/constants/work-status'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
@@ -23,6 +24,7 @@ type Props = {
 
 const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
   const [isOpenTimeEntry, setIsOpenTimeEntry] = useState<boolean>(false)
+  const [isOpenEditModal, setIsOpenEditModal] = useState<boolean>(false)
   const [timeEntryId, setTimeEntryId] = useState<number>(-1)
   const [user, setUser] = useState<string>('')
 
@@ -30,6 +32,10 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
     setIsOpenTimeEntry(!isOpenTimeEntry)
     setTimeEntryId(parseInt(id as string))
     setUser(name as string)
+  }
+
+  const handleIsOpenEditModalToggle = (): void => {
+    setIsOpenEditModal(!isOpenEditModal)
   }
 
   const EMPTY = 'N/A'
@@ -223,11 +229,25 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                   </Tippy>
                                   <Tippy placement="left" content="Edit" className="!text-xs">
                                     <Button
-                                      onClick={() => alert(row.original.id)}
+                                      onClick={handleIsOpenEditModalToggle}
                                       rounded="none"
                                       className="py-0.5 px-1 text-slate-500"
                                     >
                                       <Edit className="h-4 w-4" />
+                                      {isOpenEditModal ? (
+                                        <EditTimeEntriesModal
+                                          {...{
+                                            isOpen: isOpenEditModal,
+                                            user: row.original.user,
+                                            timeEntry: {
+                                              id: row.original.id,
+                                              timeIn: row.original.timeIn?.timeHour,
+                                              timeOut: row.original.timeOut?.timeHour
+                                            },
+                                            closeModal: handleIsOpenEditModalToggle
+                                          }}
+                                        />
+                                      ) : null}
                                     </Button>
                                   </Tippy>
                                 </div>

--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -12,6 +12,7 @@ import CellHeader from '~/components/atoms/CellHeader'
 import Button from '~/components/atoms/Buttons/Button'
 import { ITimeEntry } from '~/utils/types/timeEntryTypes'
 import InterruptionTimeEntriesModal from './../InterruptionTimeEntriesModal'
+import EditTimeEntriesModal from '../EditTimeEntryModal'
 
 const columnHelper = createColumnHelper<ITimeEntry>()
 const EMPTY = 'N/A'
@@ -153,9 +154,14 @@ export const columns = [
     header: () => <span className="font-normal text-slate-500">Actions</span>,
     cell: (props) => {
       const [isOpenTimeEntry, setIsOpenTimeEntry] = useState<boolean>(false)
+      const [isOpenEditModal, setIsOpenEditModal] = useState<boolean>(false)
 
       const handleIsOpenTimeEntryToggle = (id?: string | undefined): void => {
         setIsOpenTimeEntry(!isOpenTimeEntry)
+      }
+
+      const handleIsOpenEditModalToggle = (): void => {
+        setIsOpenEditModal(!isOpenEditModal)
       }
 
       return (
@@ -181,11 +187,25 @@ export const columns = [
           </Tippy>
           <Tippy content="Edit" placement="left" className="!text-xs">
             <Button
-              onClick={() => alert(props.row.id)}
+              onClick={handleIsOpenEditModalToggle}
               rounded="none"
               className="py-0.5 px-1 text-slate-500"
             >
               <Edit className="h-4 w-4" />
+              {isOpenEditModal ? (
+                <EditTimeEntriesModal
+                  {...{
+                    isOpen: isOpenEditModal,
+                    user: props.row.original.user,
+                    timeEntry: {
+                      id: props.row.original.id,
+                      timeIn: props.row.original.timeIn?.timeHour,
+                      timeOut: props.row.original.timeOut?.timeHour
+                    },
+                    closeModal: handleIsOpenEditModalToggle
+                  }}
+                />
+              ) : null}
             </Button>
           </Tippy>
         </div>

--- a/client/src/components/molecules/EditTimeEntryModal/index.tsx
+++ b/client/src/components/molecules/EditTimeEntryModal/index.tsx
@@ -1,0 +1,150 @@
+import classNames from 'classnames'
+import React, { FC, useEffect } from 'react'
+import { Edit, Save, X } from 'react-feather'
+import { useForm } from 'react-hook-form'
+import Button from '~/components/atoms/Buttons/ButtonAction'
+import ModalTemplate from '~/components/templates/ModalTemplate'
+import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
+import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+import { TimeEntryFormValues } from '~/utils/types/formValues'
+import useUpdateTimeEntryMutation from '~/hooks/useTimeEntryMutation'
+
+type Props = {
+  isOpen: boolean
+  timeEntry: {
+    id: number
+    timeIn: string
+    timeOut: string
+  }
+  user: {
+    id: number
+    name: string
+  }
+  closeModal: () => void
+}
+
+const EditTimeEntriesModal: FC<Props> = ({ isOpen, timeEntry, user, closeModal }): JSX.Element => {
+  const { handleUpdateTimeEntryMutation } = useUpdateTimeEntryMutation()
+  const updateTimeEntry = handleUpdateTimeEntryMutation()
+
+  const handleSave = (data: TimeEntryFormValues): void => {
+    updateTimeEntry.mutate({
+      updatedTimeEntry: {
+        userId: user.id,
+        timeEntryId: timeEntry.id,
+        timeIn: data.time_in,
+        timeOut: data.time_out !== '' ? data.time_out : null
+      }
+    })
+    closeModal()
+  }
+
+  const {
+    reset,
+    register,
+    handleSubmit,
+    formState: { isSubmitting }
+  } = useForm<TimeEntryFormValues>({
+    mode: 'onTouched'
+  })
+
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        time_in: timeEntry.timeIn,
+        time_out: timeEntry.timeOut
+      })
+    }
+  }, [isOpen])
+
+  return (
+    <ModalTemplate
+      {...{
+        isOpen,
+        closeModal
+      }}
+      className="w-full max-w-md"
+    >
+      <form
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        onSubmit={handleSubmit(handleSave)}
+      >
+        {/* Custom Modal Header */}
+        <ModalHeader
+          {...{
+            title: `${user.name}'s DTR`,
+            Icon: Edit,
+            closeModal
+          }}
+        />
+        <div className="space-y-3 px-6 py-4">
+          <div className="grid grid-cols-2 gap-x-6 px-4 py-4">
+            <div>
+              <label htmlFor="timeIn" className="space-y-0.5">
+                <p className="text-xs text-slate-500">Time In</p>
+                <input
+                  type="time"
+                  id="timeIn"
+                  className={classNames(
+                    'block w-full rounded placeholder:font-light placeholder:text-slate-400',
+                    'border border-solid border-slate-300 bg-white bg-clip-padding',
+                    'resize-none px-3 py-3 text-xs font-normal text-slate-700 transition',
+                    'clock:text-white ease-in-out focus:bg-white focus:text-slate-700',
+                    'disabled:cursor-not-allowed disabled:opacity-50'
+                  )}
+                  {...register('time_in')}
+                  disabled={isSubmitting}
+                />
+              </label>
+            </div>
+            <div>
+              <label htmlFor="timeOut" className="space-y-0.5">
+                <p className="text-xs text-slate-500">Time Out</p>
+                <input
+                  type="time"
+                  id="timeOut"
+                  className={classNames(
+                    'block w-full rounded placeholder:font-light placeholder:text-slate-400',
+                    'border border-solid border-slate-300 bg-white bg-clip-padding',
+                    'resize-none px-3 py-3 text-xs font-normal text-slate-700 transition',
+                    'clock:text-white ease-in-out focus:bg-white focus:text-slate-700',
+                    'disabled:cursor-not-allowed disabled:opacity-50'
+                  )}
+                  {...register('time_out')}
+                  disabled={isSubmitting}
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+
+        {/* Custom Modal Footer Style */}
+        <ModalFooter>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={closeModal}
+            className="relative flex items-center space-x-1 py-1 px-7 text-sm"
+            disabled={isSubmitting}
+          >
+            <X className="absolute left-2.5 h-4 w-4" />
+            <span>Close</span>
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            className="relative flex items-center space-x-2 py-1 px-7 text-sm"
+            disabled={isSubmitting}
+          >
+            <Save className="absolute left-2.5 h-4 w-4" />
+            <span>Save</span>
+          </Button>
+        </ModalFooter>
+      </form>
+    </ModalTemplate>
+  )
+}
+
+EditTimeEntriesModal.defaultProps = {}
+
+export default EditTimeEntriesModal

--- a/client/src/components/molecules/EditTimeEntryModal/index.tsx
+++ b/client/src/components/molecules/EditTimeEntryModal/index.tsx
@@ -1,13 +1,14 @@
 import classNames from 'classnames'
+import { useForm } from 'react-hook-form'
 import React, { FC, useEffect } from 'react'
 import { Edit, Save, X } from 'react-feather'
-import { useForm } from 'react-hook-form'
+
 import Button from '~/components/atoms/Buttons/ButtonAction'
+import { TimeEntryFormValues } from '~/utils/types/formValues'
 import ModalTemplate from '~/components/templates/ModalTemplate'
+import useUpdateTimeEntryMutation from '~/hooks/useTimeEntryMutation'
 import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
 import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
-import { TimeEntryFormValues } from '~/utils/types/formValues'
-import useUpdateTimeEntryMutation from '~/hooks/useTimeEntryMutation'
 
 type Props = {
   isOpen: boolean

--- a/client/src/graphql/mutations/timeEntryMutation.ts
+++ b/client/src/graphql/mutations/timeEntryMutation.ts
@@ -1,0 +1,7 @@
+import { gql } from 'graphql-request'
+
+export const UPDATE_TIME_ENTRY = gql`
+  mutation ($updatedTimeEntry: UpdateTimeEntryInput!) {
+    updateOneTimeEntry(updatedTimeEntry: $updatedTimeEntry)
+  }
+`

--- a/client/src/hooks/useTimeEntryMutation.ts
+++ b/client/src/hooks/useTimeEntryMutation.ts
@@ -1,0 +1,49 @@
+import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'react-hot-toast'
+import { UPDATE_TIME_ENTRY } from '~/graphql/mutations/timeEntryMutation'
+import { client } from '~/utils/shared/client'
+
+type UpdateTimeEntryRequest = {
+  updatedTimeEntry: {
+    userId: number
+    timeEntryId: number
+    timeIn: string | null
+    timeOut: string | null
+  }
+}
+type returnType = {
+  handleUpdateTimeEntryMutation: () => UseMutationResult<
+    any,
+    unknown,
+    UpdateTimeEntryRequest,
+    unknown
+  >
+}
+type handleUpdateTimeEntryMutationReturnType = UseMutationResult<
+  any,
+  unknown,
+  UpdateTimeEntryRequest,
+  unknown
+>
+
+const useUpdateTimeEntryMutation = (): returnType => {
+  const queryClient = useQueryClient()
+
+  const handleUpdateTimeEntryMutation = (): handleUpdateTimeEntryMutationReturnType =>
+    useMutation({
+      mutationFn: async (updatedTimeEntry: UpdateTimeEntryRequest) => {
+        return await client.request(UPDATE_TIME_ENTRY, updatedTimeEntry)
+      },
+      onSuccess: async (data) => {
+        await queryClient.refetchQueries(['GET_ALL_EMPLOYEE_TIMESHEET'])
+        toast.success(data.updateOneTimeEntry)
+      },
+      onError: (error) => {
+        const data = JSON.parse(JSON.stringify(error))
+        toast.error(data.response.errors[0].message)
+      }
+    })
+  return { handleUpdateTimeEntryMutation }
+}
+
+export default useUpdateTimeEntryMutation

--- a/client/src/hooks/useTimeEntryMutation.ts
+++ b/client/src/hooks/useTimeEntryMutation.ts
@@ -1,7 +1,8 @@
-import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-hot-toast'
-import { UPDATE_TIME_ENTRY } from '~/graphql/mutations/timeEntryMutation'
+import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query'
+
 import { client } from '~/utils/shared/client'
+import { UPDATE_TIME_ENTRY } from '~/graphql/mutations/timeEntryMutation'
 
 type UpdateTimeEntryRequest = {
   updatedTimeEntry: {


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-83

## Definition of Done
- [x] Created markup of modal for editing time entries
- [x] HR Admin user can edit time entries of employees in DTR Management table
- [x] After successful edit, the table data will be refetched

## Notes
- Modified returned data from BE

## Pre-condition
- `docker compose up --build`
- go to DTR Management page

## Expected Output
- Only HR Admin user should be able to edit
- Toast message will display on success or error
- New data will be reflected immediately on table after successful edit
- Both `Time In` and `Time Out` field are optional
- Same behaviors should also be in the mobile view

## Screenshots/Recordings
- Desktop Mode

[EditTimeEntry-FE.webm](https://user-images.githubusercontent.com/111718037/216016445-c25272b6-14a6-41fa-8dc0-ca10b0841a7a.webm)

- Mobile Mode

[EditTimeEntry-Mobile.webm](https://user-images.githubusercontent.com/111718037/216208608-df63b346-4084-4c8b-b32d-ad4f1e7d09e1.webm)


