### PR TITLE
HRIS-110 [BugTask] User should able to click Time in or out column in the My DTR and DTR Management

### DIFF
--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -6,15 +6,14 @@ import React, { useState } from 'react'
 import { Clock, Edit } from 'react-feather'
 import { createColumnHelper } from '@tanstack/react-table'
 
-import { getUserProfileLink } from '~/hooks/useTimesheetQuery'
-
 import Chip from '~/components/atoms/Chip'
 import Avatar from '~/components/atoms/Avatar'
-import CellHeader from '~/components/atoms/CellHeader'
 import Button from '~/components/atoms/Buttons/Button'
+import CellHeader from '~/components/atoms/CellHeader'
+import EditTimeEntriesModal from '../EditTimeEntryModal'
 import { ITimeEntry } from '~/utils/types/timeEntryTypes'
 import InterruptionTimeEntriesModal from './../InterruptionTimeEntriesModal'
-import EditTimeEntriesModal from '../EditTimeEntryModal'
+import { getSpecificTimeEntry, getUserProfileLink } from '~/hooks/useTimesheetQuery'
 
 const columnHelper = createColumnHelper<ITimeEntry>()
 const EMPTY = 'N/A'
@@ -46,8 +45,10 @@ export const columns = [
     footer: (info) => info.column.id,
     cell: (props) => (
       <>
-        {props.row.original.timeIn?.remarks !== undefined &&
-        props.row.original.timeIn?.remarks !== '' ? (
+        {(props.row.original.timeIn?.remarks !== undefined &&
+          props.row.original.timeIn?.remarks !== '') ||
+        getSpecificTimeEntry(Number(props.row.original.timeIn?.id)).data?.timeById?.media[0]
+          ?.fileName !== undefined ? (
           <Tippy
             content={moment(props.row.original.date).format('MMM D, YYYY')}
             placement="left"

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -12,6 +12,7 @@ import Button from '~/components/atoms/Buttons/Button'
 import CellHeader from '~/components/atoms/CellHeader'
 import { IEmployeeTimeEntry } from '~/utils/types/timeEntryTypes'
 import InterruptionTimeEntriesModal from './../InterruptionTimeEntriesModal'
+import { getSpecificTimeEntry } from '~/hooks/useTimesheetQuery'
 
 const columnHelper = createColumnHelper<IEmployeeTimeEntry>()
 const EMPTY = 'N/A'
@@ -28,8 +29,10 @@ export const columns = [
     footer: (info) => info.column.id,
     cell: (props) => (
       <>
-        {props.row.original.timeIn?.remarks !== undefined &&
-        props.row.original.timeIn?.remarks !== '' ? (
+        {(props.row.original.timeIn?.remarks !== undefined &&
+          props.row.original.timeIn?.remarks !== '') ||
+        getSpecificTimeEntry(Number(props.row.original.timeIn?.id)).data?.timeById?.media[0]
+          ?.fileName !== undefined ? (
           <Tippy
             content={moment(props.row.original.date).format('MMM D, YYYY')}
             placement="left"


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-110

## Definition of Done

- [x] User can now click Time in or out column in the My DTR and DTR Management Time In value column.

## Notes
- Bugfix on My DTR and DTR Management Time in column

## Pre-condition
- In the root folder run ``` docker compose up --build ```

## Expected Output
- TimeIn time with dot can now be open if there's a file attached or a remark available. If both are none, it will not be clickable 

## Screenshots/Recordings
- 

https://user-images.githubusercontent.com/109492180/218409390-daefdf07-f35c-4416-b05d-ea2cd9f5c9f3.mp4

