### PR TITLE
HRIS-89 [FE] Implement and Integrate Fetch Leave Summary data of a specific employee functionality

### DIFF
--- a/api/Schema/Queries/UserQuery.cs
+++ b/api/Schema/Queries/UserQuery.cs
@@ -8,9 +8,11 @@ namespace api.Schema.Queries
     public class UserQuery
     {
         private readonly TimeInService _timeInService;
-        public UserQuery(TimeInService timeInService)
+        private readonly UserService _userService;
+        public UserQuery(TimeInService timeInService, UserService userService)
         {
             _timeInService = timeInService;
+            _userService = userService;
         }
         public async Task<UserDTO?> GetUserById(string token, string schedule)
         {

--- a/client/src/components/molecules/SummaryFilterDropdown/index.tsx
+++ b/client/src/components/molecules/SummaryFilterDropdown/index.tsx
@@ -1,23 +1,42 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
+import Select from 'react-select'
 
+import useUserQuery from '~/hooks/useUserQuery'
+import { customStyles } from '~/utils/customReactSelectStyles'
 import Text from '~/components/atoms/Text'
 import RadioButton from '~/components/atoms/RadioButton'
 import { WorkStatus } from '~/utils/constants/work-status'
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import FilterDropdownTemplate from '~/components/templates/FilterDropdownTemplate'
+import { optionType, usersSelectOptions, yearSelectOptions } from '~/utils/maps/filterOptions'
 
 type Props = {}
 
 const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
   const router = useRouter()
   const currentYear = new Date().getFullYear()
+  const { handleAllUsersQuery } = useUserQuery()
+
   const range = (start: number, stop: number, step: number): number[] =>
     Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step)
-  const [year, setYear] = useState<number>(2023)
+
+  // filter states
+  const [year, setYear] = useState<number>(currentYear)
+  const [selectedUser, setSelectedUser] = useState<number>()
+
+  // filter options
+  const [nameOptions, setNameOptions] = useState<optionType[]>([])
+  const yearOptions = yearSelectOptions(range(currentYear, 2015, -1))
 
   const isListOfLeaveTabPage = router.pathname === '/leave-management/list-of-leave'
+  const isLeaveSummaryTabPage = router.pathname === '/leave-management/leave-summary'
+  const isYearlySummaryTabPage = router.pathname === '/leave-management/yearly-summary'
+
+  const { data, isSuccess, isLoading } = handleAllUsersQuery(
+    router.isReady && isLeaveSummaryTabPage
+  )
 
   const handleUpdateResult = (): void => {
     if (
@@ -30,12 +49,103 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
           year
         }
       })
+    } else if (router.pathname.includes('/leave-management/leave-summary')) {
+      void router.replace({
+        pathname: router.pathname,
+        query: {
+          id: selectedUser,
+          year
+        }
+      })
     }
   }
 
