### PR TITLE
HRIS-145 [BE] Implement Approve or Disapprove overtime, leave, and undertime functionality

### DIFF
--- a/api/Enums/InputValidationMessageEnum.cs
+++ b/api/Enums/InputValidationMessageEnum.cs
@@ -6,9 +6,16 @@ namespace api.Enums
         public const string INVALID_MANAGER = "Manager doesn't exist";
         public const string INVALID_PROJECT_LEADER = "Project Leader doesn't exist";
         public const string INVALID_PROJECT = "Project doesn't exist";
+        public const string INVALID_OVERTIME = "Overtime doesn't exist";
+        public const string INVALID_LEAVE = "Leave doesn't exist";
         public const string INVALID_DATE = "Invalid Date";
         public const string INVALID_LEAVE_TYPE = "Invalid leave type";
         public const string MISSING_LEAVE_DATES = "Leave Date/s is required";
         public const string MISSING_LEAVE_PROJECTS = "Leave Project/s is required";
+        public const string MISSING_APPROVED_MINUTES = "Approved minutes is required";
+        public const string INVALID_NOTIFICATION = "Invalid Notification";
+        public const string NOT_MANAGER_PROJECT_LEADER = "User is not Manager or Project Leader";
+        public const string MISMATCH_PROJECT_LEADER = "Project Leader doesn't match";
+        public const string MISMATCH_MANAGER = "Manager doesn't match";
     }
 }

--- a/api/Enums/NotificationTypeEnum.cs
+++ b/api/Enums/NotificationTypeEnum.cs
@@ -5,5 +5,8 @@ namespace api.Enums
         public const string LEAVE = "leave";
         public const string OVERTIME = "overtime";
         public const string UNDERTIME = "undertime";
+        public const string LEAVE_RESOLVED = "leave_resolved";
+        public const string OVERTIME_RESOLVED = "overtime_resolved";
+        public const string UNDERTIME_RESOLVED = "undertime_resolved";
     }
 }

