### PR TITLE
HRIS-123-01 [FE] Fixed routing from Leave Management pages to Notifications page

### DIFF
--- a/api/Seeders/DatabaseSeeder.cs
+++ b/api/Seeders/DatabaseSeeder.cs
@@ -1354,38 +1354,6 @@ namespace api.Seeders
                 UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
             },
         };
-        public static List<Leave> leaves = new List<Leave>(){
-            new Leave {
-                Id = 1,
-                UserId = 1,
-                LeaveTypeId = 1,
-                ManagerId = 1,
-                OtherProject = "None",
-                Reason = "Leave lang guds",
-                LeaveDate = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                IsWithPay = false,
-                IsLeaderApproved = true,
-                IsManagerApproved = true,
-                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                Days = 1.5f
-            },
-            new Leave {
-                Id = 2,
-                UserId = 2,
-                LeaveTypeId = 6,
-                ManagerId = 1,
-                OtherProject = "None",
-                Reason = "Vacation leave",
-                LeaveDate = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                IsWithPay = true,
-                IsLeaderApproved = true,
-                IsManagerApproved = true,
-                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                Days = 2.0f
-            },
-        };
 
         public static List<LeaveProject> leaveProjects = new List<LeaveProject>(){
             new LeaveProject {

--- a/client/src/components/molecules/NotificationPopOver/index.tsx
+++ b/client/src/components/molecules/NotificationPopOver/index.tsx
@@ -61,7 +61,7 @@ const NotificationPopover: FC<Props> = ({ className }): JSX.Element => {
                 ))}
               </main>
               <footer className="block bg-amber-500 py-2 text-center text-sm font-semibold text-white">
-                <Link href="notifications">See all notifications</Link>
+                <Link href="/notifications">See all notifications</Link>
               </footer>
             </Popover.Panel>
           </PopoverTransition>


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-123

## Definition of Done
- [x] Fixed routing when clicking `See all notifications` button when the user is in `List of Leave`, `Yearly Summary` or `Leave Summary` page
- [x] Removed seeder for `Leave` table that causes error in `List of Leave` page

## Notes
- only fixes

## Pre-condition
- run `docker compose up --build`
- go to any page/tab of `Leave Management`

## Expected Output
- When the user clicked `See all notifications` button from the notification bell, the user should be properly redirected to Notifications page

## Screenshots/Recordings
[Notification fix.webm](https://user-images.githubusercontent.com/111718037/221745210-57d5e5bd-e695-423d-b479-993b42715f54.webm)

