### PR TITLE
HRIS-93-01 [FE] Fix: Set the decimal places on Total Undertime and Leaves to 3

### DIFF
--- a/client/src/pages/leave-management/list-of-leave.tsx
+++ b/client/src/pages/leave-management/list-of-leave.tsx
@@ -25,8 +25,10 @@ const ListOfLeave: NextPage = (): JSX.Element => {
         isWithPay: i?.isWithPay,
         manager: i?.manager?.name,
         projectLeader: i?.projects[0]?.projectLeader?.name,
-        totalUndertime: i?.leaveType?.name === 'Undertime' ? i?.days : 0,
-        totalLeaves: i?.leaveType?.name === 'Undertime' ? 0 : i?.days,
+        totalUndertime:
+          i?.leaveType?.name === 'Undertime' ? parseFloat(i?.days.toFixed(3).toString()) : 0,
+        totalLeaves:
+          i?.leaveType?.name === 'Undertime' ? 0 : parseFloat(i?.days.toFixed(3).toString()),
         dateFiled: moment(i?.createdAt).format('MM/DD/YYYY'),
         reason: i?.reason
       })


### PR DESCRIPTION
## Issue Link


## Definition of Done

- [x] Fixed the decimal places on Total Undertime and Total Leaves value. (Set to 3)

## Notes
- This is a revision from branch https://github.com/framgia/sph-hris/pull/69

## Pre-condition
- docker compose up --build

## Expected Output
- Values on Total Undertime and Leaves should now disregard ending zeros and at max 3 decimal places.

## Screenshots/Recordings

![image](https://user-images.githubusercontent.com/109492180/217144649-da43bc9e-e6e1-4f6f-9a7e-adcb8330366a.png)
