### PR TITLE
HRIS-182 [FE] Integrate change schedule as an offset functionality for ESL Teacher

### DIFF
--- a/client/src/components/molecules/FiledOffsetModal/FileOffsetModal.tsx
+++ b/client/src/components/molecules/FiledOffsetModal/FileOffsetModal.tsx
@@ -44,7 +44,7 @@ const FileOffsetModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
   })
 
   // modify custom style control
-  customStyles.control = (provided) => ({
+  customStyles.control = (provided: Record<string, unknown>, state: any): any => ({
     ...provided,
     boxShadow: 'none',
     borderColor: 'none',
@@ -100,7 +100,7 @@ const FileOffsetModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
         isOpen,
         closeModal
       }}
-      className="w-full max-w-[686px] overflow-visible"
+      className="w-full max-w-[686px]"
     >
       <form
         // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
@@ -429,7 +429,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                                   className={menuItemButton}
                                                   onClick={handleIsOpenNewOffsetToggle}
                                                 >
-                                                  <span>ESL Offset Schedule</span>
+                                                  <span>ESL Change Shift </span>
                                                 </button>
                                               </Menu.Item>
                                               <Menu.Item>

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -359,7 +359,7 @@ export const columns = [
                   <>
                     <Menu.Item>
                       <button className={menuItemButton} onClick={handleIsOpenNewOffsetToggle}>
-                        <span>ESL Offset Schedule</span>
+                        <span>ESL Change Shift</span>
                       </button>
                     </Menu.Item>
                     <Menu.Item>

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/ChangeShiftDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/ChangeShiftDetails.tsx
@@ -1,0 +1,48 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const ChangeShiftDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Project: </span>
+        <span className="flex items-center font-medium">{row.project}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time In: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time Out: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Description: </span>
+        <span className="font-medium">{row.description}</span>
+      </li>
+    </>
+  )
+}
+
+export default ChangeShiftDetails

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/ChangeShiftResolved.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/ChangeShiftResolved.tsx
@@ -1,0 +1,48 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const ChangeShiftResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Project: </span>
+        <span className="flex items-center font-medium">{row.project}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time In: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time Out: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Description: </span>
+        <span className="font-medium">{row.description}</span>
+      </li>
+    </>
+  )
+}
+
+export default ChangeShiftResolvedDetails

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/LeaveDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/LeaveDetails.tsx
@@ -1,0 +1,44 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const LeaveDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Project: </span>
+        <span className="flex items-center font-medium">{row.project}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Duration: </span>
+        <span className="flex items-center font-medium">{row.duration}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Remarks: </span>
+        <span className="font-medium">{row.remarks}</span>
+      </li>
+    </>
+  )
+}
+
+export default LeaveDetails

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/LeaveResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/LeaveResolvedDetails.tsx
@@ -1,0 +1,44 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const LeaveResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Project: </span>
+        <span className="flex items-center font-medium">{row.project}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Duration: </span>
+        <span className="flex items-center font-medium">{row.duration}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Remarks: </span>
+        <span className="font-medium">{row.remarks}</span>
+      </li>
+    </>
+  )
+}
+
+export default LeaveResolvedDetails

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/OffsetScheduleDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/OffsetScheduleDetails.tsx
@@ -1,0 +1,44 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const OffsetScheduleDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Requested Time In: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Requested Time Out: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Description: </span>
+        <span className="font-medium">{row.description}</span>
+      </li>
+    </>
+  )
+}
+
+export default OffsetScheduleDetails

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/OvertimeDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/OvertimeDetails.tsx
@@ -1,0 +1,44 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const OvertimeDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Project: </span>
+        <span className="flex items-center font-medium">{row.project}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Duration: </span>
+        <span className="flex items-center font-medium">{row.duration}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Remarks: </span>
+        <span className="font-medium">{row.remarks}</span>
+      </li>
+    </>
+  )
+}
+
+export default OvertimeDetails

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/OvertimeResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/OvertimeResolvedDetails.tsx
@@ -1,0 +1,52 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const OvertimeResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Project: </span>
+        <span className="flex items-center font-medium">{row.project}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Duration: </span>
+        <span className="flex items-center font-medium">{row.duration}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time In: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time Out: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Remarks: </span>
+        <span className="font-medium">{row.remarks}</span>
+      </li>
+    </>
+  )
+}
+
+export default OvertimeResolvedDetails

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/ResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/ResolvedDetails.tsx
@@ -1,0 +1,40 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const ResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Project: </span>
+        <span className="flex items-center font-medium">{row.project}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Remarks: </span>
+        <span className="font-medium">{row.remarks}</span>
+      </li>
+    </>
+  )
+}
+
+export default ResolvedDetails

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/UndertimeDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/UndertimeDetails.tsx
@@ -1,0 +1,44 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const UndertimeDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Project: </span>
+        <span className="flex items-center font-medium">{row.project}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Duration: </span>
+        <span className="flex items-center font-medium">{row.duration}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Remarks: </span>
+        <span className="font-medium">{row.remarks}</span>
+      </li>
+    </>
+  )
+}
+
+export default UndertimeDetails

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/UndertimeResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/UndertimeResolvedDetails.tsx
@@ -1,0 +1,44 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const UndertimeResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Project: </span>
+        <span className="flex items-center font-medium">{row.project}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Duration: </span>
+        <span className="flex items-center font-medium">{row.duration}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Remarks: </span>
+        <span className="font-medium">{row.remarks}</span>
+      </li>
+    </>
+  )
+}
+
+export default UndertimeResolvedDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
@@ -1,20 +1,29 @@
-import moment from 'moment'
 import React, { FC } from 'react'
