### PR TITLE
HRIS-120 [BugTask] Tooltip should not display in desktop view in My Leaves page

### DIFF
--- a/client/src/components/atoms/TabLink/index.tsx
+++ b/client/src/components/atoms/TabLink/index.tsx
@@ -17,7 +17,7 @@ const TabLink: FC<Props> = ({ href, name, Icon }): JSX.Element => {
     <Link
       href={href}
       className={classNames(
-        'flex select-none items-center space-x-2 border-b-[3px] border-transparent py-2.5 outline-none',
+        'flex select-none items-center space-x-2 border-b-[3px] border-transparent py-2.5 focus:outline-none',
         router.pathname.includes(href)
           ? 'border-amber-500 font-medium text-amber-500'
           : 'font-normal text-slate-500 focus:border-slate-300 hover:border-slate-300 hover:text-slate-600'

--- a/client/src/components/templates/LeaveManagementLayout/index.tsx
+++ b/client/src/components/templates/LeaveManagementLayout/index.tsx
@@ -108,7 +108,11 @@ export const Chip = ({ count }: { count: number | undefined }): JSX.Element => {
   const parsedNumber = parseFloat(formattedNumber)
 
   return (
-    <Tippy content="Remaining Paid Leaves" placement="left" className="!text-xs">
+    <Tippy
+      content="Remaining Paid Leaves"
+      placement="left"
+      className="!text-xs opacity-100 sm:opacity-0"
+    >
       <span
         className={classNames(
           'w-fit shrink-0 rounded-full border border-green-600 bg-green-500 px-1',


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-120

## Definition of Done

- [x] Fixed tooltip in remaining paid leaves that show only on mobile view

## Notes
- This is Bugtask

## Pre-condition
cd client && npm run dev
- Go to the `my-leave pages` or in the `/leave-management/leave-summary` page

## Expected Output

- It should now have the ability to show the tooltip only when mobile show

## Screenshots/Recordings
[tooltipshow.webm](https://user-images.githubusercontent.com/108642414/218681375-1d718305-3a0a-43ff-b5cd-9615021464bb.webm)

