### PR TITLE
HRIS-160 [BE/FE] Implement and Integrate changes to DTR and My DTR page when there is a leave, undertime and overtime entry

### DIFF
--- a/api/Context/HrisContext.cs
+++ b/api/Context/HrisContext.cs
@@ -60,7 +60,7 @@ public partial class HrisContext : DbContext
             DatabaseSeeder.projects
         );
         modelBuilder.Entity<Media>().HasData(
-            DatabaseSeeder.media
+            DatabaseSeeder.media()
         );
 
         modelBuilder.Entity<MultiProject>().HasData(

--- a/api/DTOs/OvertimeDTO.cs
+++ b/api/DTOs/OvertimeDTO.cs
@@ -9,7 +9,7 @@ namespace api.DTOs
             Id = overtimes.Id;
             Projects = overtimes.MultiProjects;
             OtherProject = overtimes.OtherProject!;
-            User = new(overtimes.User.Id, overtimes.User.Name!, overtimes.User!.Role.Id, overtimes.User.Role.Name!, $"{domain}/static/{overtimes.User.ProfileImage?.CollectionName}/{overtimes.User.ProfileImage?.FileName}");
+            User = new(overtimes.User.Id, overtimes.User.Name!, overtimes.User!.Role.Id, overtimes.User.Role.Name!, $"{domain}/media/{overtimes.User.ProfileImage?.CollectionName}/{overtimes.User.ProfileImage?.FileName}");
             Manager = overtimes.Manager;
             Supervisor = overtimes.Manager.Name!;
             DateFiled = overtimes.CreatedAt;

--- a/api/DTOs/TimeEntriesSummaryDTO.cs
+++ b/api/DTOs/TimeEntriesSummaryDTO.cs
@@ -16,7 +16,7 @@ namespace api.DTOs
 
         // override
         public User User { get; set; }
-        public int Leave { get; set; }
+        public float Leave { get; set; }
         public int Absences { get; set; }
 
         public int? Late { get; set; }
@@ -24,9 +24,9 @@ namespace api.DTOs
         public int? Overtime { get; set; }
 
         // methods
-        public void AddLeave()
+        public void AddLeave(float days)
         {
-            this.Leave++;
+            this.Leave = this.Leave + days;
         }
         public void AddAbsences()
         {

--- a/api/DTOs/TimeEntryDTO.cs
+++ b/api/DTOs/TimeEntryDTO.cs
@@ -1,13 +1,12 @@
 using api.Entities;
+using api.Enums;
 
 namespace api.DTOs
 {
     public class TimeEntryDTO : TimeEntry
     {
         private static readonly int ONTIME = 0;
-        private static readonly string ABSENT = "absent";
-        private static readonly string ONDUTY = "present";
-        public TimeEntryDTO(TimeEntry timeEntry)
+        public TimeEntryDTO(TimeEntry timeEntry, Leave? leave)
         {
             Id = timeEntry.Id;
             UserId = timeEntry.UserId;
@@ -85,13 +84,17 @@ namespace api.DTOs
                 }
             }
 
-            if (timeEntry.TimeIn == null && timeEntry.TimeOut == null)
+            if (leave != null)
             {
-                Status = ABSENT;
+                Status = (leave.LeaveType.Name!).ToLower();
+            }
+            else if (timeEntry.TimeIn == null && timeEntry.TimeOut == null)
+            {
+                Status = WorkStatusEnum.ABSENT;
             }
             else
             {
-                Status = ONDUTY;
+                Status = WorkStatusEnum.ONDUTY;
             }
         }
 

--- a/api/DTOs/UserDTO.cs
+++ b/api/DTOs/UserDTO.cs
@@ -17,7 +17,7 @@ namespace api.DTOs
             EmployeeSchedule = user.EmployeeSchedule;
             Role = user.Role;
             TimeEntry = checkLatestTimeEntry(user);
-            AvatarLink = $"{domain}/static/{user.ProfileImage?.CollectionName}/{user.ProfileImage?.FileName}";
+            AvatarLink = $"{domain}/media/{user.ProfileImage?.CollectionName}/{user.ProfileImage?.FileName}";
         }
         private TimeEntry? checkLatestTimeEntry(User user)
         {

--- a/api/Enums/WorkStatusEnum.cs
+++ b/api/Enums/WorkStatusEnum.cs
@@ -1,0 +1,8 @@
+namespace api.Enums
+{
+    public class WorkStatusEnum
+    {
+        public const string ONDUTY = "present";
+        public const string ABSENT = "absent";
+    }
+}

--- a/api/Migrations/20230315070132_AvatarSeeder.Designer.cs
+++ b/api/Migrations/20230315070132_AvatarSeeder.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
@@ -11,9 +12,11 @@ using api.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(HrisContext))]
-    partial class HrisContextModelSnapshot : ModelSnapshot
+    [Migration("20230315070132_AvatarSeeder")]
+    partial class AvatarSeeder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20230315070132_AvatarSeeder.cs
+++ b/api/Migrations/20230315070132_AvatarSeeder.cs
@@ -1,0 +1,1657 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AvatarSeeder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Medias",
+                columns: new[] { "Id", "CollectionName", "CreatedAt", "FileName", "MimeType", "Name", "TimeId", "UpdatedAt" },
+                values: new object[,]
+                {
+                    { 2, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 3, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 4, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 5, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 6, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 7, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 8, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 9, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 10, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 11, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 12, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 13, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 14, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 15, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 16, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 17, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 18, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 19, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 20, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 21, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 22, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 23, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 24, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 25, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 26, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 27, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 28, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 29, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 30, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 31, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 32, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 33, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 34, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 35, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 36, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 37, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 38, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 39, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 40, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 41, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 42, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 43, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 44, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 45, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 46, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 47, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 48, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 49, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 50, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 51, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 52, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 53, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 54, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 55, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 56, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 57, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 58, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 59, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 60, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 61, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 62, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 63, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 64, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 65, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 66, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 67, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 68, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 69, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 70, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 71, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 72, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 73, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 74, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 75, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 76, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 77, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 78, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 79, "avatar", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "default.png", "image/png", "defaultAvatar", null, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) }
+                });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(4667), new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(4668) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(5668), new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(5669) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(5882), new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(5883) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(5885), new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(5885) });
+
+            migrationBuilder.UpdateData(
+                table: "Notifications",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(7282), new DateTime(2023, 3, 15, 15, 1, 29, 533, DateTimeKind.Local).AddTicks(7283) });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "ProfileImageId",
+                value: 2);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "ProfileImageId",
+                value: 3);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "ProfileImageId",
+                value: 4);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "ProfileImageId",
+                value: 5);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "ProfileImageId",
+                value: 6);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "ProfileImageId",
+                value: 7);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "ProfileImageId",
+                value: 8);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "ProfileImageId",
+                value: 9);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "ProfileImageId",
+                value: 10);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 11,
+                column: "ProfileImageId",
+                value: 11);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 12,
+                column: "ProfileImageId",
+                value: 12);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 13,
+                column: "ProfileImageId",
+                value: 13);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 14,
+                column: "ProfileImageId",
+                value: 14);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 15,
+                column: "ProfileImageId",
+                value: 15);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 16,
+                column: "ProfileImageId",
+                value: 16);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 17,
+                column: "ProfileImageId",
+                value: 17);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 18,
+                column: "ProfileImageId",
+                value: 18);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 19,
+                column: "ProfileImageId",
+                value: 19);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 20,
+                column: "ProfileImageId",
+                value: 20);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 21,
+                column: "ProfileImageId",
+                value: 21);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 22,
+                column: "ProfileImageId",
+                value: 22);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 23,
+                column: "ProfileImageId",
+                value: 23);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 24,
+                column: "ProfileImageId",
+                value: 24);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 25,
+                column: "ProfileImageId",
+                value: 25);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 26,
+                column: "ProfileImageId",
+                value: 26);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 27,
+                column: "ProfileImageId",
+                value: 27);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 28,
+                column: "ProfileImageId",
+                value: 28);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 29,
+                column: "ProfileImageId",
+                value: 29);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 30,
+                column: "ProfileImageId",
+                value: 30);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 31,
+                column: "ProfileImageId",
+                value: 31);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 32,
+                column: "ProfileImageId",
+                value: 32);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 33,
+                column: "ProfileImageId",
+                value: 33);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 34,
+                column: "ProfileImageId",
+                value: 34);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 35,
+                column: "ProfileImageId",
+                value: 35);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 36,
+                column: "ProfileImageId",
+                value: 36);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 37,
+                column: "ProfileImageId",
+                value: 37);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 38,
+                column: "ProfileImageId",
+                value: 38);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 39,
+                column: "ProfileImageId",
+                value: 39);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 40,
+                column: "ProfileImageId",
+                value: 40);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 41,
+                column: "ProfileImageId",
+                value: 41);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 42,
+                column: "ProfileImageId",
+                value: 42);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 43,
+                column: "ProfileImageId",
+                value: 43);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 44,
+                column: "ProfileImageId",
+                value: 44);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 45,
+                column: "ProfileImageId",
+                value: 45);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 46,
+                column: "ProfileImageId",
+                value: 46);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 47,
+                column: "ProfileImageId",
+                value: 47);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 48,
+                column: "ProfileImageId",
+                value: 48);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 49,
+                column: "ProfileImageId",
+                value: 49);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 50,
+                column: "ProfileImageId",
+                value: 50);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 51,
+                column: "ProfileImageId",
+                value: 51);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 52,
+                column: "ProfileImageId",
+                value: 52);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 53,
+                column: "ProfileImageId",
+                value: 53);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 54,
+                column: "ProfileImageId",
+                value: 54);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 55,
+                column: "ProfileImageId",
+                value: 55);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 56,
+                column: "ProfileImageId",
+                value: 56);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 57,
+                column: "ProfileImageId",
+                value: 57);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 58,
+                column: "ProfileImageId",
+                value: 58);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 59,
+                column: "ProfileImageId",
+                value: 59);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 60,
+                column: "ProfileImageId",
+                value: 60);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 61,
+                column: "ProfileImageId",
+                value: 61);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 62,
+                column: "ProfileImageId",
+                value: 62);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 63,
+                column: "ProfileImageId",
+                value: 63);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 64,
+                column: "ProfileImageId",
+                value: 64);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 65,
+                column: "ProfileImageId",
+                value: 65);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 66,
+                column: "ProfileImageId",
+                value: 66);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 67,
+                column: "ProfileImageId",
+                value: 67);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 68,
+                column: "ProfileImageId",
+                value: 68);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 69,
+                column: "ProfileImageId",
+                value: 69);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 70,
+                column: "ProfileImageId",
+                value: 70);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 71,
+                column: "ProfileImageId",
+                value: 71);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 72,
+                column: "ProfileImageId",
+                value: 72);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 73,
+                column: "ProfileImageId",
+                value: 73);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 74,
+                column: "ProfileImageId",
+                value: 74);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 75,
+                column: "ProfileImageId",
+                value: 75);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 76,
+                column: "ProfileImageId",
+                value: 76);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 77,
+                column: "ProfileImageId",
+                value: 77);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 78,
+                column: "ProfileImageId",
+                value: 78);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 79,
+                column: "ProfileImageId",
+                value: 79);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 5);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 6);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 7);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 8);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 9);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 10);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 11);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 12);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 13);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 14);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 15);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 16);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 17);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 18);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 19);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 20);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 21);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 22);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 23);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 24);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 25);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 26);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 27);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 28);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 29);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 30);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 31);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 32);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 33);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 34);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 35);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 36);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 37);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 38);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 39);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 40);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 41);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 42);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 43);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 44);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 45);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 46);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 47);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 48);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 49);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 50);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 51);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 52);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 53);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 54);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 55);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 56);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 57);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 58);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 59);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 60);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 61);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 62);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 63);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 64);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 65);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 66);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 67);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 68);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 69);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 70);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 71);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 72);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 73);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 74);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 75);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 76);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 77);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 78);
+
+            migrationBuilder.DeleteData(
+                table: "Medias",
+                keyColumn: "Id",
+                keyValue: 79);
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(5080), new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(5083) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(7278), new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(7281) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(7685), new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(7686) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(7690), new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(7691) });
+
+            migrationBuilder.UpdateData(
+                table: "Notifications",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(9182), new DateTime(2023, 3, 9, 11, 5, 24, 308, DateTimeKind.Local).AddTicks(9186) });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 11,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 12,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 13,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 14,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 15,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 16,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 17,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 18,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 19,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 20,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 21,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 22,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 23,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 24,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 25,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 26,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 27,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 28,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 29,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 30,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 31,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 32,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 33,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 34,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 35,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 36,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 37,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 38,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 39,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 40,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 41,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 42,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 43,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 44,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 45,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 46,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 47,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 48,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 49,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 50,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 51,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 52,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 53,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 54,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 55,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 56,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 57,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 58,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 59,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 60,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 61,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 62,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 63,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 64,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 65,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 66,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 67,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 68,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 69,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 70,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 71,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 72,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 73,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 74,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 75,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 76,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 77,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 78,
+                column: "ProfileImageId",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 79,
+                column: "ProfileImageId",
+                value: 1);
+        }
+    }
+}

