### PR TITLE
HRIS-177 [FE] Integrate approve or disapprove change offset request functionality

### DIFF
--- a/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
@@ -11,6 +11,7 @@ import useChangeShift from '~/hooks/useChangeShift'
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import ModalTemplate from '~/components/templates/ModalTemplate'
 import LeaveDetails from './NotificationTypeDetails/LeaveDetails'
+import useOffsetForESL from '~/hooks/useOffsetForESL'
 import { STATUS_OPTIONS } from '~/utils/constants/notificationFilter'
 import { NOTIFICATION_TYPE } from '~/utils/constants/notificationTypes'
 import OvertimeDetails from './NotificationTypeDetails/OvertimeDetails'
@@ -43,6 +44,9 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
 
   const { handleApproveChangeShiftMutation } = useChangeShift()
   const approveDisapproveChangeShiftMutation = handleApproveChangeShiftMutation()
+
+  const { handleApproveEslOffsetMutation } = useOffsetForESL()
+  const approveDisapproveEslOffsetMutation = handleApproveEslOffsetMutation()
 
   const handleClose = (): void => {
     void router.replace({
@@ -94,6 +98,19 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
       approveDisapproveChangeShiftMutation.mutate(
         {
           userId: user.id,
+          notificationId: parseInt(router.query.id as string),
+          isApproved
+        },
+        {
+          onSuccess: () => handleClose()
+        }
+      )
+    }
+
+    if (row.type.toLowerCase() === NOTIFICATION_TYPE.OFFSET_SCHEDULE) {
+      approveDisapproveEslOffsetMutation.mutate(
+        {
+          teamLeaderId: user.id,
           notificationId: parseInt(router.query.id as string),
           isApproved
         },

--- a/client/src/components/molecules/NotificationPopOver/index.tsx
+++ b/client/src/components/molecules/NotificationPopOver/index.tsx
@@ -113,7 +113,7 @@ const NotificationPopover: FC<Props> = (props): JSX.Element => {
                               <span className="font-semibold">{i.type.split('_')[0]} </span>
                             </p>
                             <small>
-                              {moment(i.dateFiled).fromNow()} &bull;{' '}
+                              {moment(i.createdAt).fromNow()} &bull;{' '}
                               {i.type.split('_')[0].toLowerCase() === NOTIFICATION_TYPE.OVERTIME ? (
                                 <>
                                   {moment(new Date(i.date)).format('MMM DD, YY')} -{' '}

--- a/client/src/graphql/mutations/eslOffsetMutation.ts
+++ b/client/src/graphql/mutations/eslOffsetMutation.ts
@@ -7,3 +7,11 @@ export const CREATE_ESL_OFFSET_MUTATION = gql`
     }
   }
 `
+
+export const APROVE_DISAPPROVE_ESL_OFFSET_MUTATION = gql`
+  mutation ($request: ApproveESLChangeShiftRequestInput!) {
+    approveDisapproveESLChangeShiftStatus(request: $request) {
+      id
+    }
+  }
+`

--- a/client/src/hooks/useOffsetForESL.ts
+++ b/client/src/hooks/useOffsetForESL.ts
@@ -2,13 +2,22 @@ import toast from 'react-hot-toast'
 import { useMutation, UseMutationResult } from '@tanstack/react-query'
 
 import { client } from '~/utils/shared/client'
-import { IESLOffsetInput } from '~/utils/interfaces/eslOffsetInterface'
-import { CREATE_ESL_OFFSET_MUTATION } from '~/graphql/mutations/eslOffsetMutation'
+import { IESLOffsetInput, IApproveESLOffsetInput } from '~/utils/interfaces/eslOffsetInterface'
+import {
+  CREATE_ESL_OFFSET_MUTATION,
+  APROVE_DISAPPROVE_ESL_OFFSET_MUTATION
+} from '~/graphql/mutations/eslOffsetMutation'
 
 type NewOffsetFuncReturnType = UseMutationResult<any, unknown, IESLOffsetInput, unknown>
-
+type handleApproveChangeShiftMutationType = UseMutationResult<
+  any,
+  unknown,
+  IApproveESLOffsetInput,
+  unknown
+>
 type HookReturnType = {
   handleAddNewOffsetMutation: () => NewOffsetFuncReturnType
+  handleApproveEslOffsetMutation: () => handleApproveChangeShiftMutationType
 }
 
 const useOffsetForESL = (): HookReturnType => {
@@ -26,8 +35,24 @@ const useOffsetForESL = (): HookReturnType => {
       }
     })
 
+  const handleApproveEslOffsetMutation = (): handleApproveChangeShiftMutationType =>
+    useMutation({
+      mutationFn: async (data: IApproveESLOffsetInput) => {
+        return await client.request(APROVE_DISAPPROVE_ESL_OFFSET_MUTATION, {
+          request: data
+        })
+      },
+      onSuccess: async () => {
+        toast.success('Success!')
+      },
+      onError: async () => {
+        toast.error('Something went wrong')
+      }
+    })
+
   return {
-    handleAddNewOffsetMutation
+    handleAddNewOffsetMutation,
+    handleApproveEslOffsetMutation
   }
 }
 

--- a/client/src/utils/interfaces/eslOffsetInterface.ts
+++ b/client/src/utils/interfaces/eslOffsetInterface.ts
@@ -6,3 +6,9 @@ export interface IESLOffsetInput {
   timeOut: string
   description: string
 }
+
+export interface IApproveESLOffsetInput {
+  teamLeaderId: number
+  notificationId: number
+  isApproved: boolean
+}


### PR DESCRIPTION
## Issue Link

[Backlog Link](https://framgiaph.backlog.com/view/HRIS-177)

## Definition of Done

- [x] ESL Leaders can approve / disapprove ESL Offset request


## Pre-condition

npm run dev, docker run or run docker
Create an offset request as an ESL teacher (Position ID: 5)
Go to the assigned leader that will approve / disapprove offset.
Go to the notifications and approve / disapprove the request.

## Expected Output

ESL Leaders can approve / disapprove filed ESL Offset request of an ESL teacher

## Screenshots/Recordings

Dissaproved
![image](https://user-images.githubusercontent.com/109579325/229454024-28a06c50-fc5c-48d1-8a5a-0a96004f8ad4.png)

Approved
![image](https://user-images.githubusercontent.com/109579325/229454082-a1d37fc2-48ad-4438-af7f-8e4c7b253035.png)