+  const handleDefaultValues = (field: string): optionType | null => {
+    let defaultValue: optionType | null = null
+
+    switch (field) {
+      case 'year':
+        defaultValue = yearOptions[0]
+        break
+      case 'name':
+        defaultValue = nameOptions[0]
+        break
+    }
+
+    if (isLeaveSummaryTabPage) {
+      const yearQuery = router.query.year
+      const idQuery = router.query.id
+
+      if (field === 'year') {
+        if (yearQuery !== undefined) {
+          yearOptions.forEach((option) => {
+            if (option.value === parseInt(yearQuery as string) && option.value === year) {
+              defaultValue = option
+            } else if (option.value === year) {
+              defaultValue = option
+            }
+          })
+        } else {
+          yearOptions.forEach((option) => {
+            if (option.value === year) defaultValue = option
+          })
+        }
+      } else if (field === 'name') {
+        if (idQuery !== undefined) {
+          nameOptions.forEach((name) => {
+            if (name.value === parseInt(idQuery as string) && name.value === selectedUser) {
+              defaultValue = name
+            } else if (name.value === selectedUser) {
+              defaultValue = name
+            }
+          })
+        } else {
+          nameOptions.forEach((name) => {
+            if (name.value === selectedUser) defaultValue = name
+          })
+        }
+      }
+    } else if (isYearlySummaryTabPage) {
+      const yearQuery = router.query.year
+
+      if (yearQuery !== undefined) {
+        yearOptions.forEach((option) => {
+          if (option.value === parseInt(yearQuery as string) && option.value === year) {
+            defaultValue = option
+          } else if (option.value === year) {
+            defaultValue = option
+          }
+        })
+      }
+    }
+
+    return defaultValue
+  }
+
+  useEffect(() => {
+    if (isSuccess) {
+      setNameOptions(usersSelectOptions(data.allUsers))
+      setSelectedUser(
+        router.query.id === undefined || router.query.id === ''
+          ? data.allUsers[0].id
+          : parseInt(router.query.id as string)
+      )
+    }
+  }, [isSuccess])
+
+  useEffect(() => {
+    if (router.isReady) {
+      setYear(
+        router.query.year === undefined || router.query.year === ''
+          ? currentYear
+          : parseInt(router.query.year as string)
+      )
+    }
+  }, [router])
+
   return (
     <div>
-      <FilterDropdownTemplate btnText="Filters">
+      <FilterDropdownTemplate btnText="Filters" cardClassName="overflow-visible">
         <main className="flex flex-col space-y-3 px-5 py-4">
           <Text theme="sm" weight="semibold" className="text-slate-500">
             {isListOfLeaveTabPage ? 'Leave Filters' : 'Summary Filters'}
@@ -46,58 +156,40 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
                 <>
                   <label htmlFor="filterName" className="flex flex-col space-y-1">
                     <span className="text-xs text-slate-500">Name</span>
-                    <select
-                      className={classNames(
-                        'w-full rounded-md border border-slate-300 text-xs shadow-sm',
-                        'focus:border-primary focus:ring-1 focus:ring-primary'
-                      )}
+                    <Select
                       id="filterName"
-                    >
-                      <option value="">Joshua Galit</option>
-                      <option value="">Nilo</option>
-                      <option value="">AJ</option>
-                      <option value="">RJ</option>
-                      <option value="">Alden</option>
-                      <option value="">Paul Eric</option>
-                    </select>
+                      styles={customStyles}
+                      defaultValue={handleDefaultValues('name')}
+                      isLoading={isLoading}
+                      name="name"
+                      onChange={(e) => (e !== null ? setSelectedUser(e.value) : null)}
+                      options={nameOptions}
+                    />
                   </label>
                   <label htmlFor="filterYear" className="flex flex-col space-y-1">
                     <span className="text-xs text-slate-500">Year</span>
-                    <select
-                      className={classNames(
-                        'w-full rounded-md border border-slate-300 text-xs shadow-sm',
-                        'focus:border-primary focus:ring-1 focus:ring-primary'
-                      )}
+                    <Select
                       id="filterYear"
-                    >
-                      <option value="">2017</option>
-                      <option value="">2018</option>
-                      <option value="">2019</option>
-                      <option value="">2020</option>
-                      <option value="">2021</option>
-                      <option value="">2022</option>
-                      <option value="">2023</option>
-                    </select>
+                      styles={customStyles}
+                      defaultValue={handleDefaultValues('year')}
+                      isLoading={isLoading}
+                      name="year"
+                      onChange={(e) => (e !== null ? setYear(e.value) : null)}
+                      options={yearOptions}
+                    />
                   </label>
                 </>
               ) : (
                 <label htmlFor="filterYear" className="flex flex-col space-y-1">
                   <span className="text-xs text-slate-500">Year</span>
-                  <select
-                    className={classNames(
-                      'w-full rounded-md border border-slate-300 text-xs shadow-sm',
-                      'focus:border-primary focus:ring-1 focus:ring-primary'
-                    )}
-                    defaultValue={router.query.year}
-                    onChange={(e) => setYear(parseInt(e.target.value))}
+                  <Select
                     id="filterYear"
-                  >
-                    {range(currentYear, 2015, -1).map((year, i) => (
-                      <option key={i} value={year}>
-                        {year}
-                      </option>
-                    ))}
-                  </select>
+                    styles={customStyles}
+                    defaultValue={handleDefaultValues('year')}
+                    name="year"
+                    onChange={(e) => (e !== null ? setYear(e.value) : null)}
+                    options={yearOptions}
+                  />
                 </label>
               )}
             </>