--- a/api/Seeders/DatabaseSeeder.cs
+++ b/api/Seeders/DatabaseSeeder.cs
@@ -5,16 +5,26 @@ namespace api.Seeders
 {
     public static class DatabaseSeeder
     {
-        public static Media media = new Media
+        public static List<Media> media()
         {
-            Id = 1,
-            CollectionName = "avatar",
-            Name = "defaultAvatar",
-            FileName = "default.png",
-            MimeType = "image/png",
-            CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-            UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
-        };
+            var avatars = new List<Media>();
+            for (int i = 1; i < 80; i++)
+            {
+                var newAvatar = new Media
+                {
+                    Id = i,
+                    CollectionName = "avatar",
+                    Name = "defaultAvatar",
+                    FileName = "default.png",
+                    MimeType = "image/png",
+                    CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                    UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+                };
+                avatars.Add(newAvatar);
+            }
+
+            return avatars;
+        }
         public static EmployeeSchedule employeeSchedule = new EmployeeSchedule
         {
             Id = 1,
@@ -134,7 +144,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 1
                 },
                 new User
                 {
@@ -146,7 +156,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 2
                 },
                 new User
                 {
@@ -158,7 +168,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 3
                 },
                 new User
                 {
@@ -170,7 +180,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 4
                 },
                 new User
                 {
@@ -182,7 +192,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 5
                 },
                 new User
                 {
@@ -194,7 +204,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 6
                 },
                 new User
                 {
@@ -206,7 +216,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 7
                 },
                 new User
                 {
@@ -218,7 +228,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 8
                 },
                 new User
                 {
@@ -230,7 +240,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 9
                 },
                 new User
                 {
@@ -242,7 +252,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 10
                 },
                 new User
                 {
@@ -254,7 +264,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 11
                 },
                 new User
                 {
@@ -266,7 +276,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 12
                 },
                 new User
                 {
@@ -278,7 +288,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 13
                 },
                 new User
                 {
@@ -290,7 +300,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 14
                 },
                 new User
                 {
@@ -302,7 +312,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 15
                 },
                 new User
                 {
@@ -314,7 +324,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 16
                 },
                 new User
                 {
@@ -326,7 +336,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 17
                 },
                 new User
                 {
@@ -338,7 +348,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 18
                 },
                 new User
                 {
@@ -350,7 +360,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 19
                 },
                 new User
                 {
@@ -362,7 +372,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 20
                 },
                 new User
                 {
@@ -374,7 +384,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 21
                 },
                 new User
                 {
@@ -386,7 +396,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 22
                 },
                 new User
                 {
@@ -398,7 +408,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 23
                 },
                 new User
                 {
@@ -410,7 +420,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 24
                 },
                 new User
                 {
@@ -422,7 +432,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 25
                 },
                 new User
                 {
@@ -434,7 +444,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 26
                 },
                 new User
                 {
@@ -446,7 +456,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 27
                 },
                 new User
                 {
@@ -458,7 +468,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 28
                 },
                 new User
                 {
@@ -470,7 +480,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 29
                 },
                 new User
                 {
@@ -482,7 +492,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 30
                 },
                 new User
                 {
@@ -494,7 +504,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 31
                 },
                 new User
                 {
@@ -506,7 +516,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 32
                 },
                 new User
                 {
@@ -518,7 +528,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 33
                 },
                 new User
                 {
@@ -530,7 +540,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 34
                 },
                 new User
                 {
@@ -542,7 +552,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 35
                 },
                 new User
                 {
@@ -554,7 +564,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 36
                 },
                 new User
                 {
@@ -566,7 +576,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 37
                 },
                 new User
                 {
@@ -578,7 +588,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 38
                 },
                 new User
                 {
@@ -590,7 +600,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 39
                 },
                 new User
                 {
@@ -602,7 +612,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 40
                 },
                 new User
                 {
@@ -614,7 +624,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 41
                 },
                 new User
                 {
@@ -626,7 +636,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 42
                 },
                 new User
                 {
@@ -638,7 +648,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 43
                 },
                 new User
                 {
@@ -650,7 +660,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 44
                 },
                 new User
                 {
@@ -662,7 +672,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 45
                 },
                 new User
                 {
@@ -674,7 +684,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 46
                 },
                 new User
                 {
@@ -686,7 +696,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 47
                 },
                 new User
                 {
@@ -698,7 +708,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 48
                 },
                 new User
                 {
@@ -710,7 +720,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 49
                 },
                 new User
                 {
@@ -722,7 +732,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 50
                 },
                 new User
                 {
@@ -734,7 +744,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 51
                 },
                 new User
                 {
@@ -746,7 +756,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 52
                 },
                 new User
                 {
@@ -758,7 +768,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 53
                 },
                 new User
                 {
@@ -770,7 +780,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 54
                 },
                 new User
                 {
@@ -782,7 +792,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 55
                 },
                 new User
                 {
@@ -794,7 +804,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 56
                 },
                 new User
                 {
@@ -806,7 +816,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 57
                 },
                 new User
                 {
@@ -818,7 +828,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 58
                 },
                 new User
                 {
@@ -830,7 +840,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 59
                 },
                 new User
                 {
@@ -842,7 +852,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 60
                 },
                 new User
                 {
@@ -854,7 +864,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 61
                 },
                 new User
                 {
@@ -866,7 +876,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 62
                 },
                 new User
                 {
@@ -878,7 +888,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 63
                 },
                 new User
                 {
@@ -890,7 +900,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 64
                 },
                 new User
                 {
@@ -902,7 +912,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 65
                 },
                 new User
                 {
@@ -914,7 +924,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 66
                 },
                 new User
                 {
@@ -926,7 +936,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 67
                 },
                 new User
                 {
@@ -938,7 +948,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 68
                 },
                 new User
                 {
@@ -950,7 +960,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 69
                 },
                 new User
                 {
@@ -962,7 +972,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 70
                 },
                 new User
                 {
@@ -974,7 +984,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 71
                 },
                 new User
                 {
@@ -986,7 +996,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 72
                 },
                 new User
                 {
@@ -998,7 +1008,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 73
                 },
                 new User
                 {
@@ -1010,7 +1020,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 74
                 },
                 new User
                 {
@@ -1022,7 +1032,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 75
                 },
                 new User
                 {
@@ -1034,7 +1044,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 76
                 },
                 new User
                 {
@@ -1046,7 +1056,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 77
                 },
                 new User
                 {
@@ -1058,7 +1068,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 78
                 },
                 new User
                 {
@@ -1070,7 +1080,7 @@ namespace api.Seeders
                     IsOnline = false,
                     CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                     UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
-                    ProfileImageId = media.Id
+                    ProfileImageId = 79
                 },
 
             };

