### PR TITLE
HRIS-108 [BugTask] Remaining Paid Leave should change base on the filter

### DIFF
--- a/api/DTOs/LeavesDTO.cs
+++ b/api/DTOs/LeavesDTO.cs
@@ -1,3 +1,5 @@
+using api.Entities;
+
 namespace api.DTOs
 {
     public class LeavesDTO
@@ -5,10 +7,12 @@ namespace api.DTOs
         public LeaveHeatMapDTO Heatmap { get; set; }
         public List<LeavesTableDTO> Table { get; set; }
         public LeaveBreakdownDTO Breakdown { get; set; }
+        public User? User { get; set; } = null;
 
-        public LeavesDTO(LeaveHeatMapDTO heatmapLeaves, List<LeavesTableDTO> table)
+        public LeavesDTO(LeaveHeatMapDTO heatmapLeaves, List<LeavesTableDTO> table, User? user = null)
         {
             Heatmap = heatmapLeaves;
+            User = user;
             Table = table.OrderByDescending(table => table.Date).ToList();
             Breakdown = new LeaveBreakdownDTO(table);
         }

--- a/api/Services/LeaveService.cs
+++ b/api/Services/LeaveService.cs
@@ -30,8 +30,13 @@ namespace api.Services
                             .OrderBy(o => o.LeaveDate.Day)
                             .Select(s => new LeavesTableDTO(s))
                             .ToListAsync();
+
+                var user = await context.Users
+                            .Where(u => u.Id == userId)
+                            .FirstAsync();
+
                 LeaveHeatMapDTO heatmap = new LeaveHeatMapDTO(leaves);
-                return new LeavesDTO(new LeaveHeatMapDTO(leaves), leaves);
+                return new LeavesDTO(new LeaveHeatMapDTO(leaves), leaves, user);
             }
         }
 

--- a/client/src/components/templates/LeaveManagementLayout/index.tsx
+++ b/client/src/components/templates/LeaveManagementLayout/index.tsx
@@ -5,9 +5,9 @@ import React, { FC, ReactNode } from 'react'
 import { FileText, Filter } from 'react-feather'
 
 import Layout from './../Layout'
+import useLeave from '~/hooks/useLeave'
 import useUserQuery from '~/hooks/useUserQuery'
 import TabLink from '~/components/atoms/TabLink'
-import { getRemainingPaidLeaves } from '~/hooks/useLeaveQuery'
 import SummaryFilterDropdown from '~/components/molecules/SummaryFilterDropdown'
 
 type Props = {
@@ -18,8 +18,18 @@ type Props = {
 const LeaveManagementLayout: FC<Props> = ({ children, metaTitle }): JSX.Element => {
   const router = useRouter()
   const { handleUserQuery } = useUserQuery()
+
+  const { getLeaveQuery } = useLeave()
   const { data: user } = handleUserQuery()
-  const { data: paidLeaves } = getRemainingPaidLeaves(user?.userById?.id as number)
+
+  const { data: remainingLeaves } = getLeaveQuery(
+    router.query.id !== undefined
+      ? parseInt(router.query.id as string)
+      : (user?.userById.id as number),
+    router.query.year !== undefined
+      ? parseInt(router.query.year as string)
+      : new Date().getFullYear()
+  )
 
   const isListOfLeaveTabPage = router.pathname === '/leave-management/list-of-leave'
   const isLeaveSummaryTabPage = router.pathname === '/leave-management/leave-summary'
@@ -75,7 +85,7 @@ const LeaveManagementLayout: FC<Props> = ({ children, metaTitle }): JSX.Element 
                   <div className="hidden sm:block">
                     <span className="text-slate-500 line-clamp-1">Remaining Paid Leaves:</span>
                   </div>
-                  <Chip count={paidLeaves?.paidLeaves} />
+                  <Chip count={remainingLeaves?.leaves.user.paidLeaves ?? 0} />
                 </div>
               ) : null}
               {!isListOfLeaveTabPage ? <SummaryFilterDropdown /> : null}

--- a/client/src/graphql/queries/leaveQuery.ts
+++ b/client/src/graphql/queries/leaveQuery.ts
@@ -10,6 +10,10 @@ export const GET_LEAVE_TYPES_QUERY = gql`
 export const GET_MY_LEAVES_QUERY = gql`
   query ($userId: Int!, $year: Int!) {
     leaves(userId: $userId, year: $year) {
+      user {
+        id
+        paidLeaves
+      }
       heatmap {
         january {
           value

--- a/client/src/utils/types/leaveTypes.ts
+++ b/client/src/utils/types/leaveTypes.ts
@@ -66,6 +66,10 @@ export type Breakdown = {
 }
 export type Leaves = {
   leaves: {
+    user: {
+      id: number
+      paidLeaves: number
+    }
     breakdown: Breakdown
     heatmap: Heatmap
     table: LeaveTable[]


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-108

## Definition of Done

- [x] Modified LeavesDTO and add public User to add user object
- [x] Fixed the remaining leaves count number

## Notes
N/A

## Pre-condition
- cd client && npm run dev
- goto `/leave-management/leave-summary` 
- Click the filter and try to Update the result

## Expected Output

- Able to update the remaining paid leaves based on the name userId and year provided

## Screenshots/Recordings
[bugtask remaining pad leaves.webm](https://user-images.githubusercontent.com/108642414/217730983-4bb4fa46-a0a5-48ab-86a1-ed8db5adae3b.webm)
