### PR TITLE
HRIS-184 [BugTask] Time in the notification menu and page are not same

### DIFF
--- a/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
@@ -9,7 +9,6 @@ import { ChevronRight, MoreVertical } from 'react-feather'
 
 import Chip from '~/components/atoms/Chip'
 import Avatar from '~/components/atoms/Avatar'
-import FiledOffsetModal from '../FiledOffsetModal'
 import EditTimeEntriesModal from '../EditTimeEntryModal'
 import { ITimeEntry } from '~/utils/types/timeEntryTypes'
 import { WorkStatus } from '~/utils/constants/work-status'
@@ -37,12 +36,9 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
     setUser(name as string)
   }
 
-  const [isOpenFiledOffset, setIsOpenFiledOffset] = useState<boolean>(false)
   const handleIsOpenEditModalToggle = (): void => {
     setIsOpenEditModal(!isOpenEditModal)
   }
-
-  const handleIsOpenFiledOffsetToggle = (): void => setIsOpenFiledOffset(!isOpenFiledOffset)
 
   const menuItemButton = 'px-3 py-2 text-left text-xs hover:text-slate-700 text-slate-500'
   const EMPTY = 'N/A'
@@ -256,20 +252,6 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                         />
                                       ) : null}
 
-                                      {/* This is for Filed Offset Modal */}
-                                      {isOpenFiledOffset ? (
-                                        <FiledOffsetModal
-                                          {...{
-                                            isOpen: isOpenFiledOffset,
-                                            closeModal: handleIsOpenFiledOffsetToggle,
-                                            row: row.original,
-                                            query: {
-                                              isLoading: false,
-                                              isError: false
-                                            }
-                                          }}
-                                        />
-                                      ) : null}
                                       <Tippy
                                         placement="left"
                                         content="Vertical Ellipsis"
@@ -300,14 +282,6 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                               onClick={handleIsOpenEditModalToggle}
                                             >
                                               <span>Edit DTR</span>
-                                            </button>
-                                          </Menu.Item>
-                                          <Menu.Item>
-                                            <button
-                                              className={menuItemButton}
-                                              onClick={handleIsOpenFiledOffsetToggle}
-                                            >
-                                              <span>Filed Offset</span>
                                             </button>
                                           </Menu.Item>
                                         </Menu.Items>

--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -9,7 +9,6 @@ import { createColumnHelper } from '@tanstack/react-table'
 
 import Chip from '~/components/atoms/Chip'
 import Avatar from '~/components/atoms/Avatar'
-import FiledOffsetModal from './../FiledOffsetModal'
 import CellHeader from '~/components/atoms/CellHeader'
 import EditTimeEntriesModal from '../EditTimeEntryModal'
 import { ITimeEntry } from '~/utils/types/timeEntryTypes'
@@ -171,7 +170,6 @@ export const columns = [
       const { original: timeEntry } = props.row
       const [isOpenTimeEntry, setIsOpenTimeEntry] = useState<boolean>(false)
       const [isOpenEditModal, setIsOpenEditModal] = useState<boolean>(false)
-      const [isOpenFiledOffset, setIsOpenFiledOffset] = useState<boolean>(false)
 
       const handleIsOpenTimeEntryToggle = (id?: string | undefined): void => {
         setIsOpenTimeEntry(!isOpenTimeEntry)
@@ -180,8 +178,6 @@ export const columns = [
       const handleIsOpenEditModalToggle = (): void => {
         setIsOpenEditModal(!isOpenEditModal)
       }
-
-      const handleIsOpenFiledOffsetToggle = (): void => setIsOpenFiledOffset(!isOpenFiledOffset)
 
       const menuItemButton = 'px-3 py-2 text-left text-xs hover:text-slate-700 text-slate-500'
 
@@ -220,21 +216,6 @@ export const columns = [
                 }}
               />
             ) : null}
-
-            {/* This is for Filed Offset Modal */}
-            {isOpenFiledOffset ? (
-              <FiledOffsetModal
-                {...{
-                  isOpen: isOpenFiledOffset,
-                  closeModal: handleIsOpenFiledOffsetToggle,
-                  row: props.row.original,
-                  query: {
-                    isLoading: false,
-                    isError: false
-                  }
-                }}
-              />
-            ) : null}
             <Tippy placement="left" content="Vertical Ellipsis" className="!text-xs">
               <Menu.Button className="p-0.5 text-slate-500 outline-none">
                 <MoreVertical className="h-4" />