--- a/api/Services/UserService.cs
+++ b/api/Services/UserService.cs
@@ -26,7 +26,7 @@ namespace api.Services
             using (HrisContext context = _contextFactory.CreateDbContext())
             {
                 var avatar = context.Medias.FindAsync(avatarId).Result;
-                var avatarLink = $"{_httpService.getDomainURL()}/static/{avatar?.CollectionName}/{avatar?.FileName}";
+                var avatarLink = $"{_httpService.getDomainURL()}/media/{avatar?.CollectionName}/{avatar?.FileName}";
 
                 return avatarLink;
             }

--- a/client/src/components/atoms/Chip/index.tsx
+++ b/client/src/components/atoms/Chip/index.tsx
@@ -13,13 +13,25 @@ const Chip: FC<Props> = ({ label }): JSX.Element => {
       ? 'border-green-300 bg-green-50 text-green-600'
       : null,
     label === WorkStatus.VACATION_LEAVE.toLowerCase()
-      ? 'border-amber-300 bg-amber-50 text-amber-600'
+      ? 'border-yellow-300 bg-yellow-50 text-yellow-600'
       : null,
     label === WorkStatus.SICK_LEAVE.toLowerCase()
       ? 'border-rose-300 bg-rose-50 text-rose-600'
       : null,
     label === WorkStatus.ABSENT.toLowerCase()
       ? 'border-fuchsia-300 bg-fuchsia-50 text-fuchsia-600'
+      : null,
+    label === WorkStatus.BEREAVEMENT_LEAVE.toLowerCase()
+      ? 'border-gray-300 bg-gray-100 text-gray-600'
+      : null,
+    label === WorkStatus.EMERGENCY_LEAVE.toLowerCase()
+      ? 'border-red-300 bg-red-50 text-red-600'
+      : null,
+    label === WorkStatus.MATERNITY_PATERNITY_LEAVE.toLowerCase()
+      ? 'border-violet-300 bg-violet-50 text-violet-600'
+      : null,
+    label === WorkStatus.UNDERTIME.toLowerCase()
+      ? 'border-amber-300 bg-amber-50 text-amber-600'
       : null
   )
   return <span className={styles}>{label}</span>