--- a/client/src/components/molecules/SummaryFilterDropdown/index.tsx
+++ b/client/src/components/molecules/SummaryFilterDropdown/index.tsx
@@ -22,6 +22,9 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
   const range = (start: number, stop: number, step: number): number[] =>
     Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step)
 
+  const NAME_FIELD = 'name'
+  const YEAR_FIELD = 'year'
+
   // filter states
   const [year, setYear] = useState<number>(currentYear)
   const [selectedUser, setSelectedUser] = useState<number>()
@@ -64,59 +67,24 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
     let defaultValue: optionType | null = null
 
     switch (field) {
-      case 'year':
+      case YEAR_FIELD:
         defaultValue = yearOptions[0]
         break
-      case 'name':
+      case NAME_FIELD:
         defaultValue = nameOptions[0]
         break
     }
 
     if (isLeaveSummaryTabPage) {
-      const yearQuery = router.query.year
-      const idQuery = router.query.id
+      if (field === YEAR_FIELD && router.query.year !== undefined)
+        return yearOptions.find((option) => option.value === year) ?? null
 
-      if (field === 'year') {
-        if (yearQuery !== undefined) {
-          yearOptions.forEach((option) => {
-            if (option.value === parseInt(yearQuery as string) && option.value === year) {
-              defaultValue = option
-            } else if (option.value === year) {
-              defaultValue = option
-            }
-          })
-        } else {
-          yearOptions.forEach((option) => {
-            if (option.value === year) defaultValue = option
-          })
-        }
-      } else if (field === 'name') {
-        if (idQuery !== undefined) {
-          nameOptions.forEach((name) => {
-            if (name.value === parseInt(idQuery as string) && name.value === selectedUser) {
-              defaultValue = name
-            } else if (name.value === selectedUser) {
-              defaultValue = name
-            }
-          })
-        } else {
-          nameOptions.forEach((name) => {
-            if (name.value === selectedUser) defaultValue = name
-          })
-        }
-      }
-    } else if (isYearlySummaryTabPage) {
-      const yearQuery = router.query.year
+      if (field === NAME_FIELD && router.query.id !== undefined)
+        return nameOptions.find((option) => option.value === selectedUser) ?? null
+    }
 
-      if (yearQuery !== undefined) {
-        yearOptions.forEach((option) => {
-          if (option.value === parseInt(yearQuery as string) && option.value === year) {
-            defaultValue = option
-          } else if (option.value === year) {
-            defaultValue = option
-          }
-        })
-      }
+    if (isYearlySummaryTabPage && router.query.year !== undefined) {
+      return yearOptions.find((option) => option.value === year) ?? null
     }
 
     return defaultValue
@@ -159,9 +127,9 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
                     <Select
                       id="filterName"
                       styles={customStyles}
-                      defaultValue={handleDefaultValues('name')}
+                      defaultValue={handleDefaultValues(NAME_FIELD)}
                       isLoading={isLoading}
-                      name="name"
+                      name={NAME_FIELD}
                       onChange={(e) => (e !== null ? setSelectedUser(e.value) : null)}
                       options={nameOptions}
                     />
@@ -171,9 +139,9 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
                     <Select
                       id="filterYear"
                       styles={customStyles}
-                      defaultValue={handleDefaultValues('year')}
+                      defaultValue={handleDefaultValues(YEAR_FIELD)}
                       isLoading={isLoading}
-                      name="year"
+                      name={YEAR_FIELD}
                       onChange={(e) => (e !== null ? setYear(e.value) : null)}
                       options={yearOptions}
                     />

