### PR TITLE
HRIS-174 [BE] Implement approve or disapprove change shift request functionality

### DIFF
--- a/api/Entities/MultiProject.cs
+++ b/api/Entities/MultiProject.cs
@@ -13,6 +13,7 @@ namespace api.Entities
         public int? ProjectLeaderId { get; set; }
         public int? LeaveId { get; set; }
         public int? OvertimeId { get; set; }
+        public int? ChangeShiftRequestId { get; set; }
         public Project Project { get; set; } = default!;
         public User ProjectLeader { get; set; } = default!;
     }

--- a/api/Enums/NotificationTypeEnum.cs
+++ b/api/Enums/NotificationTypeEnum.cs
@@ -9,5 +9,6 @@ namespace api.Enums
         public const string LEAVE_RESOLVED = "leave_resolved";
         public const string OVERTIME_RESOLVED = "overtime_resolved";
         public const string UNDERTIME_RESOLVED = "undertime_resolved";
+        public const string CHANGE_SHIFT_RESOLVED = "change shift_resolved";
     }
 }

--- a/api/Requests/ApproveChangeShiftRequest.cs
+++ b/api/Requests/ApproveChangeShiftRequest.cs
@@ -1,0 +1,9 @@
+namespace api.Requests
+{
+    public class ApproveChangeShiftRequest
+    {
+        public int UserId { get; set; }
+        public int NotificationId { get; set; }
+        public bool IsApproved { get; set; }
+    }
+}

--- a/api/Schema/Mutations/ApprovalMutation.cs
+++ b/api/Schema/Mutations/ApprovalMutation.cs
@@ -70,5 +70,26 @@ namespace api.Schema.Mutations
                 }
             }
         }
+
+        public async Task<bool> ApproveDisapproveChangeShift(ApproveChangeShiftRequest approvingData, [Service] ApprovalService _approvalService, [Service] IDbContextFactory<HrisContext> contextFactory)
+        {
+            using (HrisContext context = contextFactory.CreateDbContext())
+            {
+                try
+                {
+                    using var transaction = context.Database.BeginTransaction();
+
+                    await _approvalService.ApproveDisapproveChangeShift(approvingData);
+
+                    transaction.Commit();
+
+                    return true;
+                }
+                catch (GraphQLException e)
+                {
+                    throw e;
+                }
+            }
+        }
     }
 }

--- a/api/Schema/Mutations/ChangeShiftMutation.cs
+++ b/api/Schema/Mutations/ChangeShiftMutation.cs
@@ -18,12 +18,7 @@ namespace api.Schema.Mutations
                 {
                     using var transaction = context.Database.BeginTransaction();
                     var changeShift = await _changeShiftService.Create(request);
-                    var notificationList = await _notificationService.createChangeShiftRequestNotification(changeShift);
-
-                    notificationList.ForEach(notif =>
-                    {
-                        _notificationService.sendChangeShiftNotificationEvent(notif);
-                    });
+                    await _notificationService.createChangeShiftRequestNotification(changeShift);
 
                     transaction.Commit();
                     return changeShift;

--- a/api/Services/ChangeShiftService.cs
+++ b/api/Services/ChangeShiftService.cs
@@ -65,7 +65,7 @@ namespace api.Services
         public string GetRequestStatus(ChangeShiftRequest request)
         {
             if (request.IsLeaderApproved == true && request.IsManagerApproved == true) return RequestStatus.APPROVED;
-            if (request.IsLeaderApproved == false && request.IsManagerApproved == false) return RequestStatus.DISAPPROVED;
+            if (request.IsLeaderApproved == false || request.IsManagerApproved == false) return RequestStatus.DISAPPROVED;
             return RequestStatus.PENDING;
         }
     }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-174

## Definition of Done
- [x] Manager and Project Leaders can approve/disapprove Change Shift Request through notification

## Pre-condition
- run `docker compose up --build`
- go to `http://localhost:5257/graphql/`
- to approve/disapprove change shift request, run this mutation
```
# Approve/Disapparove change shift
mutation($changeShiftApproval: ApproveChangeShiftRequestInput!){
  approveDisapproveChangeShift(approvingData: $changeShiftApproval)
}

# Variables, (use values from your DB)
{
"changeShiftApproval": {
    "userId": 70,
    "notificationId": 4033,
    "isApproved": true
  }
}
```
- to watch for notifications, run this subscription
```
subscription {
  changeShiftCreated(id: 4) {
    id
    type
    data
    readAt
    isRead
  }
}
```

## Expected Output
- Project Leader/s can approve a change shift request
- Manager will only receive notification for approval if all project leaders have approved.
- Once the manager approved, `StartTime` and `EndTime` in `TimeEntries` table will be updated
- Once the manager approved/dispparoved, notification will be sent to the requesting user

## Screenshots/Recordings
[ApproveDisapproveChangeShiftBE.webm](https://user-images.githubusercontent.com/111718037/228169508-df6b8a7b-e95f-421f-b5ac-c509200a781e.webm)