--- a/client/src/components/molecules/DTRManagementTable/DesktopTable.tsx
+++ b/client/src/components/molecules/DTRManagementTable/DesktopTable.tsx
@@ -70,10 +70,25 @@ const DesktopTable: FC<Props> = (props): JSX.Element => {
                         className={classNames(
                           'group hover:bg-white hover:shadow-md hover:shadow-slate-200',
                           row.original.status === WorkStatus.VACATION_LEAVE.toLowerCase()
-                            ? 'bg-amber-50 hover:bg-amber-50'
+                            ? 'bg-yellow-50 hover:bg-yellow-50'
                             : '',
                           row.original.status === WorkStatus.ABSENT.toLowerCase()
                             ? 'bg-fuchsia-50 hover:bg-fuchsia-50'
+                            : '',
+                          row.original.status === WorkStatus.SICK_LEAVE.toLowerCase()
+                            ? 'bg-rose-50 hover:bg-rose-50'
+                            : '',
+                          row.original.status === WorkStatus.BEREAVEMENT_LEAVE.toLowerCase()
+                            ? 'bg-gray-50 hover:bg-gray-50'
+                            : '',
+                          row.original.status === WorkStatus.EMERGENCY_LEAVE.toLowerCase()
+                            ? 'bg-red-50 hover:bg-red-50'
+                            : '',
+                          row.original.status === WorkStatus.MATERNITY_PATERNITY_LEAVE.toLowerCase()
+                            ? 'bg-violet-50 hover:bg-violet-50'
+                            : '',
+                          row.original.status === WorkStatus.UNDERTIME.toLowerCase()
+                            ? 'bg-amber-50 hover:bg-amber-50'
                             : ''
                         )}
                       >

--- a/client/src/components/molecules/DTRSummaryTable/columns.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/columns.tsx
@@ -34,8 +34,13 @@ export const columns = [
       </div>
     )
   }),