--- a/client/src/components/templates/FilterDropdownTemplate/index.tsx
+++ b/client/src/components/templates/FilterDropdownTemplate/index.tsx
@@ -10,11 +10,12 @@ type Props = {
   btnStyle?: string
   Icon?: any
   btnText?: string
+  cardClassName?: string
   children: ReactNode
 }
 
 const FilterDropdownTemplate: FC<Props> = (props): JSX.Element => {
-  const { btnStyle, children, btnText, Icon, ...rest } = props
+  const { btnStyle, children, btnText, Icon, cardClassName, ...rest } = props
 
   return (
     <Menu as="div" className="relative z-10 flex w-full">
@@ -31,7 +32,7 @@ const FilterDropdownTemplate: FC<Props> = (props): JSX.Element => {
       </Menu.Button>
       <MenuTransition>
         <Menu.Items className="fixed right-4 top-[94px] flex w-80 flex-col outline-none md:top-[97px]">
-          <Card shadow-size="xl" rounded="md" className="overflow-hidden">
+          <Card shadow-size="xl" rounded="md" className={cardClassName}>
             {children}
           </Card>
         </Menu.Items>
@@ -42,7 +43,8 @@ const FilterDropdownTemplate: FC<Props> = (props): JSX.Element => {
 
 FilterDropdownTemplate.defaultProps = {
   btnText: 'Filters',
-  Icon: FilterIcon
+  Icon: FilterIcon,
+  cardClassName: 'overflow-hidden'
 }
 
 export default FilterDropdownTemplate

--- a/client/src/hooks/useLeave.ts
+++ b/client/src/hooks/useLeave.ts
@@ -16,21 +16,21 @@ import {
 import { LeaveRequest, Leaves, YearlyLeaves, LeaveTypes } from '~/utils/types/leaveTypes'
 import { CREATE_LEAVE_MUTATION } from '~/graphql/mutations/leaveMutation'
 
-type handleLeaveQueryType = UseQueryResult<Leaves, unknown>
-type handleYearlyLeaveQueryType = UseQueryResult<YearlyLeaves, unknown>
-type handleLeaveTypeQueryType = UseQueryResult<LeaveTypes, unknown>
+type getLeaveQueryType = UseQueryResult<Leaves, unknown>
+type getYearlyLeaveQueryType = UseQueryResult<YearlyLeaves, unknown>
+type getLeaveTypeQueryType = UseQueryResult<LeaveTypes, unknown>
 type handleLeaveMutationType = UseMutationResult<any, unknown, LeaveRequest, unknown>
 
 type returnType = {
-  handleLeaveQuery: (userId: number, year: number) => handleLeaveQueryType
+  getLeaveQuery: (userId: number, year: number) => getLeaveQueryType
   handleLeaveMutation: (userId: number, year: number) => handleLeaveMutationType
-  handleLeaveTypeQuery: () => handleLeaveTypeQueryType
-  handleYearlyAllLeaveQuery: (year: number, ready: boolean) => handleYearlyLeaveQueryType
+  handleLeaveTypeQuery: () => getLeaveTypeQueryType
+  getYearlyAllLeaveQuery: (year: number, ready: boolean) => getYearlyLeaveQueryType
 }
 
 const useLeave = (): returnType => {
   const queryClient = useQueryClient()
-  const handleLeaveQuery = (userId: number, year: number): handleLeaveQueryType =>
+  const getLeaveQuery = (userId: number, year: number): getLeaveQueryType =>
     useQuery({
       queryKey: ['GET_MY_LEAVES_QUERY', userId, year],
       queryFn: async () => await client.request(GET_MY_LEAVES_QUERY, { userId, year }),
@@ -38,14 +38,14 @@ const useLeave = (): returnType => {
       enabled: Boolean(userId) && Boolean(year)
     })
 
-  const handleYearlyAllLeaveQuery = (year: number, ready: boolean): handleYearlyLeaveQueryType =>
+  const getYearlyAllLeaveQuery = (year: number, ready: boolean): getYearlyLeaveQueryType =>
     useQuery({
       queryKey: ['GET_YEARLY_ALL_LEAVES_QUERY', year],
       queryFn: async () => await client.request(GET_YEARLY_ALL_LEAVES_QUERY, { year }),
       select: (data: YearlyLeaves) => data,
       enabled: ready
     })
-  const handleLeaveTypeQuery = (): handleLeaveTypeQueryType =>
+  const handleLeaveTypeQuery = (): getLeaveTypeQueryType =>
     useQuery({
       queryKey: ['GET_LEAVE_TYPES_QUERY'],
       queryFn: async () => await client.request(GET_LEAVE_TYPES_QUERY),
@@ -70,8 +70,8 @@ const useLeave = (): returnType => {
     })
 
   return {
-    handleLeaveQuery,
-    handleYearlyAllLeaveQuery,
+    getLeaveQuery,
+    getYearlyAllLeaveQuery,
     handleLeaveMutation,
     handleLeaveTypeQuery
   }

--- a/client/src/hooks/useUserQuery.ts
+++ b/client/src/hooks/useUserQuery.ts
@@ -18,7 +18,7 @@ type handleAllUsersQueryType = UseQueryResult<
 >
 type returnType = {
   handleUserQuery: () => handleUserQueryType
-  handleAllUsersQuery: () => handleAllUsersQueryType
+  handleAllUsersQuery: (ready?: boolean) => handleAllUsersQueryType
 }
 const useUserQuery = (): returnType => {
   const handleUserQuery = (): handleUserQueryType =>
@@ -31,11 +31,12 @@ const useUserQuery = (): returnType => {
         }),
       select: (data: { userById: User }) => data
     })
-  const handleAllUsersQuery = (): handleAllUsersQueryType =>
+  const handleAllUsersQuery = (ready: boolean = true): handleAllUsersQueryType =>
     useQuery({
       queryKey: ['GET_ALL_USERS_QUERY'],
       queryFn: async () => await client.request(GET_ALL_USERS_QUERY),
-      select: (data: { allUsers: User[] }) => data
+      select: (data: { allUsers: User[] }) => data,
+      enabled: ready
     })
   return {
     handleUserQuery,

--- a/client/src/pages/leave-management/leave-summary.tsx
+++ b/client/src/pages/leave-management/leave-summary.tsx
@@ -1,216 +1,153 @@
 import { NextPage } from 'next'
 import dynamic from 'next/dynamic'
 import classNames from 'classnames'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import Card from '~/components/atoms/Card'
-import { generateData } from '~/utils/generateData'
+import {
+  getHeatmapData,
+  initialChartOptions,
+  initialSeriesData,
+  Series
+} from '~/utils/generateData'
 import MaxWidthContainer from '~/components/atoms/MaxWidthContainer'
 import BreakdownOfLeaveCard from '~/components/molecules/BreakdownOfLeavesCard'
 import LeaveManagementLayout from '~/components/templates/LeaveManagementLayout'
 import LeaveManagementResultTable from '~/components/molecules/LeaveManagementResultTable'
+import useLeave from '~/hooks/useLeave'
+import { useRouter } from 'next/router'
+import { Breakdown, LeaveTable } from '~/utils/types/leaveTypes'
+import BarsLoadingIcon from '~/utils/icons/BarsLoadingIcon'
 
 const ReactApexChart = dynamic(async () => await import('react-apexcharts'), {
   ssr: false
 })
 
+type SeriesData = {
+  name: string
+  data: Series[]
+}
+
 const LeaveSummary: NextPage = (): JSX.Element => {
-  const [chart] = useState({
-    series: [
-      {
-        name: 'November',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'October',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'September',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'August',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'July',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'June',
-        data: generateData(31, {
-          min: 1,
-          max: 50
-        })
-      },
-      {
-        name: 'May',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'April',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'March',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'February',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      },
-      {
-        name: 'January',
-        data: generateData(31, {
-          min: 0,
-          max: 50
-        })
-      }
-    ],
-    options: {
-      chart: {
-        toolbar: {
-          show: false,
-          tools: {
-            download: true,
-            selection: false,
-            zoom: false,
-            zoomin: false,
-            zoomout: false,
-            pan: false,
-            reset: false
-          }
+  const router = useRouter()
+  const { handleLeaveQuery } = useLeave()
+
+  const {
+    data: leaves,
+    refetch,
+    isSuccess,
+    isLoading: isLeavesLoading,
+    isError: isLeavesError
+  } = handleLeaveQuery(
+    router.query.id !== undefined ? parseInt(router.query.id as string) : 0,
+    router.query.year !== undefined
+      ? parseInt(router.query.year as string)
+      : new Date().getFullYear()
+  )
+  const [series, setSeries] = useState<SeriesData[]>(initialSeriesData)
+
+  useEffect(() => {
+    if (isSuccess) {
+      setSeries([
+        {
+          name: 'December',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.december)
+        },
+        {
+          name: 'November',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.november)
+        },
+        {
+          name: 'October',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.october)
+        },
+        {
+          name: 'September',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.september)
+        },
+        {
+          name: 'August',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.august)
+        },
+        {
+          name: 'July',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.july)
+        },
+        {
+          name: 'June',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.june)
+        },
+        {
+          name: 'May',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.may)
+        },
+        {
+          name: 'April',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.april)
+        },
+        {
+          name: 'March',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.march)
+        },
+        {
+          name: 'February',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.february)
+        },
+        {
+          name: 'January',
+          data: getHeatmapData(31, leaves?.leaves.heatmap.january)
         }
-      },
-      plotOptions: {
-        heatmap: {
-          shadeIntensity: 0.5,
-          radius: 0,
-          useFillColorAsStroke: false,
-          colorScale: {
-            ranges: [
-              {
-                from: 1,
-                to: 6,
-                name: 'Undertime',
-                color: '#d97706'
-              },
-              {
-                from: 7,
-                to: 12,
-                name: 'Sick Leave',
-                color: '#059669'
-              },
-              {
-                from: 13,
-                to: 18,
-                name: 'Vacation Leave',
-                color: '#2563eb'
-              },
-              {
-                from: 19,
-                to: 31,
-                name: 'Emergency Leave',
-                color: '#e11d48'
-              },
-              {
-                from: 32,
-                to: 50,
-                name: 'Bereavement Leave',
-                color: '#4b5563'
-              }
-            ]
-          }
-        }
-      },
-      dataLabels: {
-        enabled: false
-      },
-      stroke: {
-        width: 1
-      },
-      title: {
-        text: ''
-      }
+      ])
     }
-  })
+  }, [isSuccess, leaves?.leaves.heatmap])
+
+  useEffect(() => {
+    if (router.isReady) void refetch()
+  }, [router])
 
   return (
     <LeaveManagementLayout metaTitle="Leave Summary">
-      <main className="default-scrollbar h-full flex-col space-y-4 overflow-y-auto px-4">
-        <MaxWidthContainer>
-          <Card className="default-scrollbar mt-4 overflow-x-auto overflow-y-hidden">
-            <div className="w-full min-w-[647px] px-5 pt-4 md:max-w-full">
-              <ReactApexChart
-                options={chart.options}
-                series={chart.series}
-                type="heatmap"
-                width={'100%'}
-                height={450}
+      {!isLeavesLoading ? (
+        <main className="default-scrollbar h-full flex-col space-y-4 overflow-y-auto px-4">
+          <MaxWidthContainer>
+            <Card className="default-scrollbar mt-4 overflow-x-auto overflow-y-hidden">
+              <div className="w-full min-w-[647px] px-5 pt-4 md:max-w-full">
+                <ReactApexChart
+                  options={initialChartOptions}
+                  series={series}
+                  type="heatmap"
+                  width={'100%'}
+                  height={450}
+                />
+              </div>
+            </Card>
+          </MaxWidthContainer>
+          <MaxWidthContainer>
+            <article
+              className={classNames(
+                'flex flex-col space-y-4 pb-24 text-xs',
+                'md:flex-row md:space-y-0 md:space-x-4'
+              )}
+            >
+              {/* Pass the needed props of these components */}
+              <BreakdownOfLeaveCard data={leaves?.leaves.breakdown as Breakdown} />
+              <LeaveManagementResultTable
+                {...{
+                  query: {
+                    data: leaves?.leaves.table as LeaveTable[],
+                    isLoading: isLeavesLoading,
+                    isError: isLeavesError
+                  }
+                }}
               />
-            </div>
-          </Card>
-        </MaxWidthContainer>
-        <MaxWidthContainer>
-          <article
-            className={classNames(
-              'flex flex-col space-y-4 pb-24 text-xs',
-              'md:flex-row md:space-y-0 md:space-x-4'
-            )}
-          >
-            {/* Pass the needed props of these components */}
-            <BreakdownOfLeaveCard
-              data={{
-                sickLeave: 0,
-                undertime: 0,
-                vacationLeave: 0,
-                emergencyLeave: 0,
-                bereavementLeave: 0,
-                maternityLeave: 0,
-                withoutPayTotal: 0,
-                withPayTotal: 0
-              }}
-            />
-            <LeaveManagementResultTable
-              {...{
-                query: {
-                  data: [],
-                  isLoading: false,
-                  isError: false
-                }
-              }}
-            />
-          </article>
-        </MaxWidthContainer>
-      </main>
+            </article>
+          </MaxWidthContainer>
+        </main>
+      ) : (
+        <div className="flex min-h-[50vh] items-center justify-center">
+          <BarsLoadingIcon className="h-7 w-7 fill-current text-amber-500" />
+        </div>
+      )}
     </LeaveManagementLayout>
   )
 }