@@ -258,11 +239,6 @@ export const columns = [
                 <Menu.Item>
                   <button className={menuItemButton} onClick={handleIsOpenEditModalToggle}>
                     <span>Edit DTR</span>
-                  </button>
-                </Menu.Item>
-                <Menu.Item>
-                  <button className={menuItemButton} onClick={handleIsOpenFiledOffsetToggle}>
-                    <span>Filed Offset</span>
                   </button>
                 </Menu.Item>
               </Menu.Items>

--- a/client/src/components/molecules/NotificationList/NotificationItem.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationItem.tsx
@@ -125,14 +125,26 @@ const NotificationItem: FC<Props> = ({ table, isLoading }): JSX.Element => {
                               </span>
                             </p>
                             <p>
-                              {moment(row.original.dateFiled).fromNow()} &bull; {row.original.date}{' '}
-                              -{' '}
                               <span className={`font-medium ${isActive ? 'text-amber-500' : ''}`}>
-                                {row.original.duration}{' '}
                                 {row.original.type.split('_')[0].toLowerCase() ===
-                                NOTIFICATION_TYPE.OVERTIME
-                                  ? 'Mins'
-                                  : 'Hrs'}
+                                NOTIFICATION_TYPE.OVERTIME ? (
+                                  <>
+                                    {moment(row.original.dateFiled).fromNow()} &bull;{' '}
+                                    {row.original.date} -{' '}
+                                    <span className="font-medium">
+                                      {row.original.duration}{' '}
+                                      {row.original.type.split('_')[0].toLowerCase() ===
+                                      NOTIFICATION_TYPE.OVERTIME
+                                        ? 'Mins'
+                                        : 'Hrs'}
+                                    </span>
+                                  </>
+                                ) : (
+                                  <>
+                                    {moment(row.original.dateFiled).fromNow()} &bull;{' '}
+                                    {row.original.date}{' '}
+                                  </>
+                                )}
                               </span>
                             </p>
                           </div>

--- a/client/src/components/molecules/NotificationPopOver/index.tsx
+++ b/client/src/components/molecules/NotificationPopOver/index.tsx
@@ -113,14 +113,21 @@ const NotificationPopover: FC<Props> = (props): JSX.Element => {
                               <span className="font-semibold">{i.type.split('_')[0]} </span>
                             </p>
                             <small>
-                              {moment(new Date(i.dateFiled)).fromNow()} &bull;{' '}
-                              {moment(new Date(i.date)).format('MMM DD, YY')} -{' '}
-                              <span className="font-medium">
-                                {i.duration}{' '}
-                                {i.type.split('_')[0].toLowerCase() === NOTIFICATION_TYPE.OVERTIME
-                                  ? 'Mins'
-                                  : 'Hrs'}
-                              </span>
+                              {moment(i.dateFiled).fromNow()} &bull;{' '}
+                              {i.type.split('_')[0].toLowerCase() === NOTIFICATION_TYPE.OVERTIME ? (
+                                <>
+                                  {moment(new Date(i.date)).format('MMM DD, YY')} -{' '}
+                                  <span className="font-medium">
+                                    {i.duration}{' '}
+                                    {i.type.split('_')[0].toLowerCase() ===
+                                    NOTIFICATION_TYPE.OVERTIME
+                                      ? 'Mins'
+                                      : 'Hrs'}
+                                  </span>
+                                </>
+                              ) : (
+                                <>{moment(new Date(i.date)).format('MMM DD, YY')}</>
+                              )}
                             </small>
                           </div>
                         </Link>

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -92,7 +92,7 @@ const Header: FC<Props> = (props): JSX.Element => {
           date: moment(parsedData.DateRequested).format('MMMM D, YYYY'),
           remarks: parsedData.Remarks,
           duration: getDuration(parsedData, notif.type),
-          dateFiled: moment(parsedData.DateFiled).format('MMMM D, YYYY'),
+          dateFiled: parsedData.DateFiled,
           status: parsedData.Status,
           readAt: notif.readAt,
           isRead: notif.isRead,


### PR DESCRIPTION
## Issue Link

Backlog Link

## Definition of Done

- [x] In the notification menu time differ in the page
- [x] Remove the hr in the notification if change shift
- [x] Filed offset should only display if your ESL


## Pre-condition

run docker 

## Expected Output

In the notification menu time differ in the page
Remove the hr in the notification if change shift
Filed offset should only display if your ESL

## Screenshots/Recordings

- [x] In the notification menu time differ in the page
- [x] Remove the hr in the notification if change shift
![image](https://user-images.githubusercontent.com/109579325/229397233-c118bd52-552a-4b28-9a44-27017433c198.png)

- [x] Filed offset should only display if your ESL
![image](https://user-images.githubusercontent.com/109579325/229397288-fc488fd9-f2bf-4d01-9622-8f88b842fdf5.png)