-  columnHelper.accessor('leave', {
-    header: () => <CellHeader label="Leave" />,
+  columnHelper.display({
+    id: 'id',
+    header: () => <CellHeader label="Leave(days)" />,
+    cell: (props) => {
+      const { original: summary } = props.row
+      return <span>{Number(summary.leave.toFixed(4))}</span>
+    },
     footer: (info) => info.column.id
   }),
   columnHelper.accessor('absences', {
@@ -47,11 +52,11 @@ export const columns = [
     footer: (info) => info.column.id
   }),
   columnHelper.accessor('undertime', {
-    header: () => <CellHeader label="Undertime" />,
+    header: () => <CellHeader label="Undertime(min)" />,
     footer: (info) => info.column.id
   }),
   columnHelper.accessor('overtime', {
-    header: () => <CellHeader label="Overtime" />,
+    header: () => <CellHeader label="Overtime(min)" />,
     footer: (info) => info.column.id
   })
 ]

--- a/client/src/components/molecules/MyDailyTimeRecordTable/DesktopTable.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/DesktopTable.tsx
@@ -65,10 +65,25 @@ const DesktopTable: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
                         className={classNames(
                           'group hover:bg-white hover:shadow-md  hover:shadow-slate-200',
                           row.original.status === WorkStatus.VACATION_LEAVE.toLowerCase()
-                            ? 'bg-amber-50 hover:bg-amber-50'
+                            ? 'bg-yellow-50 hover:bg-yellow-50'
                             : '',
                           row.original.status === WorkStatus.ABSENT.toLowerCase()
                             ? 'bg-fuchsia-50 hover:bg-fuchsia-50'
+                            : '',
+                          row.original.status === WorkStatus.SICK_LEAVE.toLowerCase()
+                            ? 'bg-rose-50 hover:bg-rose-50'
+                            : '',
+                          row.original.status === WorkStatus.BEREAVEMENT_LEAVE.toLowerCase()
+                            ? 'bg-gray-50 hover:bg-gray-50'
+                            : '',
+                          row.original.status === WorkStatus.EMERGENCY_LEAVE.toLowerCase()
+                            ? 'bg-red-50 hover:bg-red-50'
+                            : '',
+                          row.original.status === WorkStatus.MATERNITY_PATERNITY_LEAVE.toLowerCase()
+                            ? 'bg-violet-50 hover:bg-violet-50'
+                            : '',
+                          row.original.status === WorkStatus.UNDERTIME.toLowerCase()
+                            ? 'bg-amber-50 hover:bg-amber-50'
                             : ''
                         )}
                       >

--- a/client/src/utils/constants/work-status.ts
+++ b/client/src/utils/constants/work-status.ts
@@ -1,6 +1,10 @@
 export const WorkStatus = {
-  VACATION_LEAVE: 'Vacation Leave',
   SICK_LEAVE: 'Sick Leave',
+  BEREAVEMENT_LEAVE: 'Bereavement Leave',
+  EMERGENCY_LEAVE: 'Emergency Leave',
+  VACATION_LEAVE: 'Vacation Leave',
+  MATERNITY_PATERNITY_LEAVE: 'Maternity/Paternity Leave',
+  UNDERTIME: 'Undertime',
   ABSENT: 'Absent',
   ON_DUTY: 'Present'
 }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-160

## Definition of Done
- [x] Leave, Absences, Undertime, and Overtime in DTR Summary page now have correct values
- [x] Added more specific Status in MyDTR and DTR Management table.
- [x] Created seeder for default avatar for each user

## Notes
- Seeder for user avatar is just added on this task

## Pre-condition
- copy `deafult.png` from `api/wwwroot/static/avatar` to `api/wwwroot/media/avatar`
- run `docker compose up --build`
- run `dotnet ef database update` in `api` directory
- go to MyDTR and DTR Management Page

## Expected Output
- New values should reflect in Leave, Absences, Undertime and Overtime in DTR tables
- There should be new Status in time entries
- In the DB, there should be new rows in `Media` table for user avatars

## Screenshots/Recordings
- MyDTR
![image](https://user-images.githubusercontent.com/111718037/225492821-7945207f-454f-4fc5-859e-4905f1cd9ee9.png)

- DTR Summary
![image](https://user-images.githubusercontent.com/111718037/225492913-96675be3-08fc-4197-8d21-cbbbfaffd27e.png)

- Media table in DB
![image](https://user-images.githubusercontent.com/111718037/225493073-42c6eb81-c03a-49cc-82ca-33c05330763c.png)
