### PR TITLE
HRIS-104 [Markup] Create File for Overtime Modal

### DIFF
--- a/client/src/components/molecules/AddNewOvertimeModal/index.tsx
+++ b/client/src/components/molecules/AddNewOvertimeModal/index.tsx
@@ -1,0 +1,242 @@
+import classNames from 'classnames'
+import makeAnimated from 'react-select/animated'
+import { Controller, useForm } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import ReactSelect, { MultiValue } from 'react-select'
+import React, { FC, useEffect, useState } from 'react'
+import ReactTextareaAutosize from 'react-textarea-autosize'
+import { Calendar, Clock, Coffee, FileText, Save, X } from 'react-feather'
+
+import TextField from './../TextField'
+import Input from '~/components/atoms/Input'
+import SpinnerIcon from '~/utils/icons/SpinnerIcon'
+import { MyOvertimeSchema } from '~/utils/validation'
+import Button from '~/components/atoms/Buttons/ButtonAction'
+import { customStyles } from '~/utils/customReactSelectStyles'
+import ModalTemplate from '~/components/templates/ModalTemplate'
+import { NewOvertimeFormValues } from '~/utils/types/formValues'
+import { projectList } from '~/utils/constants/dummyAddNewLeaveFields'
+import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+}
+
+type ReactSelectProps = { label: string; value: string }
+
+const animatedComponents = makeAnimated()
+
+const AddNewOvertimeModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
+  const [otherProject, setOtherProject] = useState<boolean>(false)
+  const [selectedOtherProjectOption, setSelectedOtherProjectOption] = useState<
+    MultiValue<ReactSelectProps>
+  >([])
+
+  const {
+    reset,
+    control,
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting }
+  } = useForm<NewOvertimeFormValues>({
+    mode: 'onTouched',
+    resolver: yupResolver(MyOvertimeSchema)
+  })
+
+  // This will handle Submit and Save New Overtime
+  const handleSave = async (data: NewOvertimeFormValues): Promise<void> => {
+    return await new Promise((resolve) => {
+      setTimeout(() => {
+        alert(JSON.stringify({ ...data, projects: { ...selectedOtherProjectOption } }, null, 2))
+        resolve()
+      }, 2000)
+    })
+  }
+
+  // This will reset all form values
+  useEffect(() => {
+    if (isOpen) {
+      reset({
+        other_project: '',
+        date_effective: '',
+        requested_hours: '',
+        remarks: ''
+      })
+      setOtherProject(false)
+    }
+  }, [isOpen])
+
+  const handleChangeProject = (selectedOption: MultiValue<ReactSelectProps>): void => {
+    setOtherProject(false)
+    if (selectedOption.some((s) => s.label === 'Others')) {
+      setOtherProject(true)
+    }
+    setSelectedOtherProjectOption(selectedOption)
+  }
+
+  return (
+    <ModalTemplate
+      {...{
+        isOpen,
+        closeModal
+      }}
+      className="w-full max-w-[700px]"
+    >
+      <form
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        onSubmit={handleSubmit(handleSave)}
+      >
+        {/* Custom Modal Header */}
+        <ModalHeader
+          {...{
+            title: 'Add New Overtime',
+            closeModal
+          }}
+        />
+
+        <main className="grid grid-cols-2 gap-x-4 gap-y-6 py-6 px-8 text-xs text-slate-800">
+          {/* Project & Leave Type */}
+          <section className="col-span-2 overflow-visible">
+            <TextField title="Project" Icon={Coffee} isRequired>
+              <Controller
+                name="project"
+                control={control}
+                render={({ field }) => {
+                  return (
+                    <ReactSelect
+                      isMulti
+                      {...field}
+                      isClearable
+                      styles={customStyles}
+                      options={projectList}
+                      closeMenuOnSelect={false}
+                      isDisabled={isSubmitting}
+                      backspaceRemovesValue={true}
+                      onChange={handleChangeProject}
+                      components={animatedComponents}
+                      className="w-full"
+                    />
+                  )
+                }}
+              />
+              {errors?.project !== null && errors?.project !== undefined && (
+                <span className="error absolute -bottom-4 text-[10px]">
+                  {errors.project?.message}
+                </span>
+              )}
+            </TextField>
+          </section>
+
+          {/* Other Projects */}
+          {otherProject ? (
+            <section className="col-span-2">
+              <TextField
+                title="Other Project"
+                Icon={Coffee}
+                isOptional
+                optionalText="Specify if others"
+              >
+                <Input
+                  type="text"
+                  {...register('other_project')}
+                  className="py-2.5 pl-11 text-xs"
+                />
+              </TextField>
+            </section>
+          ) : null}
+
+          {/* Date Effective */}
+          <section className="col-span-2 md:col-span-1">
+            <TextField title="Date Effective" Icon={Calendar} isRequired className="flex-1">
+              <Input
+                type="date"
+                disabled={isSubmitting}
+                placeholder=""
+                {...register('date_effective')}
+                className="py-2.5 pl-11 text-xs"
+                iserror={errors.date_effective !== null && errors?.date_effective !== undefined}
+              />
+            </TextField>
+            {errors?.date_effective !== null && errors?.date_effective !== undefined && (
+              <span className="error text-[10px]">{errors.date_effective?.message}</span>
+            )}
+          </section>
+
+          {/* Requested hours */}
+          <section className="col-span-2 md:col-span-1">
+            <TextField title="Requested hours" Icon={Clock} isRequired className="flex-1">
+              <Input
+                type="text"
+                disabled={isSubmitting}
+                placeholder=""
+                {...register('requested_hours')}
+                className="py-2.5 pl-11 text-xs"
+                iserror={errors.requested_hours !== null && errors?.requested_hours !== undefined}
+              />
+            </TextField>
+            {errors?.requested_hours !== null && errors?.requested_hours !== undefined && (
+              <span className="error text-[10px]">{errors.requested_hours?.message}</span>
+            )}
+          </section>
+
+          {/* Remarks */}
+          <section className="col-span-2">
+            <TextField title="Remarks" Icon={FileText} isRequired>
+              <ReactTextareaAutosize
+                id="remarks"
+                {...register('remarks')}
+                className={classNames(
+                  'text-area-auto-resize min-h-[14vh] pl-12',
+                  errors?.remarks !== null && errors.remarks !== undefined
+                    ? 'border-rose-500 ring-rose-500'
+                    : ''
+                )}
+                disabled={isSubmitting}
+                placeholder="Write down your remarks"
+              />
+            </TextField>
+            {errors.remarks !== null && errors.remarks !== undefined && (
+              <span className="error text-[10px]">{errors.remarks?.message}</span>
+            )}
+          </section>
+        </main>
+
+        {/* Custom Modal Footer Style */}
+        <ModalFooter>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={closeModal}
+            disabled={isSubmitting}
+            className="flex items-center space-x-2 px-4 py-1 text-sm"
+          >
+            <X className="h-4 w-4" />
+            <span>Close</span>
+          </Button>
+          <Button
+            type="submit"
+            variant="success"
+            disabled={isSubmitting}
+            className="flex items-center space-x-2 px-5 py-1 text-sm"
+          >
+            {isSubmitting ? (
+              <>
+                <SpinnerIcon className="h-3 w-3 fill-amber-600" />
+                <span>Saving..</span>
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4" />
+                <span>Save</span>
+              </>
+            )}
+          </Button>
+        </ModalFooter>
+      </form>
+    </ModalTemplate>
+  )
+}
+
+export default AddNewOvertimeModal