--- a/api/Enums/ProjectEnum.cs
+++ b/api/Enums/ProjectEnum.cs
@@ -1,0 +1,7 @@
+namespace api.Enums
+{
+    public class ProjectId
+    {
+        public const int OTHER_PROJECT = 17;
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -41,7 +41,8 @@ builder.Services.AddGraphQLServer()
     .AddType<TimeEntryMutation>()
     .AddType<LeaveMutation>()
     .AddType<NotificationMutation>()
-    .AddType<OvertimeMutation>();
+    .AddType<OvertimeMutation>()
+    .AddType<ApprovalMutation>();
 
 builder.Services.AddGraphQLServer().AddProjections().AddFiltering().AddSorting();
 builder.Services.AddGraphQLServer().AddInMemorySubscriptions()
@@ -65,6 +66,7 @@ builder.Services.AddScoped<ProjectService>();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<NotificationService>();
 builder.Services.AddScoped<OvertimeService>();
+builder.Services.AddScoped<ApprovalService>();
 
 
 var app = builder.Build();

--- a/api/Requests/ApproveLeaveUndertimeRequest.cs
+++ b/api/Requests/ApproveLeaveUndertimeRequest.cs
@@ -1,0 +1,9 @@
+namespace api.Requests
+{
+    public class ApproveLeaveUndertimeRequest
+    {
+        public int UserId { get; set; }
+        public int NotificationId { get; set; }
+        public bool IsApproved { get; set; }
+    }
+}

--- a/api/Requests/ApproveOvertimeRequest.cs
+++ b/api/Requests/ApproveOvertimeRequest.cs
@@ -1,0 +1,11 @@
+namespace api.Requests
+{
+    public class ApproveOvertimeRequest
+    {
+        public int UserId { get; set; }
+        public int? OvertimeId { get; set; }
+        public int? NotificationId { get; set; }
+        public int? ApprovedMinutes { get; set; }
+        public bool IsApproved { get; set; }
+    }
+}

--- a/api/Schema/Mutations/ApprovalMutation.cs
+++ b/api/Schema/Mutations/ApprovalMutation.cs
@@ -1,0 +1,74 @@
+using api.Context;
+using api.Requests;
+using api.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Schema.Mutations
+{
+    [ExtendObjectType("Mutation")]
+    public class ApprovalMutation
+    {
+        public async Task<bool> ApproveDisapproveOvertime(ApproveOvertimeRequest approvingData, [Service] ApprovalService _approvalService, [Service] IDbContextFactory<HrisContext> contextFactory)
+        {
+            using (HrisContext context = contextFactory.CreateDbContext())
+            {
+                try
+                {
+                    using var transaction = context.Database.BeginTransaction();
+
+                    await _approvalService.ApproveDisapproveOvertime(approvingData);
+
+                    transaction.Commit();
+
+                    return true;
+                }
+                catch (GraphQLException e)
+                {
+                    throw e;
+                }
+            }
+        }
+
+        public async Task<bool> ApproveDisapproveLeave(ApproveLeaveUndertimeRequest approvingData, [Service] ApprovalService _approvalService, [Service] IDbContextFactory<HrisContext> contextFactory)
+        {
+            using (HrisContext context = contextFactory.CreateDbContext())
+            {
+                try
+                {
+                    using var transaction = context.Database.BeginTransaction();
+
+                    await _approvalService.ApproveDisapproveLeave(approvingData);
+
+                    transaction.Commit();
+
+                    return true;
+                }
+                catch (GraphQLException e)
+                {
+                    throw e;
+                }
+            }
+        }
+
+        public async Task<bool> ApproveDisapproveUndertime(ApproveLeaveUndertimeRequest approvingData, [Service] ApprovalService _approvalService, [Service] IDbContextFactory<HrisContext> contextFactory)
+        {
+            using (HrisContext context = contextFactory.CreateDbContext())
+            {
+                try
+                {
+                    using var transaction = context.Database.BeginTransaction();
+
+                    await _approvalService.ApproveDisapproveUndertime(approvingData);
+
+                    transaction.Commit();
+
+                    return true;
+                }
+                catch (GraphQLException e)
+                {
+                    throw e;
+                }
+            }
+        }
+    }
+}

--- a/api/Services/ApprovalService.cs
+++ b/api/Services/ApprovalService.cs
@@ -1,0 +1,192 @@
+using api.Context;
+using api.Entities;
+using api.Enums;
+using api.Requests;
+using api.Utils;
+using HotChocolate.Subscriptions;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+
+namespace api.Services
+{
+    public class ApprovalService
+    {
+        private readonly IDbContextFactory<HrisContext> _contextFactory = default!;
+        private readonly ITopicEventSender _eventSender;
+        private readonly CustomInputValidation _customInputValidation;
+        private readonly NotificationService _notificationService;
+        private readonly bool APPROVED = true;
+        private readonly bool DISAPPROVED = false;
+
+        public ApprovalService(IDbContextFactory<HrisContext> contextFactory, ITopicEventSender eventSender, NotificationService notificationService)
+        {
+            _contextFactory = contextFactory;
+            _eventSender = eventSender;
+            _customInputValidation = new CustomInputValidation(_contextFactory);
+            _notificationService = notificationService;
+        }
+
+        public async Task<bool> ApproveDisapproveOvertime(ApproveOvertimeRequest overtimeRequest)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                var errors = new List<IError>();
+                errors = _customInputValidation.checkApproveOvertimeRequestInput(overtimeRequest);
+                if (errors.Count > 0) throw new GraphQLException(errors);
+
+                // check if approving/disapproving is manager
+                if (_customInputValidation.checkManagerUser(overtimeRequest.UserId).Result)
+                {
+                    // validate input for manager case
+                    errors = _customInputValidation.checkManagerApproveOvertimeRequestInput(overtimeRequest);
+                    if (errors.Count > 0) throw new GraphQLException(errors);
+
+                    // approve/disapprove operation
+                    var notification = await context.OvertimeNotifications.Where(x => x.OvertimeId == overtimeRequest.OvertimeId && x.RecipientId == overtimeRequest.UserId && x.Type == NotificationTypeEnum.OVERTIME).FirstOrDefaultAsync();
+                    var overtime = await context.Overtimes.FindAsync(overtimeRequest.OvertimeId);
+                    var notificationData = notification != null ? JsonConvert.DeserializeObject<dynamic>(notification.Data) : null;
+
+                    if (overtime != null && notificationData != null)
+                    {
+                        overtime!.IsManagerApproved = overtimeRequest.IsApproved;
+
+                        if (overtimeRequest.IsApproved)
+                        {
+                            notificationData!.Status = RequestStatus.APPROVED;
+                            overtime.ApprovedMinutes = overtimeRequest.ApprovedMinutes;
+                        }
+                        if (!overtimeRequest.IsApproved)
+                        {
+                            notificationData!.Status = RequestStatus.DISAPPROVED;
+                            overtime.ApprovedMinutes = 0;
+                        }
+                    }
+
+                    if (notification != null) notification.Data = JsonConvert.SerializeObject(notificationData);
+
+                    // create notification
+                    if (overtime != null && overtime.IsManagerApproved == true && overtime.IsLeaderApproved == true)
+                        await _notificationService.createOvertimeApproveDisapproveNotification(overtime!, APPROVED);
+
+                    if (overtime != null && (overtime.IsLeaderApproved == null && overtime.IsManagerApproved == false))
+                        await _notificationService.createOvertimeApproveDisapproveNotification(overtime!, DISAPPROVED);
+
+                    await context.SaveChangesAsync();
+                    return true;
+                }
+
+                // check if approving/disapproving is projectleader (from notifications)
+                if (_customInputValidation.checkProjectLeaderUser(overtimeRequest.UserId).Result)
+                {
+                    // validate input for project leader case
+                    errors = _customInputValidation.checkLeaderApproveOvertimeRequestInput(overtimeRequest);
+                    if (errors.Count > 0) throw new GraphQLException(errors);
+
+                    // approve/disapprove operation
+                    var notification = await context.OvertimeNotifications.FindAsync(overtimeRequest.NotificationId);
+                    var overtime = await context.Overtimes.FindAsync(notification?.OvertimeId);
+                    var notificationData = notification != null ? JsonConvert.DeserializeObject<dynamic>(notification.Data) : null;
+
+
+                    // if approving project leader doesn't match
+                    var isProjectLeader = _customInputValidation.checkApprovingProjectLeader(overtimeRequest.UserId, overtime!.Id, MultiProjectTypeEnum.OVERTIME).Result;
+                    if (!isProjectLeader) throw new GraphQLException(ErrorBuilder.New().SetMessage(InputValidationMessageEnum.MISMATCH_PROJECT_LEADER).Build());
+
+                    if (overtime != null && isProjectLeader)
+                        overtime.IsLeaderApproved = overtimeRequest.IsApproved;
+
+                    // Update notification data
+                    if (overtimeRequest.IsApproved && notificationData != null) notificationData!.Status = RequestStatus.APPROVED;
+                    if (!overtimeRequest.IsApproved && notificationData != null) notificationData!.Status = RequestStatus.DISAPPROVED;
+
+                    if (notification != null) notification.Data = JsonConvert.SerializeObject(notificationData);
+
+
+                    // create notification
+                    if (overtime != null && overtime.IsManagerApproved == true && overtime.IsLeaderApproved == true)
+                        await _notificationService.createOvertimeApproveDisapproveNotification(overtime!, APPROVED);
+
+                    if (overtime != null && (overtime.IsLeaderApproved == false && overtime.IsManagerApproved == null))
+                        await _notificationService.createOvertimeApproveDisapproveNotification(overtime!, DISAPPROVED);
+                    else if (overtime != null && (overtime.IsLeaderApproved == null && overtime.IsManagerApproved == false))
+                        await _notificationService.createOvertimeApproveDisapproveNotification(overtime!, DISAPPROVED);
+
+                    // end
+                    await context.SaveChangesAsync();
+                    return true;
+                }
+            }
+
+
+            return false;
+        }
+
+        public async Task<bool> ApproveDisapproveLeave(ApproveLeaveUndertimeRequest leaveRequest)
+        {
+            var errors = _customInputValidation.checkApproveLeaveRequestInput(leaveRequest);
+
+            if (errors.Count > 0) throw new GraphQLException(errors);
+
+            // approve/disapprove operation
+            var leave = await Leave_UndertimeApprovalOperation(leaveRequest);
+
+            return true;
+        }
+
+        public async Task<bool> ApproveDisapproveUndertime(ApproveLeaveUndertimeRequest undertimeRequest)
+        {
+            var errors = _customInputValidation.checkApproveUndertimeRequestInput(undertimeRequest);
+
+            if (errors.Count > 0) throw new GraphQLException(errors);
+
+            // approve/disapprove operation
+            var leave = await Leave_UndertimeApprovalOperation(undertimeRequest);
+
+            return true;
+        }
+
+        private async Task<Leave?> Leave_UndertimeApprovalOperation(ApproveLeaveUndertimeRequest request)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                var notification = await context.LeaveNotifications.FindAsync(request.NotificationId);
+                var leave = await context.Leaves.FindAsync(notification?.LeaveId);
+                var notificationData = notification != null ? JsonConvert.DeserializeObject<dynamic>(notification.Data) : null;
+
+                var isManager = _customInputValidation.checkManagerUser(request.UserId).Result;
+                var isProjectLeader = _customInputValidation.checkApprovingProjectLeader(request.UserId, leave!.Id, MultiProjectTypeEnum.LEAVE).Result;
+
+                // if approving manager/project leader doesn't match
+                if (isManager && leave.ManagerId != request.UserId) throw new GraphQLException(ErrorBuilder.New().SetMessage(InputValidationMessageEnum.MISMATCH_MANAGER).Build());
+                if (!isManager && !isProjectLeader) throw new GraphQLException(ErrorBuilder.New().SetMessage(InputValidationMessageEnum.MISMATCH_PROJECT_LEADER).Build());
+
+                // if manager
+                if (leave != null && isManager)
+                    leave.IsManagerApproved = request.IsApproved;
+
+                // if project leader
+                if (leave != null && isProjectLeader)
+                    leave.IsLeaderApproved = request.IsApproved;
+
+                // Update notification data
+                if (request.IsApproved && notificationData != null) notificationData!.Status = RequestStatus.APPROVED;
+                if (!request.IsApproved && notificationData != null) notificationData!.Status = RequestStatus.DISAPPROVED;
+
+                if (notification != null) notification.Data = JsonConvert.SerializeObject(notificationData);
+
+                // create notification
+                if (leave != null && leave.IsManagerApproved == true && leave.IsLeaderApproved == true)
+                    await _notificationService.createLeaveApproveDisapproveNotification(leave!, APPROVED);
+
+                if (leave != null && (leave.IsLeaderApproved == false && leave.IsManagerApproved == null))
+                    await _notificationService.createLeaveApproveDisapproveNotification(leave!, DISAPPROVED);
+                else if (leave != null && (leave.IsLeaderApproved == null && leave.IsManagerApproved == false))
+                    await _notificationService.createLeaveApproveDisapproveNotification(leave!, DISAPPROVED);
+
+                await context.SaveChangesAsync();
+
+                return leave;
+            }
+        }
+    }
+}

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -14,5 +14,6 @@
     <PackageReference Include="HotChocolate.Data.EntityFramework" Version="13.0.2" />
     <PackageReference Include="LiteX.Storage.Local" Version="9.0.0" />
     <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-145