--- a/client/src/pages/leave-management/leave-summary.tsx
+++ b/client/src/pages/leave-management/leave-summary.tsx
@@ -30,7 +30,7 @@ type SeriesData = {
 
 const LeaveSummary: NextPage = (): JSX.Element => {
   const router = useRouter()
-  const { handleLeaveQuery } = useLeave()
+  const { getLeaveQuery } = useLeave()
 
   const {
     data: leaves,
@@ -38,7 +38,7 @@ const LeaveSummary: NextPage = (): JSX.Element => {
     isSuccess,
     isLoading: isLeavesLoading,
     isError: isLeavesError
-  } = handleLeaveQuery(
+  } = getLeaveQuery(
     router.query.id !== undefined ? parseInt(router.query.id as string) : 0,
     router.query.year !== undefined
       ? parseInt(router.query.year as string)

--- a/client/src/pages/leave-management/yearly-summary.tsx
+++ b/client/src/pages/leave-management/yearly-summary.tsx
@@ -32,13 +32,13 @@ type SeriesData = {
 
 const YearlySummary: NextPage = (): JSX.Element => {
   const router = useRouter()
-  const { handleYearlyAllLeaveQuery } = useLeave()
+  const { getYearlyAllLeaveQuery } = useLeave()
   const {
     data: leaves,
     isSuccess,
     isLoading: isLeavesLoading,
     isError: isLeavesError
-  } = handleYearlyAllLeaveQuery(
+  } = getYearlyAllLeaveQuery(
     isNaN(parseInt(router.query.year as string))
       ? moment().year()
       : parseInt(router.query.year as string),

--- a/client/src/pages/my-leaves.tsx
+++ b/client/src/pages/my-leaves.tsx
@@ -149,14 +149,12 @@ const MyLeaves: NextPage = (): JSX.Element => {
           </div>
 
           {/* This will Open New Modal for Filing New Leave */}
-          {isOpen ? (
-            <AddNewLeaveModal
-              {...{
-                isOpen,
-                closeModal: handleToggle
-              }}
-            />
-          ) : null}
+          <AddNewLeaveModal
+            {...{
+              isOpen,
+              closeModal: handleToggle
+            }}
+          />
         </header>
         {!isUserLoading && !isLeavesLoading ? (
           <div className="default-scrollbar h-full space-y-4 overflow-y-auto px-4">

--- a/client/src/pages/my-leaves.tsx
+++ b/client/src/pages/my-leaves.tsx
@@ -39,14 +39,14 @@ const MyLeaves: NextPage = (): JSX.Element => {
   const { handleUserQuery } = useUserQuery()
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const { data: user, isSuccess: isUserSuccess, isLoading: isUserLoading } = handleUserQuery()
-  const { handleLeaveQuery } = useLeave()
+  const { getLeaveQuery } = useLeave()
   const {
     data: leaves,
     refetch,
     isSuccess,
     isLoading: isLeavesLoading,
     isError: isLeavesError
-  } = handleLeaveQuery(user?.userById.id as number, parseInt(router.query.year as string))
+  } = getLeaveQuery(user?.userById.id as number, parseInt(router.query.year as string))
   const [series, setSeries] = useState<SeriesData[]>(initialSeriesData)
 
   useEffect(() => {

--- a/client/src/utils/maps/filterOptions.ts
+++ b/client/src/utils/maps/filterOptions.ts
@@ -6,21 +6,13 @@ export type optionType = {
 }
 
 export const usersSelectOptions = (users: User[]): optionType[] => {
-  const result: optionType[] = []
-
-  users.forEach((user) => {
-    result.push({ label: user.name, value: user.id })
+  return users.map((user) => {
+    return { label: user.name, value: user.id }
   })
-
-  return result
 }
 
 export const yearSelectOptions = (years: number[]): optionType[] => {
-  const result: optionType[] = []
-
-  years.forEach((year) => {
-    result.push({ label: year.toString(), value: year })
+  return years.map((year) => {
+    return { label: year.toString(), value: year }
   })
-
-  return result
 }

--- a/client/src/utils/maps/filterOptions.ts
+++ b/client/src/utils/maps/filterOptions.ts
@@ -1,0 +1,26 @@
+import { User } from '~/utils/types/userTypes'
+
+export type optionType = {
+  label: string
+  value: number
+}
+
+export const usersSelectOptions = (users: User[]): optionType[] => {
+  const result: optionType[] = []
+
+  users.forEach((user) => {
+    result.push({ label: user.name, value: user.id })
+  })
+
+  return result
+}
+
+export const yearSelectOptions = (years: number[]): optionType[] => {
+  const result: optionType[] = []
+
+  years.forEach((year) => {
+    result.push({ label: year.toString(), value: year })
+  })
+
+  return result
+}

--- a/client/src/utils/types/userTypes.ts
+++ b/client/src/utils/types/userTypes.ts
@@ -37,3 +37,9 @@ export type Time = {
   id: number
   timeHour: string
 }
+
+export type Users = {
+  id: number
+  name: string
+  email: string
+}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-89
https://framgiaph.backlog.com/view/HRIS-101

## Definition of Done
- [x] Changed filter dropdown to react-select dropdown
- [x] User can view the leave summary of a given employee in a given year
- [x] Filter values persists after reload

## Notes
- Filter task, HRIS-101, is also included in this PR
- Filter dropdown from `Yearly Summary` tab/page was also changed to use react-select


## Pre-condition
Commands to run
- `docker compose up --build`
- go to `http://localhost:3000/leave-management/leave-summary`

## Expected Output
- At first visit of page, there should be no queries in the URL
- Selecting filters then clicking the `Update Results` button would also update the URL, adding the selected filters
- User can type text on dropdown fields to narrow the options
- After reloading the page, the filter values and displayed data should remain the same

## Screenshots/Recordings
- Desktop Mode

[LeaveSummaryDesktop.webm](https://user-images.githubusercontent.com/111718037/217155613-9bb977e8-acb2-41a3-9e5d-3525a93f9d39.webm)

- Mobile Mode

[LeaveSummaryMobile.webm](https://user-images.githubusercontent.com/111718037/217156125-efd415ee-7501-44a8-a9a3-9a0e14e7af2f.webm)
