### PR TITLE
HRIS-134 [FE] Implement Filter notifications functionality

### DIFF
--- a/client/src/components/molecules/NotificationFilterDropdown/index.tsx
+++ b/client/src/components/molecules/NotificationFilterDropdown/index.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import { useRouter } from 'next/router'
 import { Menu } from '@headlessui/react'
 import React, { FC, ReactNode } from 'react'
 
@@ -6,42 +7,65 @@ import Text from '~/components/atoms/Text'
 import { Filters } from '~/pages/notifications'
 import Button from '~/components/atoms/Buttons/Button'
 import MenuTransition from '~/components/templates/MenuTransition'
+import { STATUS_OPTIONS, TYPE_OPTIONS } from '~/utils/constants/notificationFilter'
 
 type Props = {
   className?: string
   filters: Filters
   setFilters: React.Dispatch<React.SetStateAction<any>>
+  startFilter: () => void
   children: ReactNode
 }
 
 const NotificationFilterDropdown: FC<Props> = (props): JSX.Element => {
+  const router = useRouter()
+
   const {
     children,
     className = 'shrink-0 outline-none active:scale-95',
     filters,
-    setFilters
+    setFilters,
+    startFilter
   } = props
 
-  const statusOptions = ['All', 'Pending', 'Approved', 'Dissaproved']
-  const typeOptions = ['All', 'Overtime', 'Undertime', 'Leave']
+  const statusOptions = [
+    STATUS_OPTIONS.ALL,
+    STATUS_OPTIONS.PENDING,
+    STATUS_OPTIONS.APPROVED,
+    STATUS_OPTIONS.DISAPPROVED
+  ]
+  const typeOptions = [
+    TYPE_OPTIONS.ALL,
+    TYPE_OPTIONS.OVERTIME,
+    TYPE_OPTIONS.UNDERTIME,
+    TYPE_OPTIONS.LEAVE
+  ]
 
   const filterStatusOptions = (statusList: string[]): JSX.Element[] => {
-    return statusList.map((item) => <option key={item}>{item}</option>)
+    return statusList.map((item) => (
+      <option key={item} value={item.toLowerCase()}>
+        {item}
+      </option>
+    ))
   }
   const filterTypeOptions = (typeList: string[]): JSX.Element[] => {
-    return typeList.map((item) => <option key={item}>{item}</option>)
+    return typeList.map((item) => (
+      <option key={item} value={item.toLowerCase()}>
+        {item}
+      </option>
+    ))
   }
 
   const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     setFilters({
       ...filters,
-      status: e.currentTarget.value !== 'All' ? e.currentTarget.value.toLowerCase() : ''
+      status: e.currentTarget.value.toLowerCase()
     })
   }
   const handleTypeChange = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     setFilters({
       ...filters,
-      type: e.currentTarget.value !== 'All' ? e.currentTarget.value.toLowerCase() : ''
+      type: e.currentTarget.value.toLowerCase()
     })
   }
 
@@ -68,19 +92,29 @@ const NotificationFilterDropdown: FC<Props> = (props): JSX.Element => {
                 focus:border-primary focus:ring-1 focus:ring-primary
                 `}
                 id="filterStatus"
+                defaultValue={
+                  router.query.status !== undefined
+                    ? router.query.status
+                    : STATUS_OPTIONS.ALL.toLowerCase()
+                }
                 onChange={(e) => handleStatusChange(e)}
               >
                 {filterStatusOptions(statusOptions)}
               </select>
             </label>
-            <label htmlFor="filterStatus" className="flex flex-col space-y-1 border-t">
+            <label htmlFor="filterType" className="flex flex-col space-y-1 border-t">
               <span className="mt-3 text-xs text-slate-500">Filter Type</span>
               <select
                 className={`
                   w-full rounded-md border border-slate-300 text-xs shadow-sm 
                 focus:border-primary focus:ring-1 focus:ring-primary
                 `}
-                id="filterStatus"
+                id="filterType"
+                defaultValue={
+                  router.query.type !== undefined
+                    ? router.query.type
+                    : TYPE_OPTIONS.ALL.toLowerCase()
+                }
                 onChange={(e) => handleTypeChange(e)}
               >
                 {filterTypeOptions(typeOptions)}
@@ -95,6 +129,7 @@ const NotificationFilterDropdown: FC<Props> = (props): JSX.Element => {
                 'w-full border border-dark-primary bg-primary py-2 text-xs text-white',
                 'transition duration-150 ease-in-out hover:bg-dark-primary active:bg-primary'
               )}
+              onClick={startFilter}
             >
               Update Results
             </Button>

--- a/client/src/utils/constants/notificationFilter.ts
+++ b/client/src/utils/constants/notificationFilter.ts
@@ -1,0 +1,13 @@
+export const STATUS_OPTIONS = {
+  ALL: 'All',
+  PENDING: 'Pending',
+  APPROVED: 'Approved',
+  DISAPPROVED: 'Dissaproved'
+}
+
+export const TYPE_OPTIONS = {
+  ALL: 'All',
+  OVERTIME: 'Overtime',
+  UNDERTIME: 'Undertime',
+  LEAVE: 'Leave'
+}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-134

## Definition of Done
- [x] Users can filter their notification list
- [x] Filter parameters will be persistent on page reload

## Pre-condition
- run `docker compose up --build`
- go to `http://localhost:3000/notifications`
- perform filter using the `Filters` button

## Expected Output
- at first visit of page, the URL should have no queries
- after filtering, filter parameters should be present in the URL
- filter parameters and result should persist even after page reload

## Screenshots/Recordings
[Filter.webm](https://user-images.githubusercontent.com/111718037/221782513-d7ec0c9d-9d56-4583-91d7-77f80d2cf471.webm)

