### PR TITLE
HRIS-125 [BugTask] Change table to accordion in My leave, Yearly summary and Leave summary

### DIFF
--- a/client/src/components/molecules/BreakdownOfLeavesCard/index.tsx
+++ b/client/src/components/molecules/BreakdownOfLeavesCard/index.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 const BreakdownOfLeaveCard: FC<Props> = ({ data }): JSX.Element => {
   return (
-    <MaxWidthContainer maxWidth="md:max-w-[18rem]">
+    <MaxWidthContainer maxWidth="lg:max-w-[18rem]">
       <Card className="shrink-0 overflow-hidden">
         <header
           className={classNames(

--- a/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
@@ -90,7 +90,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                             </div>
                             <ChevronRight
                               className={classNames(
-                                'h-4 w-4 text-slate-600',
+                                'h-4 w-4 text-slate-600 duration-300',
                                 open ? 'rotate-90' : ''
                               )}
                             />

--- a/client/src/components/molecules/DTRSummaryTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/MobileDisclose.tsx
@@ -60,7 +60,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                           </div>
                           <ChevronRight
                             className={classNames(
-                              'h-4 w-4 text-slate-600',
+                              'h-4 w-4 text-slate-600 duration-300',
                               open ? 'rotate-90' : ''
                             )}
                           />

--- a/client/src/components/molecules/LeaveManagementResultTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/MobileDisclose.tsx
@@ -1,0 +1,132 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+import classNames from 'classnames'
+import { Table } from '@tanstack/react-table'
+import { Disclosure } from '@headlessui/react'
+import { Calendar, ChevronRight } from 'react-feather'
+
+import { getLeaveType } from '~/utils/getLeaveType'
+import { LeaveTable } from '~/utils/types/leaveTypes'
+import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
+import DisclosureTransition from '~/components/templates/DisclosureTransition'
+
+type Props = {
+  table: Table<LeaveTable>
+  query: {
+    isLoading: boolean
+    isError: boolean
+  }
+}
+
+const MobileDisclose: FC<Props> = ({ table, query: { isLoading, isError } }): JSX.Element => {
+  return (
+    <>
+      {isError === null || !isError ? (
+        isLoading ? (
+          <div className="flex flex-col px-4 py-3">
+            {Array.from({ length: 30 }, (_, i) => (
+              <LineSkeleton key={i} className="py-1" />
+            ))}
+          </div>
+        ) : (
+          <>
+            {table.getPageCount() === 0 ? (
+              <DiscloseMessage message="No Available Data" />
+            ) : (
+              <>
+                {table.getRowModel().rows.map((row) => (
+                  <Disclosure key={row.id}>
+                    {({ open }) => (
+                      <>
+                        <Disclosure.Button
+                          className={classNames(
+                            'w-full border-b border-slate-200 py-3 px-4 hover:bg-white',
+                            open ? 'bg-white' : 'hover:shadow-md hover:shadow-slate-200'
+                          )}
+                        >
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center space-x-2 text-slate-500">
+                              <Calendar className="h-4 w-4" />
+                              <span className="font-medium">
+                                {moment(new Date(row.original.date)).format('MMMM DD, YYYY')}
+                              </span>
+                            </div>
+                            <ChevronRight
+                              className={classNames(
+                                'h-4 w-4 text-slate-600 duration-300',
+                                open ? 'rotate-90' : ''
+                              )}
+                            />
+                          </div>
+                        </Disclosure.Button>
+                        <DisclosureTransition>
+                          <Disclosure.Panel
+                            className={classNames(
+                              'text-slate-500',
+                              open ? 'bg-white shadow-md' : ''
+                            )}
+                          >
+                            <ul
+                              className={classNames(
+                                'flex flex-col divide-y divide-slate-100',
+                                'transition duration-150 ease-in-out'
+                              )}
+                            >
+                              <li className="px-4 py-2 font-normal hover:bg-slate-50">
+                                Type of leave:{' '}
+                                <span className="font-medium">
+                                  {getLeaveType(row.original.leaveTypeId)}
+                                </span>
+                              </li>
+                              <li className="px-4 py-2 font-normal hover:bg-slate-50">
+                                Pay?:{' '}
+                                <span className="font-medium">
+                                  {row.original.isWithPay ? 'With Pay' : 'Without Pay'}
+                                </span>
+                              </li>
+                              <li className="px-4 py-2  font-normal hover:bg-slate-50">
+                                Reason: <span className="font-medium">{row.original.reason}</span>
+                              </li>
+                              <li className="px-4 py-2 font-normal hover:bg-slate-50">
+                                No. of leaves:{' '}
+                                <span className="font-medium">{row.original.numLeaves}</span>
+                              </li>
+                            </ul>
+                          </Disclosure.Panel>
+                        </DisclosureTransition>
+                      </>
+                    )}
+                  </Disclosure>
+                ))}
+              </>
+            )}
+          </>
+        )
+      ) : (
+        <DiscloseMessage message="Something went wrong" type="error" />
+      )}
+    </>
+  )
+}
+
+const DiscloseMessage = ({
+  message,
+  type = 'default'
+}: {
+  message: string
+  type?: string
+}): JSX.Element => {
+  return (
+    <p
+      className={classNames(
+        'py-2 text-center font-medium',
+        type === 'default' && 'text-slate-500',
+        type === 'error' && 'bg-rose-50 text-rose-500'
+      )}
+    >
+      {message}
+    </p>
+  )
+}
+
+export default MobileDisclose

--- a/client/src/components/molecules/LeaveManagementResultTable/index.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/index.tsx
@@ -12,6 +12,7 @@ import { columns } from './columns'
 import FooterTable from './../FooterTable'
 import LeaveManagementTable from './Table'
 import Card from '~/components/atoms/Card'
+import MobileDisclose from './MobileDisclose'
 import { LeaveTable } from '~/utils/types/leaveTypes'
 
 type Props = {
@@ -50,8 +51,21 @@ const LeaveManagementResultTable: FC<Props> = (props): JSX.Element => {
 
   return (
     <div className="flex flex-1 flex-col space-y-1">
-      <Card className="overflow-hidden" shadow-size="sm">
+      {/* Show on Desktop */}
+      <Card className="hidden overflow-hidden md:block" shadow-size="sm">
         <LeaveManagementTable
+          {...{
+            query: {
+              isLoading,
+              isError
+            },
+            table
+          }}
+        />
+      </Card>
+      {/* Shows on Mobile */}
+      <Card className="block overflow-hidden md:hidden" shadow-size="sm">
+        <MobileDisclose
           {...{
             query: {
               isLoading,

--- a/client/src/components/molecules/ListOfLeaveTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/ListOfLeaveTable/MobileDisclose.tsx
@@ -68,7 +68,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                             </div>
                             <ChevronRight
                               className={classNames(
-                                'h-4 w-4 text-slate-600',
+                                'h-4 w-4 text-slate-600 duration-300',
                                 open ? 'rotate-90' : ''
                               )}
                             />

--- a/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
@@ -77,7 +77,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                             </div>
                             <ChevronRight
                               className={classNames(
-                                'h-4 w-4 text-slate-600',
+                                'h-4 w-4 text-slate-600 duration-300',
                                 open ? 'rotate-90' : ''
                               )}
                             />

--- a/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
@@ -60,7 +60,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                             </div>
                             <ChevronRight
                               className={classNames(
-                                'h-4 w-4 text-slate-600',
+                                'h-4 w-4 text-slate-600 duration-300',
                                 open ? 'rotate-90' : ''
                               )}
                             />

--- a/client/src/components/molecules/NotificationList/NotificationItem.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationItem.tsx
@@ -9,6 +9,7 @@ import Avatar from '~/components/atoms/Avatar'
 import { INotification } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/Button'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
+import DisclosureTransition from '~/components/templates/DisclosureTransition'
 
 type Props = {
   table: Table<INotification>
@@ -69,64 +70,66 @@ const NotificationItem: FC<Props> = ({ table, isLoading }): JSX.Element => {
                           />
                         </div>
                       </Disclosure.Button>
-                      <Disclosure.Panel
-                        className={classNames('text-slate-600', open ? 'bg-white shadow-md' : '')}
-                      >
-                        <ul className="flex flex-col flex-wrap divide-y divide-slate-200 md:flex-row md:items-center md:divide-none">
-                          <li className="px-4 py-2 md:py-3">
-                            Project: <span className="font-semibold">{row.original.project}</span>
-                          </li>
-                          <li className="px-4 py-2 md:py-3">
-                            Type: <span className="font-semibold">{row.original.type}</span>
-                          </li>
-                          <li className="px-4 py-2 md:py-3">
-                            Date Requested:{' '}
-                            <span className="font-semibold">{row.original.date}</span>
-                          </li>
-                          <li className="px-4 py-2 md:py-3">
-                            Requested Hours:{' '}
-                            <span className="font-semibold">{row.original.duration}</span>
-                          </li>
-                          <li className="px-4 py-2 md:py-3">
-                            Date Filed:{' '}
-                            <span className="font-semibold">{row.original.dateFiled}</span>
-                          </li>
-                          <li className="inline-flex items-center px-4 py-2 md:py-3">
-                            Status:{' '}
-                            <span
-                              className={classNames(
-                                'py-0.25  ml-1 rounded-full border  px-1.5',
-                                row.original.status === 'Pending' &&
-                                  'border-amber-200 bg-amber-50 text-amber-600',
-                                row.original.status === 'Approved' &&
-                                  'border-green-200 bg-green-50 text-green-600',
-                                row.original.status === 'Disapproved' &&
-                                  'border-rose-200 bg-rose-50 text-rose-600'
-                              )}
-                            >
-                              {row.original.status}
-                            </span>
-                          </li>
-                          <li className="px-4 py-2 md:py-3">
-                            Remarks: <span className="font-semibold">{row.original.remarks}</span>
-                          </li>
-                          <li className="inline-flex items-center px-4 py-2 md:py-3">
-                            Actions:{' '}
-                            <div className="ml-2 inline-flex items-center divide-x divide-slate-300 rounded border border-slate-300">
-                              <Tippy placement="left" content="Approve" className="!text-xs">
-                                <Button rounded="none" className="py-0.5 px-1 text-slate-500">
-                                  <Check className="h-4 w-4" />
-                                </Button>
-                              </Tippy>
-                              <Tippy placement="left" content="Disapprove" className="!text-xs">
-                                <Button rounded="none" className="py-0.5 px-1 text-slate-500">
-                                  <X className="h-4 w-4" />
-                                </Button>
-                              </Tippy>
-                            </div>
-                          </li>
-                        </ul>
-                      </Disclosure.Panel>
+                      <DisclosureTransition>
+                        <Disclosure.Panel
+                          className={classNames('text-slate-600', open ? 'bg-white shadow-md' : '')}
+                        >
+                          <ul className="flex flex-col flex-wrap divide-y divide-slate-200 md:flex-row md:items-center md:divide-none">
+                            <li className="px-4 py-2 md:py-3">
+                              Project: <span className="font-semibold">{row.original.project}</span>
+                            </li>
+                            <li className="px-4 py-2 md:py-3">
+                              Type: <span className="font-semibold">{row.original.type}</span>
+                            </li>
+                            <li className="px-4 py-2 md:py-3">
+                              Date Requested:{' '}
+                              <span className="font-semibold">{row.original.date}</span>
+                            </li>
+                            <li className="px-4 py-2 md:py-3">
+                              Requested Hours:{' '}
+                              <span className="font-semibold">{row.original.duration}</span>
+                            </li>
+                            <li className="px-4 py-2 md:py-3">
+                              Date Filed:{' '}
+                              <span className="font-semibold">{row.original.dateFiled}</span>
+                            </li>
+                            <li className="inline-flex items-center px-4 py-2 md:py-3">
+                              Status:{' '}
+                              <span
+                                className={classNames(
+                                  'py-0.25  ml-1 rounded-full border  px-1.5',
+                                  row.original.status === 'Pending' &&
+                                    'border-amber-200 bg-amber-50 text-amber-600',
+                                  row.original.status === 'Approved' &&
+                                    'border-green-200 bg-green-50 text-green-600',
+                                  row.original.status === 'Disapproved' &&
+                                    'border-rose-200 bg-rose-50 text-rose-600'
+                                )}
+                              >
+                                {row.original.status}
+                              </span>
+                            </li>
+                            <li className="px-4 py-2 md:py-3">
+                              Remarks: <span className="font-semibold">{row.original.remarks}</span>
+                            </li>
+                            <li className="inline-flex items-center px-4 py-2 md:py-3">
+                              Actions:{' '}
+                              <div className="ml-2 inline-flex items-center divide-x divide-slate-300 rounded border border-slate-300">
+                                <Tippy placement="left" content="Approve" className="!text-xs">
+                                  <Button rounded="none" className="py-0.5 px-1 text-slate-500">
+                                    <Check className="h-4 w-4" />
+                                  </Button>
+                                </Tippy>
+                                <Tippy placement="left" content="Disapprove" className="!text-xs">
+                                  <Button rounded="none" className="py-0.5 px-1 text-slate-500">
+                                    <X className="h-4 w-4" />
+                                  </Button>
+                                </Tippy>
+                              </div>
+                            </li>
+                          </ul>
+                        </Disclosure.Panel>
+                      </DisclosureTransition>
                     </>
                   )}
                 </Disclosure>

--- a/client/src/components/molecules/OvertimeManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/MobileDisclose.tsx
@@ -87,7 +87,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                             </div>
                             <ChevronRight
                               className={classNames(
-                                'h-4 w-4 text-slate-600',
+                                'h-4 w-4 text-slate-600 duration-300',
                                 open ? 'rotate-90' : ''
                               )}
                             />

--- a/client/src/components/molecules/UserMenuDropdown/index.tsx
+++ b/client/src/components/molecules/UserMenuDropdown/index.tsx
@@ -22,7 +22,7 @@ const UserMenuDropDown: FC<Props> = (props): JSX.Element => {
 
   const menu = 'relative z-30 flex w-full text-left'
   const menuItems = classNames(
-    'absolute flex w-44 flex-col divide-y divide-slate-200 overflow-hidden rounded-md',
+    'absolute flex w-48 flex-col divide-y divide-slate-200 overflow-hidden rounded-md',
     'bg-white py-1 shadow-xl shadow-slate-200 ring-1 ring-black ring-opacity-5 focus:outline-none',
     position === 'bottom' && 'top-10 right-0',
     position === 'right' && 'bottom-0 -right-48 origin-bottom-right',

--- a/client/src/components/organisms/Drawer/index.tsx
+++ b/client/src/components/organisms/Drawer/index.tsx
@@ -25,7 +25,7 @@ const Drawer: FC<Props> = (props): JSX.Element => {
     <aside>
       <div
         className={classNames(
-          'flex h-screen max-w-[250px] shrink-0 flex-col border-r border-slate-200',
+          'flex h-screen max-w-[253px] shrink-0 flex-col border-r border-slate-200',
           'fixed top-0 left-0 z-50 w-full bg-white shadow-lg transition-all duration-300',
           isOpenDrawer ? 'translate-x-0' : '-translate-x-full'
         )}

--- a/client/src/components/organisms/Sidebar/index.tsx
+++ b/client/src/components/organisms/Sidebar/index.tsx
@@ -24,7 +24,7 @@ const Sidebar: FC<Props> = (props): JSX.Element => {
       className={classNames(
         'flex h-screen shrink-0 flex-col border-r border-slate-200',
         'w-full bg-white transition-all duration-300',
-        isOpenSidebar ? 'max-w-0 md:max-w-[250px]' : 'max-w-0 md:max-w-[80px]'
+        isOpenSidebar ? 'max-w-0 md:max-w-[253px]' : 'max-w-0 md:max-w-[80px]'
       )}
     >
       {/* Business Logo */}

--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -11,8 +11,12 @@ const Document = (): JSX.Element => {
           href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
           rel="stylesheet"
         />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap"
+          rel="stylesheet"
+        />
       </Head>
-      <body className="font-inter antialiased selection:bg-amber-400">
+      <body className="font-poppins antialiased selection:bg-amber-400">
         <Main />
         <NextScript />
       </body>

--- a/client/src/pages/leave-management/leave-summary.tsx
+++ b/client/src/pages/leave-management/leave-summary.tsx
@@ -132,7 +132,7 @@ const LeaveSummary: NextPage = (): JSX.Element => {
             <article
               className={classNames(
                 'flex flex-col space-y-4 pb-24 text-xs',
-                'md:flex-row md:space-y-0 md:space-x-4'
+                'lg:flex-row lg:space-y-0 lg:space-x-4'
               )}
             >
               {/* Pass the needed props of these components */}

--- a/client/src/pages/leave-management/yearly-summary.tsx
+++ b/client/src/pages/leave-management/yearly-summary.tsx
@@ -123,7 +123,7 @@ const YearlySummary: NextPage = (): JSX.Element => {
             <article
               className={classNames(
                 'flex flex-col space-y-4 pb-24 text-xs',
-                'md:flex-row md:space-y-0 md:space-x-4'
+                'lg:flex-row lg:space-y-0 lg:space-x-4'
               )}
             >
               {/* Pass the needed props of these components */}

--- a/client/src/pages/my-leaves.tsx
+++ b/client/src/pages/my-leaves.tsx
@@ -177,7 +177,7 @@ const MyLeaves: NextPage = (): JSX.Element => {
               <article
                 className={classNames(
                   'flex flex-col space-y-4 pb-24 text-xs',
-                  'md:flex-row md:space-y-0 md:space-x-4'
+                  'lg:flex-row lg:space-y-0 lg:space-x-4'
                 )}
               >
                 {/* Pass the needed props of these components */}

--- a/client/src/utils/generateData.ts
+++ b/client/src/utils/generateData.ts
@@ -33,6 +33,7 @@ export const getHeatmapData = (count: number, heatmap: HeatmapDetails[]): Series
 export const initialChartOptions = {
   chart: {
     id: 'LeavesHeatMap',
+    fontFamily: 'Poppins, Inter',
     toolbar: {
       show: false,
       tools: {

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -7,7 +7,8 @@ module.exports = {
     },
     extend: {
       fontFamily: {
-        inter: 'Inter, sans-serif'
+        inter: 'Inter, sans-serif',
+        poppins: 'Poppins, Inter'
       },
       strokeWidth: {
         0.5: '1px'


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-125

## Definition of Done

- [x] Added Accordion Component in My Leave, yearly Summary and Leave Summary Page
- [x] Added minor delay animation in Mobile Disclose Icon
- [x] Changed `Inter` font into `Poppins` font

## Notes
N/A

## Pre-condition

cd `client` && `npm run dev`
cd `api` && `dotnet run watch`

## Expected Output

- It should now have an accordion mobile disclose in My leave, Yearly summary and Leave summary
- Changed general font into `Poppins` font

## Screenshots/Recordings
[accordion.webm](https://user-images.githubusercontent.com/108642414/220076380-5e4558eb-564b-4300-97b2-9d6c502e6f3a.webm)
