### PR TITLE
HRIS-150 [BE/FE] Implement and Integrate filter list be Pending, Approved and Rejected functionality for My Overtime Page

### DIFF
--- a/api/DTOs/MyOvertimeDTO.cs
+++ b/api/DTOs/MyOvertimeDTO.cs
@@ -1,0 +1,33 @@
+using api.Entities;
+
+namespace api.DTOs
+{
+    public class MyOvertimeDTO : Overtime
+    {
+        public MyOvertimeDTO(Overtime overtimes)
+        {
+            Id = overtimes.Id;
+            Projects = overtimes.MultiProjects;
+            OtherProject = overtimes.OtherProject!;
+            Manager = overtimes.Manager;
+            Supervisor = overtimes.Manager.Name!;
+            DateFiled = overtimes.CreatedAt;
+            Remarks = overtimes.Remarks!;
+            OvertimeDate = overtimes.OvertimeDate;
+            ApprovedMinutes = overtimes.ApprovedMinutes;
+            IsLeaderApproved = overtimes.IsLeaderApproved;
+            IsManagerApproved = overtimes.IsManagerApproved!;
+        }
+        new public int Id { get; set; }
+        public ICollection<MultiProject> Projects { get; set; } = default!;
+        new public string OtherProject { get; set; } = default!;
+        public string Supervisor { get; set; }
+        public DateTime? DateFiled { get; set; }
+        new public string Remarks { get; set; }
+        new public DateTime? OvertimeDate { get; set; }
+        new public int? ApprovedMinutes { get; set; }
+        new public bool? IsLeaderApproved { get; set; }
+        new public bool? IsManagerApproved { get; set; }
+
+    }
+}

--- a/api/Schema/Queries/OvertimeQuery.cs
+++ b/api/Schema/Queries/OvertimeQuery.cs
@@ -1,4 +1,3 @@
-using api.Entities;
 using api.Services;
 
 namespace api.Schema.Queries
@@ -11,7 +10,7 @@ namespace api.Schema.Queries
         {
             _overtimeService = overtimeService;
         }
-        public async Task<List<Overtime>> GetOvertime([Service] OvertimeService _overtimeService, int UserId)
+        public async Task<List<DTOs.MyOvertimeDTO>> GetOvertime(int UserId)
         {
             return await _overtimeService.GetOvertime(UserId);
         }

--- a/api/Services/OvertimeService.cs
+++ b/api/Services/OvertimeService.cs
@@ -71,16 +71,19 @@ namespace api.Services
             return RequestStatus.PENDING;
         }
 
-        public async Task<List<Overtime>> GetOvertime(int UserId)
+        public async Task<List<MyOvertimeDTO>> GetOvertime(int UserId)
         {
             using (HrisContext context = _contextFactory.CreateDbContext())
             {
                 return await context.Overtimes
-                    .Include(i => i.MultiProjects)
-                        .ThenInclude(t => t.ProjectLeader)
-                    .Include(i => i.MultiProjects)
-                        .ThenInclude(t => t.Project)
+                    .Include(x => x.MultiProjects)
+                        .ThenInclude(x => x.Project)
+                    .Include(x => x.MultiProjects)
+                        .ThenInclude(x => x.ProjectLeader)
+                    .Include(x => x.Manager)
+                        .ThenInclude(x => x.Role)
                     .Where(w => w.UserId == UserId)
+                    .Select(x => new MyOvertimeDTO(x))
                     .ToListAsync();
             }
         }

--- a/client/src/components/molecules/MyOvertimeTable/DesktopTable.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/DesktopTable.tsx
@@ -3,10 +3,10 @@ import classNames from 'classnames'
 import { flexRender, Table } from '@tanstack/react-table'
 
 import TableSkeleton from './../SkeletonTable'
-import { IMyOvertime } from '~/utils/interfaces'
+import { IMyOvertimeTable } from '~/utils/interfaces'
 
 type Props = {
-  table: Table<IMyOvertime>
+  table: Table<IMyOvertimeTable>
   isLoading: boolean
   error: unknown
 }

--- a/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
@@ -8,18 +8,14 @@ import { ChevronRight, Eye } from 'react-feather'
 
 import Chip from './Chip'
 import ShowRemarksModal from './ShowRemarksModal'
