### PR TITLE
HRIS-91 [FE] Integrate Fetch Yearly Summary data of all employees functionality

### DIFF
--- a/client/src/components/molecules/SummaryFilterDropdown/index.tsx
+++ b/client/src/components/molecules/SummaryFilterDropdown/index.tsx
@@ -20,7 +20,10 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
   const isListOfLeaveTabPage = router.pathname === '/leave-management/list-of-leave'
 
   const handleUpdateResult = (): void => {
-    if (router.pathname.includes('/my-leaves')) {
+    if (
+      router.pathname.includes('/my-leaves') ||
+      router.pathname.includes('/leave-management/yearly-summary')
+    ) {
       void router.replace({
         pathname: router.pathname,
         query: {
@@ -89,7 +92,7 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
                     onChange={(e) => setYear(parseInt(e.target.value))}
                     id="filterYear"
                   >
-                    {range(currentYear, currentYear - 10, -1).map((year, i) => (
+                    {range(currentYear, 2015, -1).map((year, i) => (
                       <option key={i} value={year}>
                         {year}
                       </option>

--- a/client/src/graphql/queries/leaveQuery.ts
+++ b/client/src/graphql/queries/leaveQuery.ts
@@ -72,3 +72,77 @@ export const GET_MY_LEAVES_QUERY = gql`
     }
   }
 `
+
+export const GET_YEARLY_ALL_LEAVES_QUERY = gql`
+  query ($year: Int!) {
+    yearlyAllLeaves(year: $year) {
+      heatmap {
+        january {
+          value
+          day
+        }
+        february {
+          value
+          day
+        }
+        march {
+          value
+          day
+        }
+        april {
+          value
+          day
+        }
+        may {
+          value
+          day
+        }
+        june {
+          value
+          day
+        }
+        july {
+          value
+          day
+        }
+        august {
+          value
+          day
+        }
+        september {
+          value
+          day
+        }
+        october {
+          value
+          day
+        }
+        november {
+          value
+          day
+        }
+        december {
+          value
+          day
+        }
+      }
+      table {
+        date
+        leaveTypeId
+        isWithPay
+        reason
+        numLeaves
+      }
+      breakdown {
+        sickLeave
+        undertime
+        vacationLeave
+        emergencyLeave
+        bereavementLeave
+        maternityLeave
+        withoutPayTotal
+        withPayTotal
+      }
+    }
+  }
+`

--- a/client/src/hooks/useLeave.ts
+++ b/client/src/hooks/useLeave.ts
@@ -1,13 +1,15 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
 
 import { client } from '~/utils/shared/client'
-import { Leaves } from '~/utils/types/leaveTypes'
-import { GET_MY_LEAVES_QUERY } from '~/graphql/queries/leaveQuery'
+import { Leaves, YearlyLeaves } from '~/utils/types/leaveTypes'
+import { GET_MY_LEAVES_QUERY, GET_YEARLY_ALL_LEAVES_QUERY } from '~/graphql/queries/leaveQuery'
 
 type handleLeaveQueryType = UseQueryResult<Leaves, unknown>
+type handleYearlyLeaveQueryType = UseQueryResult<YearlyLeaves, unknown>
 
 type returnType = {
   handleLeaveQuery: (userId: number, year: number) => handleLeaveQueryType
+  handleYearlyAllLeaveQuery: (year: number, ready: boolean) => handleYearlyLeaveQueryType
 }
 
 const useLeave = (): returnType => {
@@ -18,8 +20,18 @@ const useLeave = (): returnType => {
       select: (data: Leaves) => data,
       enabled: Boolean(userId) && Boolean(year)
     })
+
+  const handleYearlyAllLeaveQuery = (year: number, ready: boolean): handleYearlyLeaveQueryType =>
+    useQuery({
+      queryKey: ['GET_YEARLY_ALL_LEAVES_QUERY', year],
+      queryFn: async () => await client.request(GET_YEARLY_ALL_LEAVES_QUERY, { year }),
+      select: (data: YearlyLeaves) => data,
+      enabled: ready
+    })
+
   return {
-    handleLeaveQuery
+    handleLeaveQuery,
+    handleYearlyAllLeaveQuery
   }
 }
 

--- a/client/src/pages/leave-management/yearly-summary.tsx
+++ b/client/src/pages/leave-management/yearly-summary.tsx
@@ -1,216 +1,150 @@
 import { NextPage } from 'next'
 import dynamic from 'next/dynamic'
 import classNames from 'classnames'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import Card from '~/components/atoms/Card'
-import { generateData } from '~/utils/generateData'
 import MaxWidthContainer from '~/components/atoms/MaxWidthContainer'
 import BreakdownOfLeaveCard from '~/components/molecules/BreakdownOfLeavesCard'
 import LeaveManagementLayout from '~/components/templates/LeaveManagementLayout'
 import LeaveManagementResultTable from '~/components/molecules/LeaveManagementResultTable'
 
+import {
+  getHeatmapData,
+  initialChartOptions,
+  initialSeriesData,
+  Series
+} from '~/utils/generateData'
+import useLeave from '~/hooks/useLeave'
+import { Breakdown, LeaveTable } from '~/utils/types/leaveTypes'
+import BarsLoadingIcon from '~/utils/icons/BarsLoadingIcon'
+import moment from 'moment'
+import { useRouter } from 'next/router'
+
 const ReactApexChart = dynamic(async () => await import('react-apexcharts'), {
   ssr: false
 })
 
+type SeriesData = {
+  name: string
+  data: Series[]
+}
+
 const YearlySummary: NextPage = (): JSX.Element => {
-  const [chart] = useState({
-    series: [
-      {
-        name: 'November',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'October',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'September',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'August',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'July',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'June',
-        data: generateData(31, {
-          min: 1,
-          max: 50
-        })
-      },
-      {
-        name: 'May',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'April',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'March',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'February',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'January',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      }
-    ],
-    options: {
-      chart: {
-        toolbar: {
-          show: false,
-          tools: {
-            download: true,
-            selection: false,
-            zoom: false,
-            zoomin: false,
-            zoomout: false,
-            pan: false,
-            reset: false
-          }
+  const router = useRouter()
+  const { handleYearlyAllLeaveQuery } = useLeave()
+  const {
+    data: leaves,
+    isSuccess,
+    isLoading: isLeavesLoading,
+    isError: isLeavesError
+  } = handleYearlyAllLeaveQuery(
+    isNaN(parseInt(router.query.year as string))
+      ? moment().year()
+      : parseInt(router.query.year as string),
+    router.isReady
+  )
+
+  const [series, setSeries] = useState<SeriesData[]>(initialSeriesData)
+
+  useEffect(() => {
+    if (isSuccess) {
+      setSeries([
+        {
+          name: 'December',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.december)
+        },
+        {
+          name: 'November',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.november)
+        },
+        {
+          name: 'October',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.october)
+        },
+        {
+          name: 'September',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.september)
+        },
+        {
+          name: 'August',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.august)
+        },
+        {
+          name: 'July',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.july)
+        },
+        {
+          name: 'June',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.june)
+        },
+        {
+          name: 'May',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.may)
+        },
+        {
+          name: 'April',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.april)
+        },
+        {
+          name: 'March',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.march)
+        },
+        {
+          name: 'February',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.february)
+        },
+        {
+          name: 'January',
+          data: getHeatmapData(31, leaves?.yearlyAllLeaves.heatmap.january)
         }
-      },
-      plotOptions: {
-        heatmap: {
-          shadeIntensity: 0.5,
-          radius: 0,
-          useFillColorAsStroke: false,
-          colorScale: {
-            ranges: [
-              {
-                from: 1,
-                to: 6,
-                name: 'Undertime',
-                color: '#d97706'
-              },
-              {
-                from: 7,
-                to: 12,
-                name: 'Sick Leave',
-                color: '#059669'
-              },
-              {
-                from: 13,
-                to: 18,
-                name: 'Vacation Leave',
-                color: '#2563eb'
-              },
-              {
-                from: 19,
-                to: 31,
-                name: 'Emergency Leave',
-                color: '#e11d48'
-              },
-              {
-                from: 32,
-                to: 50,
-                name: 'Bereavement Leave',
-                color: '#4b5563'
-              }
-            ]
-          }
-        }
-      },
-      dataLabels: {
-        enabled: false
-      },
-      stroke: {
-        width: 1
-      },
-      title: {
-        text: ''
-      }
+      ])
     }
-  })
+  }, [isSuccess, leaves?.yearlyAllLeaves.heatmap])
 
   return (
     <LeaveManagementLayout metaTitle="Yearly Summary">
-      <main className="default-scrollbar h-full flex-col space-y-4 overflow-y-auto px-4">
-        <MaxWidthContainer>
-          <Card className="default-scrollbar mt-4 overflow-x-auto overflow-y-hidden">
-            <div className="w-full min-w-[647px] px-5 pt-4 md:max-w-full">
-              <ReactApexChart
-                options={chart.options}
-                series={chart.series}
-                type="heatmap"
-                width={'100%'}
-                height={450}
+      {!isLeavesLoading ? (
+        <main className="default-scrollbar h-full flex-col space-y-4 overflow-y-auto px-4">
+          <MaxWidthContainer>
+            <Card className="default-scrollbar mt-4 overflow-x-auto overflow-y-hidden">
+              <div className="w-full min-w-[647px] px-5 pt-4 md:max-w-full">
+                <ReactApexChart
+                  options={initialChartOptions}
+                  series={series}
+                  type="heatmap"
+                  width={'100%'}
+                  height={450}
+                />
+              </div>
+            </Card>
+          </MaxWidthContainer>
+          <MaxWidthContainer>
+            <article
+              className={classNames(
+                'flex flex-col space-y-4 pb-24 text-xs',
+                'md:flex-row md:space-y-0 md:space-x-4'
+              )}
+            >
+              {/* Pass the needed props of these components */}
+              <BreakdownOfLeaveCard data={leaves?.yearlyAllLeaves.breakdown as Breakdown} />
+              <LeaveManagementResultTable
+                {...{
+                  query: {
+                    data: leaves?.yearlyAllLeaves.table as LeaveTable[],
+                    isLoading: isLeavesLoading,
+                    isError: isLeavesError
+                  }
+                }}
               />
-            </div>
-          </Card>
-        </MaxWidthContainer>
-        <MaxWidthContainer>
-          <article
-            className={classNames(
-              'flex flex-col space-y-4 pb-24 text-xs',
-              'md:flex-row md:space-y-0 md:space-x-4'
-            )}
-          >
-            {/* Pass the needed props of these components */}
-            <BreakdownOfLeaveCard
-              data={{
-                sickLeave: 0,
-                undertime: 0,
-                vacationLeave: 0,
-                emergencyLeave: 0,
-                bereavementLeave: 0,
-                maternityLeave: 0,
-                withoutPayTotal: 0,
-                withPayTotal: 0
-              }}
-            />
-            <LeaveManagementResultTable
-              {...{
-                query: {
-                  data: [],
-                  isLoading: false,
-                  isError: false
-                }
-              }}
-            />
-          </article>
-        </MaxWidthContainer>
-      </main>
+            </article>
+          </MaxWidthContainer>
+        </main>
+      ) : (
+        <div className="flex min-h-[50vh] items-center justify-center">
+          <BarsLoadingIcon className="h-7 w-7 fill-current text-amber-500" />
+        </div>
+      )}
     </LeaveManagementLayout>
   )
 }

--- a/client/src/utils/generateData.ts
+++ b/client/src/utils/generateData.ts
@@ -47,6 +47,7 @@ export const initialChartOptions = {
     }
   },
   tooltip: {
+    enabled: false,
     y: {
       title: {
         formatter: function (seriesName: string) {

--- a/client/src/utils/types/leaveTypes.ts
+++ b/client/src/utils/types/leaveTypes.ts
@@ -40,3 +40,11 @@ export type Leaves = {
     table: LeaveTable[]
   }
 }
+
+export type YearlyLeaves = {
+  yearlyAllLeaves: {
+    breakdown: Breakdown
+    heatmap: Heatmap
+    table: LeaveTable[]
+  }
+}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-91
https://framgiaph.backlog.com/view/HRIS-95

## Definition of Done
- [x] User can view and filter by year the Yearly Leave Summary

## Note
- This task also covered the task HRIS-95

## Pre-condition
- `docker compose up --build`
- go to `http://localhost:3000/leave-management/yearly-summary`

## Expected Output
- At first page visit, it should display the data from current year and the URL must have no query
- After selecting a year and clicking `Update Result` in the filter dropdown, the year should reflect on the URL with query key `year`

## Screenshots/Recordings
[YearlySummaryIntegrate.webm](https://user-images.githubusercontent.com/111718037/216879330-90f41259-4056-48a1-a4b7-712cb78f46cd.webm)