https://framgiaph.backlog.com/view/HRIS-147

## Note
- This is combined PR for Tasks HRIS-145 and HRIS-147

## Definition of Done
- [x] Manager and Project Leaders can approve/disapprove leave and undertime (through notifications)
- [x] Project Leaders can approve/disapprove overtime (through notifications)
- [x] Managers can approve/disapprove overtime (through overtime)
- [x] Create and send notification on approved/disapproved requests

## Pre-condition
- run `docker compose up --build`
- go to `http://localhost:5257/graphql/`
- run these mutations one-by-one, uncomment mutations
```
# Approve/Disapprove overtime (Manager)
mutation($overtimeApprovalManager: ApproveOvertimeRequestInput!){
  approveDisapproveOvertime(approvingData: $overtimeApprovalManager)
}

# Approve/Disapprove overtime (Project Leader)
# mutation($overtimeApprovalLeader: ApproveOvertimeRequestInput!){
#   approveDisapproveOvertime(approvingData: $overtimeApprovalLeader)
# }

# # Approve/Disapparove undertime
# mutation($undertimeApproval: ApproveLeaveUndertimeRequestInput!){
#   approveDisapproveUndertime(approvingData: $undertimeApproval)
# }

# Approve/Disapprove leave
# mutation($leaveApproval: ApproveLeaveUndertimeRequestInput!){
#   approveDisapproveLeave(approvingData: $leaveApproval)
# }

```
- variables, change values using data from your database (note: `userId` is the id of approving leader/manager)
```
{
  "overtimeApprovalManager": {
    "userId": 70,
    "overtimeId": 1018,
    "isApproved": true,
    "approvedMinutes": 123
  },
  "overtimeApprovalLeader": {
    "userId": 2,
    "notificationId": 2076,
    "isApproved": true
  },
  "leaveApproval": {
    "userId": 70,
    "notificationId": 4079,
    "isApproved": true
  },
  "undertimeApproval": {
    "userId": 70,
    "notificationId": 4079,
    "isApproved": true
  }
}
```
- for monitoring of notification sent, uncomment the one you'll monitor (note: `id` is the id of the user that made request)
```
subscription {
    leaveCreated(id: 4) {
      id
      type
      data
      readAt
      isRead
    }
  }

# subscription {
#     overtimeCreated(id: 4) {
#       id
#       type
#       data
#       readAt
#       isRead
#     }
#   }
```

## Expected Output
- `isLeaderApproved` and `isManagerApproved` columns on tables `Overtimes` and `Leaves` should be updated accordingly
- if the request has been approved/disapproved by both manager and project leader, `Notification` should be created and sent to the requesting user

## Screenshots/Recordings
[ApproveDisapprove.webm](https://user-images.githubusercontent.com/111718037/223897436-40d02b36-aa7d-4d39-ab6c-75bb0f1e5395.webm)

