### PR TITLE
HRIS-90 [BE] Implement Fetch Yearly Summary data of all employees functionality

### DIFF
--- a/api/DTOs/HeatMapDTO.cs
+++ b/api/DTOs/HeatMapDTO.cs
@@ -32,5 +32,11 @@ namespace api.DTOs
                     break;
             }
         }
+
+        public HeatMapDTO(int day, int value)
+        {
+            this.day = day;
+            this.value = value;
+        }
     }
 }

--- a/api/DTOs/LeaveHeatMapDTO.cs
+++ b/api/DTOs/LeaveHeatMapDTO.cs
@@ -17,7 +17,7 @@ namespace api.DTOs
 
         public LeaveHeatMapDTO(List<LeavesTableDTO> leaves)
         {
-            leaves.ForEach(leave =>
+            leaves.OrderBy(leave => leave.Date).ToList().ForEach(leave =>
             {
                 switch (leave.Date?.Month)
                 {
@@ -37,28 +37,58 @@ namespace api.DTOs
                         May?.Add(new HeatMapDTO(leave));
                         break;
                     case 6:
-                        January?.Add(new HeatMapDTO(leave));
-                        break;
-                    case 7:
                         June?.Add(new HeatMapDTO(leave));
                         break;
-                    case 8:
+                    case 7:
                         July?.Add(new HeatMapDTO(leave));
                         break;
-                    case 9:
+                    case 8:
                         August?.Add(new HeatMapDTO(leave));
                         break;
-                    case 10:
+                    case 9:
                         September?.Add(new HeatMapDTO(leave));
                         break;
-                    case 11:
+                    case 10:
                         October?.Add(new HeatMapDTO(leave));
                         break;
-                    case 12:
+                    case 11:
                         November?.Add(new HeatMapDTO(leave));
+                        break;
+                    case 12:
+                        December?.Add(new HeatMapDTO(leave));
                         break;
                 }
             });
+        }
+
+        public void summarizeMonth()
+        {
+            this.January = this.summarizeToDays(this.January);
+            this.February = this.summarizeToDays(this.February);
+            this.March = this.summarizeToDays(this.March);
+            this.April = this.summarizeToDays(this.April);
+            this.May = this.summarizeToDays(this.May);
+            this.June = this.summarizeToDays(this.June);
+            this.July = this.summarizeToDays(this.July);
+            this.August = this.summarizeToDays(this.August);
+            this.September = this.summarizeToDays(this.September);
+            this.October = this.summarizeToDays(this.October);
+            this.November = this.summarizeToDays(this.November);
+            this.December = this.summarizeToDays(this.December);
+        }
+
+        private List<HeatMapDTO> summarizeToDays(List<HeatMapDTO> month)
+        {
+            var groupedByDays = month.GroupBy(month => month.day);
+            List<HeatMapDTO> newHeatmap = new List<HeatMapDTO>();
+
+            foreach (var dayGroup in groupedByDays)
+            {
+                var majority = dayGroup.GroupBy(group => group.value).OrderByDescending(value => value.Count()).First();
+                newHeatmap.Add(new HeatMapDTO(dayGroup.Key, majority.Key));
+            }
+
+            return newHeatmap;
         }
     }
 }

--- a/api/DTOs/LeavesDTO.cs
+++ b/api/DTOs/LeavesDTO.cs
@@ -9,7 +9,7 @@ namespace api.DTOs
         public LeavesDTO(LeaveHeatMapDTO heatmapLeaves, List<LeavesTableDTO> table)
         {
             Heatmap = heatmapLeaves;
-            Table = table;
+            Table = table.OrderByDescending(table => table.Date).ToList();
             Breakdown = new LeaveBreakdownDTO(table);
         }
     }

--- a/api/Schema/Queries/LeaveQuery.cs
+++ b/api/Schema/Queries/LeaveQuery.cs
@@ -21,5 +21,10 @@ namespace api.Schema.Queries
         {
             return await _leaveService.GetLeavesSummary(userId, year);
         }
+
+        public async Task<LeavesDTO> GetYearlyAllLeaves(int year)
+        {
+            return await _leaveService.ShowYearlyLeavesSummary(year);
+        }
     }
 }

--- a/api/Services/LeaveService.cs
+++ b/api/Services/LeaveService.cs
@@ -28,6 +28,22 @@ namespace api.Services
             }
         }
 
+        public async Task<LeavesDTO> ShowYearlyLeavesSummary(int year)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+
+                var leaves = await context.Leaves
+                            .Include(i => i.LeaveType)
+                            .Where(u => u.LeaveDate.Year == year)
+                            .OrderBy(o => o.LeaveDate.Day)
+                            .Select(s => new LeavesTableDTO(s))
+                            .ToListAsync();
+                LeaveHeatMapDTO heatmap = new LeaveHeatMapDTO(leaves);
+                heatmap.summarizeMonth();
+                return new LeavesDTO(heatmap, leaves);
+            }
+        }
         public async Task<List<Leave>> Create(CreateLeaveRequest leave)
         {
             using (HrisContext context = _contextFactory.CreateDbContext())


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-90

## Definition of Done
- [x] Can query the yearly summary of leaves of all employee
- [x] Can fetch the heatmap, table (list of leaves) and breakdown of leave types


## Pre-condition
- `docker compose up --build` or `dotnet run` on `api` directory
- go to `http://localhost:5257/graphql/`
- you can play around using this query
```
query($year:Int!){
  yearlyAllLeaves(year: $year){
    heatmap{
      january{
        value
        day
      }
      february{
        value
        day
      }
    }
    table{
      date
      leaveTypeId
      isWithPay
      reason
      numLeaves
    }
    breakdown{
      undertime
      sickLeave
      vacationLeave
      emergencyLeave
      bereavementLeave
      maternityLeave
      withoutPayTotal
      withPayTotal
    }
  }
}
```
- using this variable
```
{
 "year": 2022
}
```

## Expected Output
- The query should return 
- In case of same number of majority type of leave, the type that has earliest/oldest entry will be selected

## Screenshots/Recordings
[FetchYearlySummary.webm](https://user-images.githubusercontent.com/111718037/216528339-4e4ab13c-415b-4da6-8d5c-2cd60ed8a32c.webm)