-import { Check, X } from 'react-feather'
 import { useRouter } from 'next/router'
+import { Check, X } from 'react-feather'
 
 import useLeave from '~/hooks/useLeave'
-import { INotification } from '~/utils/interfaces'
-import Button from '~/components/atoms/Buttons/ButtonAction'
-import ModalTemplate from '~/components/templates/ModalTemplate'
-import { STATUS_OPTIONS } from '~/utils/constants/notificationFilter'
-import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
-import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
+import useOvertime from '~/hooks/useOvertime'
 import { User } from '~/utils/types/userTypes'
 import { Roles } from '~/utils/constants/roles'
-import { NOTIFICATION_TYPE } from '~/utils/constants/notificationTypes'
-import useOvertime from '~/hooks/useOvertime'
+import { INotification } from '~/utils/interfaces'
 import useChangeShift from '~/hooks/useChangeShift'
+import Button from '~/components/atoms/Buttons/ButtonAction'
+import ModalTemplate from '~/components/templates/ModalTemplate'
+import LeaveDetails from './NotificationTypeDetails/LeaveDetails'
+import { STATUS_OPTIONS } from '~/utils/constants/notificationFilter'
+import { NOTIFICATION_TYPE } from '~/utils/constants/notificationTypes'
+import OvertimeDetails from './NotificationTypeDetails/OvertimeDetails'
+import ResolvedDetails from './NotificationTypeDetails/ResolvedDetails'
+import UndertimeDetails from './NotificationTypeDetails/UndertimeDetails'
+import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
+import ChangeShiftDetails from './NotificationTypeDetails/ChangeShiftDetails'
+import LeaveResolvedDetails from './NotificationTypeDetails/LeaveResolvedDetails'
+import OffsetScheduleDetails from './NotificationTypeDetails/OffsetScheduleDetails'
+import ChangeShiftResolvedDetails from './NotificationTypeDetails/ChangeShiftResolved'
+import OvertimeResolvedDetails from './NotificationTypeDetails/OvertimeResolvedDetails'
+import UndertimeResolvedDetails from './NotificationTypeDetails/UndertimeResolvedDetails'
 
 type Props = {
   isOpen: boolean
@@ -113,60 +122,85 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
       />
       <main className="px-8 py-4 text-sm  text-slate-700">
         <ul className="flex flex-col space-y-3 divide-y divide-slate-200">
-          <li className="inline-flex items-center space-x-3">
-            <span className="text-slate-600">Project: </span>
-            <span className="flex items-center font-medium">{row.project}</span>
-          </li>
-          <li className="inline-flex items-center space-x-3 pt-2">
-            <span className="text-slate-600">Date: </span>
-            <span className="flex items-center font-medium">{row.date}</span>
-          </li>
-          {(row.type.toLowerCase() === NOTIFICATION_TYPE.OVERTIME ||
-            row.type.toLowerCase() === NOTIFICATION_TYPE.UNDERTIME ||
-            row.type.toLowerCase() === NOTIFICATION_TYPE.LEAVE ||
-            row.type.toLowerCase() === NOTIFICATION_TYPE.OVERTIME_RESOLVED ||
-            row.type.toLowerCase() === NOTIFICATION_TYPE.UNDERTIME_RESOLVED ||
-            row.type.toLowerCase() === NOTIFICATION_TYPE.LEAVE_RESOLVED) && (
-            <li className="inline-flex items-center space-x-3 pt-2">
-              <span className="text-slate-600">Duration: </span>
-              <span className="flex items-center font-medium">{row.duration}</span>
-            </li>
+          {/* DETAILS FOR OVERTIME DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OVERTIME && (
+            <OvertimeDetails
+              {...{
+                row
+              }}
+            />
           )}
-          {(row.type.toLowerCase() === NOTIFICATION_TYPE.CHANGE_SHIFT ||
-            row.type.toLowerCase() === NOTIFICATION_TYPE.CHANGE_SHIFT_RESOLVED) && (
-            <>
-              <li className="inline-flex items-center space-x-3 pt-2">
-                <span className="text-slate-600">Time In: </span>
-                <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
-              </li>
-              <li className="inline-flex items-center space-x-3 pt-2">
-                <span className="text-slate-600">Time Out: </span>
-                <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
-              </li>
-            </>
+          {/* DETAILS FOR UNDERTIME DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.UNDERTIME && (
+            <UndertimeDetails
+              {...{
+                row
+              }}
+            />
           )}
-          <li className="inline-flex items-center space-x-3 pt-2">
-            <span className="text-slate-600">Date Filed: </span>
-            <span className="flex items-center font-medium">
-              {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-              {moment(new Date(row.dateFiled)).fromNow()}
-            </span>
-          </li>
-          <li className="inline-flex items-center space-x-3 pt-2">
-            <span className="text-slate-600">Status: </span>
-            <span className="flex items-center font-medium">{row.status}</span>
-          </li>
-          {row.type.toLowerCase() === NOTIFICATION_TYPE.CHANGE_SHIFT ||
-          row.type.toLowerCase() === NOTIFICATION_TYPE.CHANGE_SHIFT_RESOLVED ? (
-            <li className="inline-flex flex-col space-y-2 pt-2">
-              <span className="text-slate-600">Description: </span>
-              <span className="font-medium">{row.description}</span>
-            </li>
-          ) : (
-            <li className="inline-flex flex-col space-y-2 pt-2">
-              <span className="text-slate-600">Remarks: </span>
-              <span className="font-medium">{row.remarks}</span>
-            </li>
+          {/* DETAILS FOR LEAVE DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.LEAVE && (
+            <LeaveDetails
+              {...{
+                row
+              }}
+            />
+          )}
+          {/* DETAILS FOR CHANGE SHIFT DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.CHANGE_SHIFT && (
+            <ChangeShiftDetails
+              {...{
+                row
+              }}
+            />
+          )}
+          {/* DETAILS FOR OVERTIME RESOLVED DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OVERTIME_RESOLVED && (
+            <OvertimeResolvedDetails
+              {...{
+                row
+              }}
+            />
+          )}
+          {/* DETAILS FOR UNDERTIME RESOLVED DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.UNDERTIME_RESOLVED && (
+            <UndertimeResolvedDetails
+              {...{
+                row
+              }}
+            />
+          )}
+          {/* DETAILS FOR LEAVE RESOLVED DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.LEAVE_RESOLVED && (
+            <LeaveResolvedDetails
+              {...{
+                row
+              }}
+            />
+          )}
+          {/* DETAILS FOR CHANGE SHIFT RESOLVED DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.CHANGE_SHIFT_RESOLVED && (
+            <ChangeShiftResolvedDetails
+              {...{
+                row
+              }}
+            />
+          )}
+          {/* DETAILS FOR RESOLVED DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.RESOLVED && (
+            <ResolvedDetails
+              {...{
+                row
+              }}
+            />
+          )}
+          {/* DETAILS FOR OFFSET SCHEDULE DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OFFSET_SCHEDULE && (
+            <OffsetScheduleDetails
+              {...{
+                row
+              }}
+            />
           )}
         </ul>
       </main>

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -29,6 +29,7 @@ import {
   getLeaveNotificationSubQuery,
   getOvertimeNotificationSubQuery
 } from '~/graphql/subscriptions/leaveSubscription'
+import { getESLOffsetNotificationSubscription } from '~/graphql/subscriptions/eslOffsetSubscription'
 
 const Tooltip = dynamic(async () => await import('rc-tooltip'), { ssr: false })
 
@@ -189,6 +190,19 @@ const Header: FC<Props> = (props): JSX.Element => {
     clientWebsocket.subscribe(
       {
         query: getChangeShiftNotificationSubQuery(userId)
+      },
+      {
+        next: ({ data }: any) => {
+          void queryClient.invalidateQueries({ queryKey: ['GET_ALL_USER_NOTIFICATION'] })
+        },
+        error: () => null,
+        complete: () => null
+      }
+    )
+
+    clientWebsocket.subscribe(
+      {
+        query: getESLOffsetNotificationSubscription(userId)
       },
       {
         next: ({ data }: any) => {

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -85,7 +85,7 @@ const Header: FC<Props> = (props): JSX.Element => {
         const mapped: INotification = {
           id: notif.id,
           name: parsedData.User.Name,
-          project: parsedData.Projects.join(', '),
+          project: parsedData.Projects?.join(', '),
           type: notif.type.charAt(0).toUpperCase() + notif.type.slice(1),
           specificType: parsedData.Type,
           date: moment(parsedData.DateRequested).format('MMMM D, YYYY'),

--- a/client/src/graphql/mutations/eslOffsetMutation.ts
+++ b/client/src/graphql/mutations/eslOffsetMutation.ts
@@ -1,0 +1,9 @@
+import { gql } from 'graphql-request'
+
+export const CREATE_ESL_OFFSET_MUTATION = gql`
+  mutation ($request: CreateESLChangeShiftRequestInput!) {
+    createESLChangeShift(request: $request) {
+      id
+    }
+  }
+`

--- a/client/src/graphql/queries/UserQuery.ts
+++ b/client/src/graphql/queries/UserQuery.ts
@@ -58,3 +58,12 @@ export const GET_ALL_USERS_QUERY = gql`
     }
   }
 `
+
+export const GET_ALL_ESL_USERS_QUERY = gql`
+  query ($requestingUserId: Int) {
+    allESLUsers(exceptUserId: $requestingUserId) {
+      id
+      name
+    }
+  }
+`

--- a/client/src/graphql/subscriptions/eslOffsetSubscription.ts
+++ b/client/src/graphql/subscriptions/eslOffsetSubscription.ts
@@ -1,0 +1,10 @@
+export const getESLOffsetNotificationSubscription = (id: number): string => `
+  subscription {
+    eslChangeShiftCreated(id: ${id}) {
+      type
+      data
+      readAt
+      isRead
+    }
+  }
+`

--- a/client/src/hooks/useOffsetForESL.ts
+++ b/client/src/hooks/useOffsetForESL.ts
@@ -1,0 +1,34 @@
+import toast from 'react-hot-toast'
+import { useMutation, UseMutationResult } from '@tanstack/react-query'
+
+import { client } from '~/utils/shared/client'
+import { IESLOffsetInput } from '~/utils/interfaces/eslOffsetInterface'
+import { CREATE_ESL_OFFSET_MUTATION } from '~/graphql/mutations/eslOffsetMutation'
+
+type NewOffsetFuncReturnType = UseMutationResult<any, unknown, IESLOffsetInput, unknown>
+
+type HookReturnType = {
+  handleAddNewOffsetMutation: () => NewOffsetFuncReturnType
+}
+
+const useOffsetForESL = (): HookReturnType => {
+  const handleAddNewOffsetMutation = (): NewOffsetFuncReturnType =>
+    useMutation({
+      mutationFn: async (request: IESLOffsetInput) => {
+        return await client.request(CREATE_ESL_OFFSET_MUTATION, { request })
+      },
+      onSuccess: async () => {
+        toast.success('Added New Offset Successfully')
+      },
+      onError: async (err: Error) => {
+        const [errorMessage] = err.message.split(/:\s/, 2)
+        toast.error(errorMessage)
+      }
+    })
+
+  return {
+    handleAddNewOffsetMutation
+  }
+}
+
+export default useOffsetForESL

--- a/client/src/hooks/useUserQuery.ts
+++ b/client/src/hooks/useUserQuery.ts
@@ -1,5 +1,9 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
-import { GET_ALL_USERS_QUERY, GET_USER_QUERY } from '~/graphql/queries/UserQuery'
+import {
+  GET_ALL_ESL_USERS_QUERY,
+  GET_ALL_USERS_QUERY,
+  GET_USER_QUERY
+} from '~/graphql/queries/UserQuery'
 import { client } from '~/utils/shared/client'
 import { User } from '~/utils/types/userTypes'
 import moment from 'moment'
@@ -10,16 +14,28 @@ type handleUserQueryType = UseQueryResult<
   },
   unknown
 >
+
 type handleAllUsersQueryType = UseQueryResult<
   {
     allUsers: User[]
   },
   unknown
 >
+
+type ESLUserReturnType = UseQueryResult<
+  {
+    allESLUsers: Array<Pick<User, 'id' | 'name'>>
+  },
+  unknown
+>
+
 type returnType = {
   handleUserQuery: () => handleUserQueryType
   handleAllUsersQuery: (ready?: boolean) => handleAllUsersQueryType
+  getESLUserQuery: (ready?: boolean) => ESLUserReturnType
 }
+
+// GET SPECIFIC USER
 const useUserQuery = (): returnType => {
   const handleUserQuery = (): handleUserQueryType =>
     useQuery({
@@ -31,6 +47,8 @@ const useUserQuery = (): returnType => {
         }),
       select: (data: { userById: User }) => data
     })
+
+  // GET ALL USERS
   const handleAllUsersQuery = (ready: boolean = true): handleAllUsersQueryType =>
     useQuery({
       queryKey: ['GET_ALL_USERS_QUERY'],
@@ -38,9 +56,21 @@ const useUserQuery = (): returnType => {
       select: (data: { allUsers: User[] }) => data,
       enabled: ready
     })
+
+  // GET ALL ESL USERS
+  const getESLUserQuery = (ready: boolean = true): ESLUserReturnType =>
+    useQuery({
+      queryKey: ['GET_ESL_USERS_QUERY'],
+      queryFn: async () =>
+        await client.request(GET_ALL_ESL_USERS_QUERY, { requestingUserId: null }),
+      select: (data: { allESLUsers: Array<Pick<User, 'id' | 'name'>> }) => data,
+      enabled: ready
+    })
+
   return {
     handleUserQuery,
-    handleAllUsersQuery
+    handleAllUsersQuery,
+    getESLUserQuery
   }
 }
 

--- a/client/src/pages/notifications.tsx
+++ b/client/src/pages/notifications.tsx
@@ -57,7 +57,7 @@ const Notifications: NextPage = (): JSX.Element => {
         const mapped: INotification = {
           id: notif.id,
           name: parsedData.User.Name,
-          project: parsedData.Projects.join(', '),
+          project: parsedData?.Projects?.join(', '),
           type: notif.type.charAt(0).toUpperCase() + notif.type.slice(1),
           specificType: parsedData.Type,
           date: moment(parsedData.DateRequested).format('MMMM D, YYYY'),

--- a/client/src/utils/constants/notificationTypes.ts
+++ b/client/src/utils/constants/notificationTypes.ts
@@ -13,5 +13,6 @@ export const NOTIFICATION_TYPE = {
   UNDERTIME_RESOLVED: 'undertime_resolved',
   LEAVE_RESOLVED: 'leave_resolved',
   CHANGE_SHIFT_RESOLVED: 'change shift_resolved',
-  RESOLVED: 'resolved'
+  RESOLVED: 'resolved',
+  OFFSET_SCHEDULE: 'offset schedule'
 }

--- a/client/src/utils/createLeaveHelpers.ts
+++ b/client/src/utils/createLeaveHelpers.ts
@@ -32,3 +32,11 @@ export const generateNumberOfDaysSelect = (
     return { label: type.value, value: type.value.toString() }
   })
 }
+
+export const generateESLUserSelect = (
+  eslUsers: Array<Pick<User, 'id' | 'name'>>
+): SelectOptionType[] => {
+  return eslUsers?.map((user) => {
+    return { label: user.name, value: user.id.toString() }
+  })
+}

--- a/client/src/utils/interfaces/eslOffsetInterface.ts
+++ b/client/src/utils/interfaces/eslOffsetInterface.ts
@@ -1,0 +1,8 @@
+export interface IESLOffsetInput {
+  userId: number
+  teamLeaderId: number
+  timeEntryId: number
+  timeIn: string
+  timeOut: string
+  description: string
+}


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-182

## Definition of Done
- [x] Created `useOffsetForESL` hooks to handle add action
- [x] Fetched All ESL Users and display it in Team Leader React Select
- [x] Implement Logic to save offset ELS Data 
- [x] Displayed Error Message for the request that is already exist 

## Notes
- Make sure that your position is 5 which is the user position of ESL Teacher to show the dropdown
BE #147 

## Pre-condition
- run `cd client && npm run dev`
- run `cd api && dotnet run watch`
- go to `http://localhost:3000/my-daily-time-record
- to create request click the action dropdown name `ESL Offset Schedule`

## Expected Output
- only ESL Teachers should be able to create request
- after creating a request, a notification should be created and sent to the Team Leader
- the `allESLUsers` data will display in the Team Leaders React Select dropdown list
- ESL Teacher can now be able to request and offset based on the form provided

## Screenshots/Recordings
[recording.webm](https://user-images.githubusercontent.com/108642414/229034773-e53b082f-e9bb-4f7a-a431-0753c42a7a34.webm)
