### PR TITLE
HRIS-133 [BE] Implement Fetch notifications for the authenticated user functionality

### DIFF
--- a/api/Context/HrisContext.cs
+++ b/api/Context/HrisContext.cs
@@ -1,5 +1,4 @@
 ﻿using api.Entities;
-using api.Enums;
 using api.Seeders;
 using Microsoft.EntityFrameworkCore;
 
@@ -65,7 +64,7 @@ public partial class HrisContext : DbContext
             DatabaseSeeder.leaveProjects
         );
 
-        modelBuilder.Entity<Notification>().HasDiscriminator(b => b.Type).HasValue<LeaveNotification>(NotificationTypeEnum.LEAVE);
+        modelBuilder.Entity<Notification>().HasDiscriminator();
         modelBuilder.Entity<LeaveNotification>().HasData(
             DatabaseSeeder.notifications_leave
         );

--- a/api/Entities/Leave.cs
+++ b/api/Entities/Leave.cs
@@ -16,8 +16,8 @@ namespace api.Entities
         public DateTime LeaveDate { get; set; }
         public float Days { get; set; }
         public bool IsWithPay { get; set; }
-        public bool IsLeaderApproved { get; set; } = false;
-        public bool IsManagerApproved { get; set; } = false;
+        public bool? IsLeaderApproved { get; set; }
+        public bool? IsManagerApproved { get; set; }
         public ICollection<LeaveProject> LeaveProjects { get; set; } = default!;
         public LeaveType LeaveType { get; set; } = default!;
         public User Manager { get; set; } = default!;

--- a/api/Enums/NotificationTypeEnum.cs
+++ b/api/Enums/NotificationTypeEnum.cs
@@ -4,5 +4,6 @@ namespace api.Enums
     {
         public const string LEAVE = "leave";
         public const string OVERTIME = "overtime";
+        public const string UNDERTIME = "undertime";
     }
 }

--- a/api/Enums/RequestStatusEnum.cs
+++ b/api/Enums/RequestStatusEnum.cs
@@ -1,0 +1,9 @@
+namespace api.Enums
+{
+    public class RequestStatus
+    {
+        public const string APPROVED = "Approved";
+        public const string DISAPPROVED = "Disapproved";
+        public const string PENDING = "Pending";
+    }
+}

--- a/api/Migrations/20230222054212_ModifyNotificationDiscriminator.Designer.cs
+++ b/api/Migrations/20230222054212_ModifyNotificationDiscriminator.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
@@ -11,9 +12,11 @@ using api.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(HrisContext))]
-    partial class HrisContextModelSnapshot : ModelSnapshot
+    [Migration("20230222054212_ModifyNotificationDiscriminator")]
+    partial class ModifyNotificationDiscriminator
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20230222054212_ModifyNotificationDiscriminator.cs
+++ b/api/Migrations/20230222054212_ModifyNotificationDiscriminator.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class ModifyNotificationDiscriminator : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Notifications",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Discriminator",
+                table: "Notifications",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsManagerApproved",
+                table: "Leaves",
+                type: "bit",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "bit");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsLeaderApproved",
+                table: "Leaves",
+                type: "bit",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "bit");
+
+            migrationBuilder.UpdateData(
+                table: "LeaveProjects",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 2, 22, 13, 42, 11, 196, DateTimeKind.Local).AddTicks(7684), new DateTime(2023, 2, 22, 13, 42, 11, 196, DateTimeKind.Local).AddTicks(7685) });
+
+            migrationBuilder.InsertData(
+                table: "Notifications",
+                columns: new[] { "Id", "CreatedAt", "Data", "Discriminator", "IsRead", "LeaveId", "ReadAt", "RecipientId", "Type", "UpdatedAt" },
+                values: new object[] { 1, new DateTime(2023, 2, 22, 13, 42, 11, 196, DateTimeKind.Local).AddTicks(9699), "Some JSON Data", "LeaveNotification", false, 1, null, 70, "leave", new DateTime(2023, 2, 22, 13, 42, 11, 196, DateTimeKind.Local).AddTicks(9701) });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Discriminator",
+                table: "Notifications");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsManagerApproved",
+                table: "Leaves",
+                type: "bit",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "bit",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsLeaderApproved",
+                table: "Leaves",
+                type: "bit",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "bit",
+                oldNullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "LeaveProjects",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 2, 17, 15, 54, 59, 441, DateTimeKind.Local).AddTicks(8844), new DateTime(2023, 2, 17, 15, 54, 59, 441, DateTimeKind.Local).AddTicks(8851) });
+
+            migrationBuilder.UpdateData(
+                table: "Notifications",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 2, 17, 15, 54, 59, 442, DateTimeKind.Local).AddTicks(4733), new DateTime(2023, 2, 17, 15, 54, 59, 442, DateTimeKind.Local).AddTicks(4742) });
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -22,7 +22,8 @@ builder.Services.AddGraphQLServer()
     .AddType<TimeSheetQuery>()
     .AddType<InterruptionQuery>()
     .AddType<LeaveQuery>()
