### PR TITLE
HRIS-176 [BE] Implement approve or disapprove change offset request functionality

### DIFF
--- a/api/Requests/ApproveESLChangeShiftRequest.cs
+++ b/api/Requests/ApproveESLChangeShiftRequest.cs
@@ -1,0 +1,9 @@
+namespace api.Requests
+{
+    public class ApproveESLChangeShiftRequest
+    {
+        public int ManagerId { get; set; }
+        public int NotificationId { get; set; }
+        public bool IsApproved { get; set; }
+    }
+}

--- a/api/Requests/ApproveESLChangeShiftRequest.cs
+++ b/api/Requests/ApproveESLChangeShiftRequest.cs
@@ -2,7 +2,7 @@ namespace api.Requests
 {
     public class ApproveESLChangeShiftRequest
     {
-        public int ManagerId { get; set; }
+        public int TeamLeaderId { get; set; }
         public int NotificationId { get; set; }
         public bool IsApproved { get; set; }
     }

--- a/api/Schema/Mutations/ESLChangeShiftMutation.cs
+++ b/api/Schema/Mutations/ESLChangeShiftMutation.cs
@@ -29,5 +29,24 @@ namespace api.Schema.Mutations
                 }
             }
         }
+
+        public async Task<ESLChangeShiftRequest> ApproveDisapproveESLChangeShiftStatus(ApproveESLChangeShiftRequest request, [Service] ApprovalService _eslChangeShiftStatusService, [Service] IDbContextFactory<HrisContext> contextFactory)
+        {
+            using (HrisContext context = contextFactory.CreateDbContext())
+            {
+                try
+                {
+                    using var transaction = context.Database.BeginTransaction();
+                    var eSLChangeShift = await _eslChangeShiftStatusService.ApproveDisapproveESLChangeShiftStatus(request);
+
+                    transaction.Commit();
+                    return eSLChangeShift;
+                }
+                catch (GraphQLException)
+                {
+                    throw;
+                }
+            }
+        }
     }
 }

--- a/api/Services/ChangeShiftService.cs
+++ b/api/Services/ChangeShiftService.cs
@@ -81,12 +81,5 @@ namespace api.Services
             if (request.IsLeaderApproved == false || request.IsManagerApproved == false) return RequestStatus.DISAPPROVED;
             return RequestStatus.PENDING;
         }
-
-        public string GetESLChangeShiftStatus(ESLChangeShiftRequest request)
-        {
-            if (request.IsLeaderApproved == true) return RequestStatus.APPROVED;
-            if (request.IsLeaderApproved == false) return RequestStatus.DISAPPROVED;
-            return RequestStatus.PENDING;
-        }
     }
 }

--- a/api/Services/ChangeShiftService.cs
+++ b/api/Services/ChangeShiftService.cs
@@ -81,5 +81,12 @@ namespace api.Services
             if (request.IsLeaderApproved == false || request.IsManagerApproved == false) return RequestStatus.DISAPPROVED;
             return RequestStatus.PENDING;
         }
+
+        public string GetESLChangeShiftStatus(ESLChangeShiftRequest request)
+        {
+            if (request.IsLeaderApproved == true) return RequestStatus.APPROVED;
+            if (request.IsLeaderApproved == false) return RequestStatus.DISAPPROVED;
+            return RequestStatus.PENDING;
+        }
     }
 }

--- a/api/Services/NotificationService.cs
+++ b/api/Services/NotificationService.cs
@@ -618,7 +618,7 @@ namespace api.Services
                     DateFiled = (DateTime)request.CreatedAt!,
                     Type = NotificationDataTypeEnum.REQUEST,
                     Description = request.Description,
-                    Status = _changeShiftService.GetESLChangeShiftStatus(request),
+                    Status = _eslChangeShiftService.GetRequestStatus(request),
                 }
                 );
 

--- a/api/Services/NotificationService.cs
+++ b/api/Services/NotificationService.cs
@@ -595,5 +595,48 @@ namespace api.Services
                 { return "There's an error!"; }
             }
         }
