### PR TITLE
HRIS-83-01 [FE] Fix: Disabled time fields if there are no initial data

### DIFF
--- a/client/src/components/molecules/EditTimeEntryModal/index.tsx
+++ b/client/src/components/molecules/EditTimeEntryModal/index.tsx
@@ -94,7 +94,9 @@ const EditTimeEntriesModal: FC<Props> = ({ isOpen, timeEntry, user, closeModal }
                     'disabled:cursor-not-allowed disabled:opacity-50'
                   )}
                   {...register('time_in')}
-                  disabled={isSubmitting}
+                  disabled={
+                    isSubmitting || timeEntry.timeIn === null || timeEntry.timeIn === undefined
+                  }
                 />
               </label>
             </div>
@@ -112,7 +114,9 @@ const EditTimeEntriesModal: FC<Props> = ({ isOpen, timeEntry, user, closeModal }
                     'disabled:cursor-not-allowed disabled:opacity-50'
                   )}
                   {...register('time_out')}
-                  disabled={isSubmitting}
+                  disabled={
+                    isSubmitting || timeEntry.timeOut === null || timeEntry.timeOut === undefined
+                  }
                 />
               </label>
             </div>
@@ -135,7 +139,11 @@ const EditTimeEntriesModal: FC<Props> = ({ isOpen, timeEntry, user, closeModal }
             type="submit"
             variant="primary"
             className="relative flex items-center space-x-2 py-1 px-7 text-sm"
-            disabled={isSubmitting}
+            disabled={
+              isSubmitting ||
+              (timeEntry.timeIn === undefined && timeEntry.timeOut === undefined) ||
+              (timeEntry.timeIn === null && timeEntry.timeOut === null)
+            }
           >
             <Save className="absolute left-2.5 h-4 w-4" />
             <span>Save</span>


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-83

## Definition of Done
- [x] Disabled the time fields if there are no initial data
- [x] Save button is disabled if both time fields are empty

## Notes
- Revision 1 from task HRIS-83

## Pre-condition
- `docker compose up --build`
- go to DTR Management page

## Expected Output
- Any time fields are disabled if there are no initial data
- Save button is disabled if both time fields are empty

## Screenshots/Recordings
- One time field is empty
![image](https://user-images.githubusercontent.com/111718037/216224612-39574c8d-3a20-479c-b614-8a77d1f8a4b4.png)

- Both time field is empty, Save button disabled
![image](https://user-images.githubusercontent.com/111718037/216224722-99377b36-713c-47a0-b269-acdcff2b8d11.png)