-    .AddType<ProjectQuery>();
+    .AddType<ProjectQuery>()
+    .AddType<NotificationQuery>();
 
 builder.Services.AddGraphQLServer()
     .AddMutationType(q => q.Name("Mutation"))

--- a/api/Schema/Queries/NotificationQuery.cs
+++ b/api/Schema/Queries/NotificationQuery.cs
@@ -1,0 +1,20 @@
+using api.Entities;
+using api.Services;
+
+namespace api.Schema.Queries
+{
+    [ExtendObjectType("Query")]
+    public class NotificationQuery
+    {
+        private readonly NotificationService _notificationService;
+        public NotificationQuery(NotificationService notificationService)
+        {
+            _notificationService = notificationService;
+        }
+
+        public async Task<List<Notification>> GetNotificationByRecipientId(int id)
+        {
+            return await _notificationService.getByRecipientId(id);
+        }
+    }
+}

--- a/api/Services/LeaveService.cs
+++ b/api/Services/LeaveService.cs
@@ -167,5 +167,39 @@ namespace api.Services
 
             }
         }
+
+        public float LeaveDaysToHours(float days)
+        {
+            switch (days)
+            {
+                case 0.125f:
+                    return 4;
+                case 0.19f:
+                    return 1.5f;
+                case 0.25f:
+                    return 2;
+                case 0.31f:
+                    return 2.5f;
+                case 0.38f:
+                    return 3;
+                case 0.5f:
+                    return 4;
+                case 0.625f:
+                    return 5;
+                case 0.69f:
+                    return 5.5f;
+                case 1:
+                    return 8;
+                default:
+                    return 0;
+            }
+        }
+
+        public string GetLeaveRequestStatus(Leave leave)
+        {
+            if (leave.IsLeaderApproved == true && leave.IsManagerApproved == true) return RequestStatus.APPROVED;
+            if (leave.IsLeaderApproved == false && leave.IsManagerApproved == false) return RequestStatus.DISAPPROVED;
+            return RequestStatus.PENDING;
+        }
     }
 }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-133

## Definition of Done
- [x] Can fetch Notification by id
- [x] Modified implementation on creating Notification data

## Notes
- Notification related data is all stored in the `data` column of Notification table in string of JSON
- If you encounter error in updating your database, try to delete the rows not generated by seeder in the `Leave` table

## Pre-condition
- run `dotnet ef database update`
- run `docker compose up`
- go to `http://localhost:5257/graphql/`
- use the following query
```
query($id: Int!) {
  notificationByRecipientId(id: $id){
    id
    type
    data
    readAt
    isRead
  }
}
```
- use the following variable
```
{
  "id": 4
}
```

## Expected Output
- The query should return list of notifications for the recipient
- `Data` column of the Notification table should contain more necessary data

## Screenshot/Recordings
- Sample query
![image](https://user-images.githubusercontent.com/111718037/220545234-7adb0aa8-217f-462d-ad20-84db28ed99f9.png)

- New Notifications table
![image](https://user-images.githubusercontent.com/111718037/220545368-30d5c8be-da48-4060-b66c-4bf3efa18feb.png)