+
+        public async Task<ESLChangeShiftNotification> CreateESLChangeShiftStatusRequestNotification(ESLChangeShiftRequest request)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                var user = await context.Users.FindAsync(request.UserId);
+                var timeEntry = await context.TimeEntries.FindAsync(request.TimeEntryId);
+
+
+                var dataToUser = JsonSerializer.Serialize(new ChangeShiftData
+                {
+                    User = new NotificationUser
+                    {
+                        Id = (int)user?.Id!,
+                        Name = user?.Name!,
+                        AvatarLink = _userService.GenerateAvatarLink(user?.ProfileImageId ?? default)
+                    },
+                    RequestedTimeIn = request.TimeIn,
+                    RequestedTimeOut = request.TimeOut,
+                    DateRequested = timeEntry!.Date,
+                    DateFiled = (DateTime)request.CreatedAt!,
+                    Type = NotificationDataTypeEnum.REQUEST,
+                    Description = request.Description,
+                    Status = _changeShiftService.GetESLChangeShiftStatus(request),
+                }
+                );
+
+                // Notification to User
+                var notificationToUser = new ESLChangeShiftNotification
+                {
+                    RecipientId = request.UserId,
+                    ESLChangeShiftRequestId = request.Id,
+                    Type = NotificationTypeEnum.ESL_OFFSET_SCHEDULE,
+                    Data = dataToUser
+                };
+
+                context.ESLChangeShiftNotifications.Add(notificationToUser);
+                sendESLChangeShiftNotificationEvent(notificationToUser);
+
+                await context.SaveChangesAsync();
+                return notificationToUser;
+            }
+        }
     }
 }

--- a/api/Utils/Validation.cs
+++ b/api/Utils/Validation.cs
@@ -416,5 +416,19 @@ namespace api.Utils
 
             return errors;
         }
+
+        public List<IError> ESLChangeShiftStatusRequestInput(ApproveESLChangeShiftRequest request)
+        {
+            var errors = new List<IError>();
+
+            if (!checkUserExist(request.ManagerId))
+                errors.Add(buildError(nameof(request.ManagerId), InputValidationMessageEnum.INVALID_USER));
+
+            if (!(checkManagerUser(request.ManagerId).Result || checkProjectLeaderUser(request.ManagerId).Result)) errors.Add(buildError(nameof(request.ManagerId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
+
+            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.ESL_OFFSET_SCHEDULE).Result) errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
+
+            return errors;
+        }
     }
 }

--- a/api/Utils/Validation.cs
+++ b/api/Utils/Validation.cs
@@ -421,10 +421,11 @@ namespace api.Utils
         {
             var errors = new List<IError>();
 
-            if (!checkUserExist(request.ManagerId))
-                errors.Add(buildError(nameof(request.ManagerId), InputValidationMessageEnum.INVALID_USER));
+            if (!checkUserExist(request.TeamLeaderId))
+                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_USER));
 
-            if (!(checkManagerUser(request.ManagerId).Result || checkProjectLeaderUser(request.ManagerId).Result)) errors.Add(buildError(nameof(request.ManagerId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
+            if (checkNonESLUser(request.TeamLeaderId))
+                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_TEAM_LEADER));
 
             if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.ESL_OFFSET_SCHEDULE).Result) errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
 


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-176

## Definition of Done

- [x] Can Approve / Disapprove change offset request
- [x] New notification will be sent to the user after the approval / disapproval 

## Notes
- BE integration only

## Pre-condition
- There should be an existing ESL Change shift request
- Inside the API directory, run ``` dotnet run ```
- To test:
#### Mutation
```
mutation ($request: ApproveESLChangeShiftRequestInput!) {
  approveDisapproveESLChangeShiftStatus(request: $request){
    id
  }
}
```
#### Sample Variables
```
{
  "request": {
    "managerId" : 57,
    "notificationId" : 2019,
    "isApproved" : true
  }
}
```
#### Notification subscription
```
subscription {
  eslChangeShiftCreated(id: 4) {
    type
    data
    readAt
    isRead
  }
}
```
## Expected Output
- It should alter the Status value inside the Notifications.Data to approved or disapproved
- It should send a notification after the disapproval
- It should alter the StartTime and EndTime inside TimeEntries table

## Screenshots/Recordings

https://user-images.githubusercontent.com/109492180/229072923-08d589d6-05ae-4149-89fb-9746d4e95a27.mp4