+import { IMyOvertimeTable } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/Button'
-import { IMyOvertime } from '~/utils/types/overtimeTypes'
+import { decimalFormatter } from '~/utils/myOvertimeHelpers'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import DisclosureTransition from '~/components/templates/DisclosureTransition'
-import {
-  decimalFormatter,
-  getApprovalStatus,
-  getProjectWithNameDisplay
-} from '~/utils/myOvertimeHelpers'
 
 type Props = {
-  table: Table<IMyOvertime>
+  table: Table<IMyOvertimeTable>
   isLoading: boolean
   error: unknown
 }
@@ -59,16 +55,9 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                           <div className="flex items-center justify-between">
                             <div className="flex items-center space-x-2">
                               <span className="font-semibold text-slate-700">
-                                {moment(new Date(row.original.overtimeDate)).format(
-                                  'MMMM DD, YYYY'
-                                )}
+                                {moment(new Date(row.original.date)).format('MMMM DD, YYYY')}
                               </span>
-                              <Chip
-                                label={getApprovalStatus(
-                                  row.original.isLeaderApproved,
-                                  row.original.isManagerApproved
-                                )}
-                              />
+                              <Chip label={row.original.status} />
                             </div>
                             <ChevronRight
                               className={classNames(
@@ -87,30 +76,60 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                           >
                             <ul className="flex flex-col divide-y divide-slate-200">
                               <li className="flex flex-col space-y-2 px-4 py-2.5">
-                                <span>Projects with Leader:</span>
+                                <span>Projects:</span>
                                 <div className="flex flex-wrap items-center space-x-2">
-                                  {row?.original?.multiProjects.map((option, index) => (
-                                    <span
-                                      key={index}
-                                      className="rounded border border-slate-300 bg-slate-50 px-1.5 font-medium"
-                                    >
-                                      {getProjectWithNameDisplay(option, row.original)}
-                                    </span>
-                                  ))}
+                                  {row?.original?.projects.map((option, index) => {
+                                    const projectName = option.project_name.label
+                                    const otherProjects =
+                                      option.project_name.label !== 'Others' &&
+                                      option.project_name.label.split(',')
+
+                                    return (
+                                      <div key={index}>
+                                        <>
+                                          {typeof otherProjects === 'object' &&
+                                          projectName !== '' ? (
+                                            <>
+                                              {otherProjects.map((val, index) => (
+                                                <span
+                                                  key={index}
+                                                  className="rounded border border-slate-300 bg-slate-50 px-1.5 font-medium"
+                                                >
+                                                  {val}
+                                                </span>
+                                              ))}
+                                            </>
+                                          ) : null}
+                                        </>
+                                      </div>
+                                    )
+                                  })}
                                 </div>
                               </li>
                               <li className="px-4 py-2.5">
-                                Date Filed:{' '}
+                                Date:{' '}
                                 <span className="font-semibold">
-                                  {moment(new Date(row.original.overtimeDate)).format(
-                                    'MMMM DD, YYYY'
-                                  )}
+                                  {moment(new Date(row.original.date)).format('MMMM DD, YYYY')}
                                 </span>
                               </li>
                               <li className="px-4 py-2.5">
                                 Requested hours:{' '}
                                 <span className="font-semibold">
-                                  {decimalFormatter(row.original.requestedMinutes)}
+                                  {decimalFormatter(row?.original?.requestedHours)}
+                                </span>
+                              </li>
+                              <li className="px-4 py-2.5">
+                                Supervisor:{' '}
+                                <span className="font-semibold">{row.original.supervisor}</span>
+                              </li>
+                              <li className="px-4 py-2.5">
+                                Approved Minutes:{' '}
+                                <span className="font-semibold">
+                                  {row.original.approvedMinutes ?? (
+                                    <span className="italic text-slate-400">
+                                      (pending approval)
+                                    </span>
+                                  )}
                                 </span>
                               </li>
                               <li className="flex flex-col space-y-2 px-4 py-3">

--- a/client/src/components/molecules/MyOvertimeTable/ShowRemarksModal.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/ShowRemarksModal.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { Eye } from 'react-feather'
 
-import { IMyOvertime } from '~/utils/types/overtimeTypes'
+import { IMyOvertimeTable } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import ModalTemplate from '~/components/templates/ModalTemplate'
 import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
@@ -10,7 +10,7 @@ import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
 type Props = {
   isOpen: boolean
   closeModal: () => void
-  row: IMyOvertime
+  row: IMyOvertimeTable
 }
 
 const ShowRemarksModal: FC<Props> = ({ isOpen, closeModal, row }): JSX.Element => {

--- a/client/src/components/molecules/MyOvertimeTable/index.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/index.tsx
@@ -13,15 +13,15 @@ import DesktopTable from './DesktopTable'
 import FooterTable from './../FooterTable'
 import MobileDisclose from './MobileDisclose'
 import { fuzzyFilter } from '~/utils/fuzzyFilter'
-import { IMyOvertime } from '~/utils/types/overtimeTypes'
+import { IMyOvertimeTable } from '~/utils/interfaces'
 
 type Props = {
   query: {
-    data: IMyOvertime[]
+    data: IMyOvertimeTable[]
     error: unknown
   }
   table: {
-    columns: Array<ColumnDef<IMyOvertime, any>>
+    columns: Array<ColumnDef<IMyOvertimeTable, any>>
     globalFilter: string
     setGlobalFilter: Dispatch<SetStateAction<string>>
   }
@@ -70,7 +70,7 @@ const MyOvertimeTable: FC<Props> = (props): JSX.Element => {
         />
       </div>
       {/* Show on medium size and beyond */}
-      <div className="mx-auto hidden w-full max-w-fit md:block">
+      <div className="mx-auto mb-8 hidden w-full max-w-fit md:block">
         <DesktopTable
           {...{
             table,

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -283,15 +283,26 @@ const Header: FC<Props> = (props): JSX.Element => {
           <div className="inline-flex items-center space-x-4">
             <div className="relative">
               {newNotificationCount > 0 ? (
-                <span
-                  className={classNames(
-                    'shrink-0 rounded-full border border-rose-600 bg-rose-500 !text-[10px] font-semibold text-white',
-                    'absolute -right-1 -top-1 z-50 flex h-4 w-4 select-none items-center justify-center ring-4 ring-white',
-                    newNotificationCount > 9 ? 'px-2 py-0.5' : ' px-1.5'
-                  )}
-                >
-                  {newNotificationCount > 9 ? '9+' : newNotificationCount}
-                </span>
+                <>
+                  <span
+                    className={classNames(
+                      'shrink-0 animate-ping rounded-full border border-rose-600 bg-rose-500 !text-[10px] font-semibold text-white',
+                      'absolute -right-1 -top-1 z-50 flex h-4 w-4 select-none items-center justify-center ring-4 ring-white',
+                      newNotificationCount > 9 ? 'px-2 py-0.5' : ' px-1.5'
+                    )}
+                  >
+                    {newNotificationCount > 9 ? '9+' : newNotificationCount}
+                  </span>
+                  <span
+                    className={classNames(
+                      'shrink-0 rounded-full border border-rose-600 bg-rose-500 !text-[10px] font-semibold text-white',
+                      'absolute -right-1 -top-1 z-50 flex h-4 w-4 select-none items-center justify-center ring-4 ring-white',
+                      newNotificationCount > 9 ? 'px-2 py-0.5' : ' px-1.5'
+                    )}
+                  >
+                    {newNotificationCount > 9 ? '9+' : newNotificationCount}
+                  </span>
+                </>
               ) : null}
               <NotificationPopover
                 className="h-5 w-5 text-slate-400"

--- a/client/src/graphql/queries/overtimeQueries.ts
+++ b/client/src/graphql/queries/overtimeQueries.ts
@@ -4,16 +4,20 @@ export const GET_ALL_OVERTIME_QUERY = gql`
   query ($userId: Int!) {
     overtime(userId: $userId) {
       id
-      multiProjects {
+      projects {
         id
         project {
+          id
           name
         }
         projectLeader {
+          id
           name
         }
       }
       otherProject
+      supervisor
+      dateFiled
       overtimeDate
       requestedMinutes
       approvedMinutes

--- a/client/src/hooks/useOvertimeQuery.ts
+++ b/client/src/hooks/useOvertimeQuery.ts
@@ -1,16 +1,16 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
 
 import { client } from '~/utils/shared/client'
-import { IMyOvertime } from '~/utils/types/overtimeTypes'
+import { IMyOvertimeData } from '~/utils/interfaces'
 import { GET_ALL_OVERTIME_QUERY } from '~/graphql/queries/overtimeQueries'
 
 export const getOvertimeQuery = (
   userId: number
-): UseQueryResult<{ overtime: IMyOvertime[] }, unknown> => {
+): UseQueryResult<{ overtime: IMyOvertimeData[] }, unknown> => {
   const result = useQuery({
     queryKey: ['GET_ALL_OVERTIME_QUERY', userId],
     queryFn: async () => await client.request(GET_ALL_OVERTIME_QUERY, { userId }),
-    select: (data: { overtime: IMyOvertime[] }) => data,
+    select: (data: { overtime: IMyOvertimeData[] }) => data,
     enabled: !isNaN(userId)
   })
   return result

--- a/client/src/pages/my-overtime.tsx
+++ b/client/src/pages/my-overtime.tsx
@@ -1,29 +1,108 @@
+import moment from 'moment'
 import { NextPage } from 'next'
 import classNames from 'classnames'
-import React, { useState } from 'react'
+import { useRouter } from 'next/router'
+import React, { useEffect, useState } from 'react'
 
 import useUserQuery from '~/hooks/useUserQuery'
 import Layout from '~/components/templates/Layout'
+import { IMyOvertimeTable } from '~/utils/interfaces'
 import { getOvertimeQuery } from '~/hooks/useOvertimeQuery'
 import BarsLoadingIcon from '~/utils/icons/BarsLoadingIcon'
+import { getApprovalStatus } from '~/utils/myOvertimeHelpers'
 import MyOvertimeTable from '~/components/molecules/MyOvertimeTable'
 import { columns } from '~/components/molecules/MyOvertimeTable/columns'
 import GlobalSearchFilter from '~/components/molecules/GlobalSearchFilter'
 import YearlyFilterDropdown from '~/components/molecules/MyOvertimeTable/YearlyFilterDropdown'
 
 const MyOverTime: NextPage = (): JSX.Element => {
+  const router = useRouter()
+  const { status, year } = router.query
   const [globalFilter, setGlobalFilter] = useState<string>('')
+  const [filteredData, setFilteredData] = useState<IMyOvertimeTable[]>()
 
   // From User Query Hooks
   const { handleUserQuery } = useUserQuery()
-  const { data: user, isLoading: isUserLoading } = handleUserQuery()
+  const { data: user } = handleUserQuery()
 
   // From Overtime Query Hooks
-  const {
-    data: overtime,
-    isLoading: isOvertimeLoading,
-    error: errorOvertime
-  } = getOvertimeQuery(user?.userById?.id as number)
+  const { data: overtime } = getOvertimeQuery(user?.userById?.id as number)
+
+  useEffect(() => {
+    if (router.isReady && year === undefined && status === undefined) {
+      void router.replace({
+        pathname: router.pathname,
+        query: {
+          status: null,
+          year: new Date().getFullYear().toString()
+        }
+      })
+    }
+  }, [router])
+
+  // Get the Initial Data and Passed through `filteredData` State
+  const getOvertimeMappedData = (): IMyOvertimeTable[] | undefined => {
+    return overtime?.overtime.map((item) => {
+      const [project] = item.projects
+      const mapped: IMyOvertimeTable = {
+        id: item.id,
+        projects: [
+          {
+            project_name: {
+              value: project?.project.id as unknown as string,
+              label: project?.project.name
+            },
+            project_leader: {
+              value: project?.projectLeader.id as unknown as string,
+              label: project?.projectLeader.name
+            }
+          },
+          {
+            project_name: {
+              value: item?.otherProject ?? '',
+              label: item?.otherProject ?? ''
+            },
+            project_leader: {
+              value: 'others',
+              label: 'others'
+            }
+          }
+        ],
+        date: moment(new Date(item.overtimeDate)).format('MMMM DD, YYYY'),
+        requestedHours: item?.requestedMinutes ?? 0,
+        approvedMinutes: item?.approvedMinutes,
+        supervisor: project?.projectLeader.name,
+        dateFiled: moment(new Date(item.dateFiled)).format('MMMM DD, YYYY'),
+        remarks: item.remarks,
+        status: getApprovalStatus(item?.isLeaderApproved, item?.isManagerApproved) as string
+      }
+      return mapped
+    })
+  }
+
+  // For Filtering based on year and status
+  useEffect(() => {
+    const mappedData = getOvertimeMappedData()
+
+    const filteredOvertime = mappedData?.filter((item) => {
+      if (year !== undefined || status !== undefined) {
+        const yearOvertime = new Date(item.date).getFullYear().toString()
+        if (status === '') return yearOvertime === year
+        return yearOvertime === year && item.status === status
+      }
+      return item
+    })
+
+    setFilteredData(filteredOvertime)
+  }, [router.query])
+
+  // Fetched Once and siplay all data
+  useEffect(() => {
+    if (overtime?.overtime !== undefined) {
+      const mappedData = getOvertimeMappedData()
+      setFilteredData(mappedData)
+    }
+  }, [overtime])
 
   return (
     <Layout metaTitle="My Overtime">
@@ -46,12 +125,12 @@ const MyOverTime: NextPage = (): JSX.Element => {
           />
           <YearlyFilterDropdown />
         </header>
-        {!isUserLoading && !isOvertimeLoading && user !== undefined && overtime !== undefined ? (
+        {filteredData !== undefined ? (
           <MyOvertimeTable
             {...{
               query: {
-                data: overtime?.overtime,
-                error: errorOvertime
+                data: filteredData,
+                error: null
               },
               table: {
                 columns,

--- a/client/src/utils/constants/dummyMyOvertimeData.ts
+++ b/client/src/utils/constants/dummyMyOvertimeData.ts
@@ -1,26 +1,215 @@
-import { IMyOvertime } from './../types/overtimeTypes'
+import { IMyOvertimeData } from './../interfaces'
 
-export const dummyMyOvertimeData: IMyOvertime[] = [
+export const dummyMyOvertimeData: IMyOvertimeData[] = [
   {
-    id: 1,
-    multiProjects: [
+    id: 2,
+    projects: [
       {
-        id: 1,
+        id: 6152,
         project: {
-          name: 'Joshua'
+          id: 1,
+          name: 'Admin'
         },
         projectLeader: {
-          name: 'adf'
+          id: 2,
+          name: 'Alvil Balbuena'
+        }
+      },
+      {
+        id: 6153,
+        project: {
+          id: 13,
+          name: 'MetaJobs'
+        },
+        projectLeader: {
+          id: 2,
+          name: 'Alvil Balbuena'
         }
       }
     ],
-    overtimeDate: '2023-02-01 02:34:26.0000000',
-    requestedMinutes: 120,
-    approvedMinutes: 120,
+    otherProject: '',
+    supervisor: 'Daisuke Nishide',
+    dateFiled: '2023-03-07T18:23:12.285+08:00',
+    overtimeDate: '2023-02-17T00:00:00.000+08:00',
+    requestedMinutes: 0,
+    approvedMinutes: null,
     isLeaderApproved: null,
     isManagerApproved: null,
-    remarks:
-      '1 Lorem ipsum dolor, sit amet consectetur adipisicing elit. Odit, id maiores perspiciatis animi assumenda, non laudantium qui doloribus soluta accusamus eaque et voluptate. Porro, explicabo rem fugit vel nisi eligendi.',
-    createdAt: '2023-02-01 02:34:26.0000000'
+    remarks: 'I have overtime sh',
+    createdAt: '2023-03-12T18:03:06.103+08:00'
+  },
+  {
+    id: 1002,
+    projects: [
+      {
+        id: 8138,
+        project: {
+          id: 2,
+          name: 'Casec'
+        },
+        projectLeader: {
+          id: 2,
+          name: 'Alvil Balbuena'
+        }
+      }
+    ],
+    otherProject: '',
+    supervisor: 'Ryan Dupay',
+    dateFiled: '2023-03-09T17:05:03.446+08:00',
+    overtimeDate: '2023-02-21T00:00:00.000+08:00',
+    requestedMinutes: 0,
+    approvedMinutes: null,
+    isLeaderApproved: null,
+    isManagerApproved: null,
+    remarks: 'f aadf asdf',
+    createdAt: '2023-03-12T18:03:06.104+08:00'
+  },
+  {
+    id: 1003,
+    projects: [
+      {
+        id: 8139,
+        project: {
+          id: 17,
+          name: 'Others'
+        },
+        projectLeader: {
+          id: 1,
+          name: 'Abdul Jalil Palala'
+        }
+      }
+    ],
+    otherProject: 'HRIS',
+    supervisor: 'Ryan Dupay',
+    dateFiled: '2023-03-09T17:05:28.380+08:00',
+    overtimeDate: '2023-03-02T00:00:00.000+08:00',
+    requestedMinutes: 0,
+    approvedMinutes: null,
+    isLeaderApproved: null,
+    isManagerApproved: false,
+    remarks: ' af adf',
+    createdAt: '2023-03-12T18:03:06.104+08:00'
+  },
+  {
+    id: 1004,
+    projects: [
+      {
+        id: 8140,
+        project: {
+          id: 17,
+          name: 'Others'
+        },
+        projectLeader: {
+          id: 1,
+          name: 'Abdul Jalil Palala'
+        }
+      }
+    ],
+    otherProject: 'HRIS',
+    supervisor: 'Daisuke Nishide',
+    dateFiled: '2023-03-09T18:27:40.470+08:00',
+    overtimeDate: '2023-03-01T00:00:00.000+08:00',
+    requestedMinutes: 0,
+    approvedMinutes: null,
+    isLeaderApproved: false,
+    isManagerApproved: null,
+    remarks: 'Approved',
+    createdAt: '2023-03-12T18:03:06.104+08:00'
+  },
+  {
+    id: 2002,
+    projects: [
+      {
+        id: 9136,
+        project: {
+          id: 1,
+          name: 'Admin'
+        },
+        projectLeader: {
+          id: 1,
+          name: 'Abdul Jalil Palala'
+        }
+      },
+      {
+        id: 9137,
+        project: {
+          id: 4,
+          name: '01Booster'
+        },
+        projectLeader: {
+          id: 2,
+          name: 'Alvil Balbuena'
+        }
+      },
+      {
+        id: 9138,
+        project: {
+          id: 16,
+          name: 'OsakaMetro'
+        },
+        projectLeader: {
+          id: 1,
+          name: 'Abdul Jalil Palala'
+        }
+      }
+    ],
+    otherProject: '',
+    supervisor: 'Daisuke Nishide',
+    dateFiled: '2023-03-10T15:10:23.423+08:00',
+    overtimeDate: '2023-03-03T00:00:00.000+08:00',
+    requestedMinutes: 0,
+    approvedMinutes: null,
+    isLeaderApproved: true,
+    isManagerApproved: false,
+    remarks: 'asf',
+    createdAt: '2023-03-12T18:03:06.107+08:00'
+  },
+  {
+    id: 2003,
+    projects: [
+      {
+        id: 9139,
+        project: {
+          id: 17,
+          name: 'Others'
+        },
+        projectLeader: {
+          id: 1,
+          name: 'Abdul Jalil Palala'
+        }
+      },
+      {
+        id: 9140,
+        project: {
+          id: 4,
+          name: '01Booster'
+        },
+        projectLeader: {
+          id: 2,
+          name: 'Alvil Balbuena'
+        }
+      },
+      {
+        id: 9141,
+        project: {
+          id: 17,
+          name: 'Others'
+        },
+        projectLeader: {
+          id: 2,
+          name: 'Alvil Balbuena'
+        }
+      }
+    ],
+    otherProject: 'HRIS,Test1',
+    supervisor: 'Ryan Dupay',
+    dateFiled: '2023-03-10T15:13:28.105+08:00',
+    overtimeDate: '2023-03-02T00:00:00.000+08:00',
+    requestedMinutes: 0,
+    approvedMinutes: null,
+    isLeaderApproved: true,
+    isManagerApproved: true,
+    remarks: 'asdf',
+    createdAt: '2023-03-12T18:03:06.107+08:00'
   }
 ]

--- a/client/src/utils/interfaces/index.tsx
+++ b/client/src/utils/interfaces/index.tsx
@@ -37,22 +37,6 @@ export interface IListOfLeave {
   reason: string
 }
 
-export interface IMyOvertime {
-  id: number
-  // eslint-disable-next-line @typescript-eslint/array-type
-  project: {
-    value: string
-    label: string
-  }[]
-  date: string
-  overtimeIn: string
-  overtimeOut: string
-  requestedHours: number
-  supervisor: string
-  dateFiled: string
-  remarks: string
-  status: string
-}
 export interface INotification {
   id: number
   name: string
@@ -117,3 +101,54 @@ export interface IOvertimeManagement {
 export type IOvertimeManagementManager = Required<
   Omit<IOvertimeManagement, 'overtimeIn' | 'overtimeOut' | 'supervisor'>
 >
+
+export interface IMyOvertimeData {
+  id: number
+  projects: Array<{
+    id: number
+    project: {
+      id: number
+      name: string
+    }
+    projectLeader: {
+      id: number
+      name: string
+    }
+  }>
+  otherProject?: string
+  supervisor: string
+  dateFiled: string
+  overtimeDate: string
+  requestedMinutes: number | null
+  approvedMinutes: number | null
+  isLeaderApproved: boolean | null
+  isManagerApproved: boolean | null
+  remarks: string
+  createdAt: string
+}
+
+export interface IMyOvertimeTable {
+  id: number
+  // eslint-disable-next-line @typescript-eslint/array-type
+  projects: {
+    project_name: {
+      label: string
+      value: string
+    }
+    project_leader: {
+      label: string
+      value: string
+    }
+  }[]
+  manager?: {
+    label: string
+    value: string
+  }
+  date: string
+  requestedHours: number
+  approvedMinutes: number | null
+  supervisor: string
+  dateFiled: string
+  remarks: string
+  status: string
+}

--- a/client/src/utils/myOvertimeHelpers.ts
+++ b/client/src/utils/myOvertimeHelpers.ts
@@ -1,5 +1,3 @@
-import { IMultiProject, IMyOvertime } from './types/overtimeTypes'
-
 export const decimalFormatter = (value: number): number => {
   const decimalFormatter = new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 3,
@@ -19,30 +17,13 @@ export const getApprovalStatus = (
   isManagerApproved: boolean | null
 ): ApprovalStatus => {
   switch (true) {
-    case isLeaderApprove === null || isManagerApproved === null:
-      return 'pending'
     case isLeaderApprove === true && isManagerApproved === true:
       return 'approved'
+    case isLeaderApprove === false || isManagerApproved === false:
+      return 'disapproved'
+    case isLeaderApprove === null || isManagerApproved === null:
+      return 'pending'
     default:
       return 'disapproved'
   }
-}
-
-export const getInitialProjectNameAndLeader = (original: IMyOvertime): string => {
-  const projectName = original.multiProjects[0].project?.name ?? ''
-  const projectLeader = original.multiProjects[0].projectLeader?.name ?? ''
-
-  return projectName === 'Others' || original.otherProject !== ''
-    ? `${original.otherProject ?? ''} - ${projectLeader}`
-    : `${projectName} - ${projectLeader}`
-}
-
-export const getProjectWithNameDisplay = (option: IMultiProject, original: IMyOvertime): string => {
-  const projectName = option.project?.name ?? ''
-  const projectLeader = option.projectLeader?.name ?? ''
-  const otherProject = original.otherProject ?? ''
-
-  return projectName === 'Others' || otherProject !== ''
-    ? `${otherProject} - ${projectLeader}`
-    : `${projectName} - ${projectLeader}`
 }


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-150
https://framgiaph.backlog.com/view/HRIS-149

## Definition of Done

- [x] [BE] Created `MyOvertimeDTO` for each overtime properties
- [x] [FE] Refactor MyOvertime columns and tables properties based on the newly created overtime query
- [x] [FE] Implement Filtering based on the `year` and `status` of the overtime

## Notes
- I fixed and added the `supervisor` columns in the table and follow code implementation of sir Nilo

#### I also fixed the previous comments of QA about the Project and Leaders column 
- #116 
- #113 

## Pre-condition
cd `api` && dotnet run watch
cd `client` && `npm run dev`

## Expected Output

- It should now filter the MyOvertime data based on `year` and `status` -> ['pending', 'disapproved', 'approved']

## Screenshots/Recordings
[filtering.webm](https://user-images.githubusercontent.com/108642414/224582831-abd54f48-de67-4488-aba9-fb765158f4a1.webm)