--- a/client/src/components/molecules/AddNewOvertimeModal/index.tsx
+++ b/client/src/components/molecules/AddNewOvertimeModal/index.tsx
@@ -5,7 +5,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import ReactSelect, { MultiValue } from 'react-select'
 import React, { FC, useEffect, useState } from 'react'
 import ReactTextareaAutosize from 'react-textarea-autosize'
-import { Calendar, Clock, Coffee, FileText, Save, X } from 'react-feather'
+import { Calendar, Clock, Coffee, FileText, RefreshCcw, Save, X } from 'react-feather'
 
 import TextField from './../TextField'
 import Input from '~/components/atoms/Input'
@@ -55,18 +55,33 @@ const AddNewOvertimeModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => 
     })
   }
 
+  // modify custom style control
+  customStyles.control = (provided) => ({
+    ...provided,
+    boxShadow: 'none',
+    borderColor: 'none',
+    '&:hover': {
+      color: '#75c55e'
+    }
+  })
+
   // This will reset all form values
   useEffect(() => {
     if (isOpen) {
-      reset({
-        other_project: '',
-        date_effective: '',
-        requested_hours: '',
-        remarks: ''
-      })
-      setOtherProject(false)
+      handleReset()
     }
   }, [isOpen])
+
+  const handleReset = (): void => {
+    reset({
+      project: '' as any,
+      other_project: '',
+      date_effective: '',
+      requested_hours: undefined,
+      remarks: ''
+    })
+    setOtherProject(false)
+  }
 
   const handleChangeProject = (selectedOption: MultiValue<ReactSelectProps>): void => {
     setOtherProject(false)
@@ -103,30 +118,41 @@ const AddNewOvertimeModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => 
               <Controller
                 name="project"
                 control={control}
-                render={({ field }) => {
+                rules={{ required: true }}
+                render={({ field: { value, onChange } }) => {
                   return (
                     <ReactSelect
                       isMulti
-                      {...field}
                       isClearable
+                      placeholder=""
+                      value={value}
                       styles={customStyles}
                       options={projectList}
-                      closeMenuOnSelect={false}
+                      onChange={(options) => {
+                        onChange(options.map((c) => c))
+                        return handleChangeProject(options)
+                      }}
+                      classNames={{
+                        control: (state) =>
+                          state.isFocused
+                            ? 'border-primary'
+                            : errors.project !== null && errors.project !== undefined
+                            ? 'border-rose-500 ring-rose-500'
+                            : 'border-slate-300'
+                      }}
                       isDisabled={isSubmitting}
+                      closeMenuOnSelect={false}
                       backspaceRemovesValue={true}
-                      onChange={handleChangeProject}
                       components={animatedComponents}
                       className="w-full"
                     />
                   )
                 }}
               />
-              {errors?.project !== null && errors?.project !== undefined && (
-                <span className="error absolute -bottom-4 text-[10px]">
-                  {errors.project?.message}
-                </span>
-              )}
             </TextField>
+            {errors.project !== null && errors.project !== undefined && (
+              <span className="error text-[10px]">Project is required</span>
+            )}
           </section>
 
           {/* Other Projects */}
@@ -140,6 +166,7 @@ const AddNewOvertimeModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => 
               >
                 <Input
                   type="text"
+                  required
                   {...register('other_project')}
                   className="py-2.5 pl-11 text-xs"
                 />
@@ -186,6 +213,7 @@ const AddNewOvertimeModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => 
             <TextField title="Remarks" Icon={FileText} isRequired>
               <ReactTextareaAutosize
                 id="remarks"
+                placeholder=""
                 {...register('remarks')}
                 className={classNames(
                   'text-area-auto-resize min-h-[14vh] pl-12',
@@ -194,7 +222,6 @@ const AddNewOvertimeModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => 
                     : ''
                 )}
                 disabled={isSubmitting}
-                placeholder="Write down your remarks"
               />
             </TextField>
             {errors.remarks !== null && errors.remarks !== undefined && (
@@ -205,6 +232,16 @@ const AddNewOvertimeModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => 
 
         {/* Custom Modal Footer Style */}
         <ModalFooter>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleReset}
+            disabled={isSubmitting}
+            className="flex items-center space-x-2 px-4 py-1 text-sm"
+          >
+            <RefreshCcw className="h-4 w-4" />
+            <span>Reset</span>
+          </Button>
           <Button
             type="button"
             variant="secondary"
@@ -223,7 +260,7 @@ const AddNewOvertimeModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => 
           >
             {isSubmitting ? (
               <>
-                <SpinnerIcon className="h-3 w-3 fill-amber-600" />
+                <SpinnerIcon className="h-3 w-3 fill-white" />
                 <span>Saving..</span>
               </>
             ) : (

--- a/client/src/components/molecules/MyOvertimeTable/columns.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/columns.tsx
@@ -76,8 +76,10 @@ export const columns = [
       )
     }
   }),
-  columnHelper.accessor('id', {
-    header: () => ''
+  columnHelper.display({
+    id: 'empty1',
+    header: () => '',
+    footer: (info) => info.column.id
   }),
   columnHelper.accessor('date', {
     header: () => <CellHeader label="Date" />,
@@ -114,8 +116,10 @@ export const columns = [
     footer: (info) => info.column.id,
     cell: (props) => <Chip label={props.getValue()} />
   }),
-  columnHelper.accessor('id', {
-    header: () => ''
+  columnHelper.display({
+    id: 'empty2',
+    header: () => '',
+    footer: (info) => info.column.id
   }),
   columnHelper.display({
     id: 'id',

--- a/client/src/pages/my-overtime.tsx
+++ b/client/src/pages/my-overtime.tsx
@@ -9,10 +9,14 @@ import MyOvertimeTable from '~/components/molecules/MyOvertimeTable'
 import { columns } from '~/components/molecules/MyOvertimeTable/columns'
 import GlobalSearchFilter from '~/components/molecules/GlobalSearchFilter'
 import { dummyMyOvertimeData } from '~/utils/constants/dummyMyOvertimeData'
+import AddNewOvertimeModal from '~/components/molecules/AddNewOvertimeModal'
 import YearlyFilterDropdown from '~/components/molecules/MyOvertimeTable/YearlyFilterDropdown'
 
 const MyOverTime: NextPage = (): JSX.Element => {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
   const [globalFilter, setGlobalFilter] = useState<string>('')
+
+  const handleToggle = (): void => setIsOpen(!isOpen)
 
   return (
     <Layout metaTitle="My Overtime">
@@ -37,6 +41,7 @@ const MyOverTime: NextPage = (): JSX.Element => {
             <Button
               type="button"
               variant="primary"
+              onClick={handleToggle}
               className="flex items-center space-x-0.5 px-1.5 py-[3px]"
             >
               <Plus className="h-4 w-4" />
@@ -44,6 +49,14 @@ const MyOverTime: NextPage = (): JSX.Element => {
             </Button>
             <YearlyFilterDropdown />
           </div>
+
+          {/* File New Overtime Modal */}
+          <AddNewOvertimeModal
+            {...{
+              isOpen,
+              closeModal: handleToggle
+            }}
+          />
         </header>
         <MyOvertimeTable
           {...{

--- a/client/src/utils/types/formValues.ts
+++ b/client/src/utils/types/formValues.ts
@@ -51,6 +51,6 @@ export type NewOvertimeFormValues = {
   }[]
   other_project?: string
   date_effective: string
-  requested_hours: string
+  requested_hours: number
   remarks: string
 }

--- a/client/src/utils/validation/index.ts
+++ b/client/src/utils/validation/index.ts
@@ -70,6 +70,6 @@ export const MyOvertimeSchema = Yup.object().shape({
   ),
   other_project: Yup.string().label('Other Project'),
   date_effective: Yup.string().required().label('Date Effective'),
-  requested_hours: Yup.string().required().label('Requested hours'),
+  requested_hours: Yup.number().required().label('Requested hours'),
   remarks: Yup.string().required().label('Reason')
 })


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-104

## Definition of Done

- [x] Reused `ModalTemplate`, `ModalHeader` and `ModalFooter` component
- [x] Applied `react-hook-form` validation rule
- [x] Resused `Input` and `TextField` component 

## Notes
- https://www.figma.com/file/w3lR4Elj1q5yZgK3Xw0eIx/HRIS-Wireframe?node-id=2741%3A20513&t=G2Cl95iUvU9UB5y0-4

## Pre-condition
cd client && npm run dev
cd api && dotnet run watch

## Expected Output

- It should now have a markup for File Overtime Modal
- Applied animation and validation rules with loading submit indicator

## Screenshots/Recordings
[file overtime modal.webm](https://user-images.githubusercontent.com/108642414/218619020-10fa2a14-2e29-465f-8b9d-5bf573da8c23.webm)
