### PR TITLE
HRIS-184-02 [FE] Readded Filed Offset Modal in DTR Management page

### DIFF
--- a/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/DTRManagementTable/MobileDisclose.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-import Tippy from '@tippyjs/react'
 import classNames from 'classnames'
 import { motion } from 'framer-motion'
 import React, { FC, useState } from 'react'
@@ -9,6 +8,7 @@ import { ChevronRight, MoreVertical } from 'react-feather'
 
 import Chip from '~/components/atoms/Chip'
 import Avatar from '~/components/atoms/Avatar'
+import FiledOffsetModal from '../FiledOffsetModal'
 import EditTimeEntriesModal from '../EditTimeEntryModal'
 import { ITimeEntry } from '~/utils/types/timeEntryTypes'
 import { WorkStatus } from '~/utils/constants/work-status'
@@ -27,6 +27,7 @@ type Props = {
 const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
   const [isOpenTimeEntry, setIsOpenTimeEntry] = useState<boolean>(false)
   const [isOpenEditModal, setIsOpenEditModal] = useState<boolean>(false)
+  const [isOpenFiledOffset, setIsOpenFiledOffset] = useState<boolean>(false)
   const [timeEntryId, setTimeEntryId] = useState<number>(-1)
   const [user, setUser] = useState<string>('')
 
@@ -39,6 +40,8 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
   const handleIsOpenEditModalToggle = (): void => {
     setIsOpenEditModal(!isOpenEditModal)
   }
+
+  const handleIsOpenFiledOffsetToggle = (): void => setIsOpenFiledOffset(!isOpenFiledOffset)
 
   const menuItemButton = 'px-3 py-2 text-left text-xs hover:text-slate-700 text-slate-500'
   const EMPTY = 'N/A'
@@ -252,15 +255,24 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                         />
                                       ) : null}
 
-                                      <Tippy
-                                        placement="left"
-                                        content="Vertical Ellipsis"
-                                        className="!text-xs"
-                                      >
-                                        <Menu.Button className="p-0.5 text-slate-500 outline-none">
-                                          <MoreVertical className="h-4" />
-                                        </Menu.Button>
-                                      </Tippy>
+                                      {/* This is for Filed Offset Modal */}
+                                      {isOpenFiledOffset ? (
+                                        <FiledOffsetModal
+                                          {...{
+                                            isOpen: isOpenFiledOffset,
+                                            closeModal: handleIsOpenFiledOffsetToggle,
+                                            row: row.original,
+                                            query: {
+                                              isLoading: false,
+                                              isError: false
+                                            }
+                                          }}
+                                        />
+                                      ) : null}
+
+                                      <Menu.Button className="p-0.5 text-slate-500 outline-none">
+                                        <MoreVertical className="h-4" />
+                                      </Menu.Button>
                                       <MenuTransition>
                                         <Menu.Items
                                           className={classNames(
@@ -282,6 +294,14 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                               onClick={handleIsOpenEditModalToggle}
                                             >
                                               <span>Edit DTR</span>
+                                            </button>
+                                          </Menu.Item>
+                                          <Menu.Item>
+                                            <button
+                                              className={menuItemButton}
+                                              onClick={handleIsOpenFiledOffsetToggle}
+                                            >
+                                              <span>Filed Offset</span>
                                             </button>
                                           </Menu.Item>
                                         </Menu.Items>

--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -9,6 +9,7 @@ import { createColumnHelper } from '@tanstack/react-table'
 
 import Chip from '~/components/atoms/Chip'
 import Avatar from '~/components/atoms/Avatar'
+import FiledOffsetModal from './../FiledOffsetModal'
 import CellHeader from '~/components/atoms/CellHeader'
 import EditTimeEntriesModal from '../EditTimeEntryModal'
 import { ITimeEntry } from '~/utils/types/timeEntryTypes'
@@ -170,6 +171,7 @@ export const columns = [
       const { original: timeEntry } = props.row
       const [isOpenTimeEntry, setIsOpenTimeEntry] = useState<boolean>(false)
       const [isOpenEditModal, setIsOpenEditModal] = useState<boolean>(false)
+      const [isOpenFiledOffset, setIsOpenFiledOffset] = useState<boolean>(false)
 
       const handleIsOpenTimeEntryToggle = (id?: string | undefined): void => {
         setIsOpenTimeEntry(!isOpenTimeEntry)
@@ -178,6 +180,8 @@ export const columns = [
       const handleIsOpenEditModalToggle = (): void => {
         setIsOpenEditModal(!isOpenEditModal)
       }
+
+      const handleIsOpenFiledOffsetToggle = (): void => setIsOpenFiledOffset(!isOpenFiledOffset)
 
       const menuItemButton = 'px-3 py-2 text-left text-xs hover:text-slate-700 text-slate-500'
 
@@ -216,11 +220,24 @@ export const columns = [
                 }}
               />
             ) : null}
-            <Tippy placement="left" content="Vertical Ellipsis" className="!text-xs">
-              <Menu.Button className="p-0.5 text-slate-500 outline-none">
-                <MoreVertical className="h-4" />
-              </Menu.Button>
-            </Tippy>
+
+            {/* This is for Filed Offset Modal */}
+            {isOpenFiledOffset ? (
+              <FiledOffsetModal
+                {...{
+                  isOpen: isOpenFiledOffset,
+                  closeModal: handleIsOpenFiledOffsetToggle,
+                  row: props.row.original,
+                  query: {
+                    isLoading: false,
+                    isError: false
+                  }
+                }}
+              />
+            ) : null}
+            <Menu.Button className="p-0.5 text-slate-500 outline-none">
+              <MoreVertical className="h-4" />
+            </Menu.Button>
             <MenuTransition>
               <Menu.Items
                 className={classNames(
@@ -239,6 +256,11 @@ export const columns = [
                 <Menu.Item>
                   <button className={menuItemButton} onClick={handleIsOpenEditModalToggle}>
                     <span>Edit DTR</span>
+                  </button>
+                </Menu.Item>
+                <Menu.Item>
+                  <button className={menuItemButton} onClick={handleIsOpenFiledOffsetToggle}>
+                    <span>Filed Offset</span>
                   </button>
                 </Menu.Item>
               </Menu.Items>

--- a/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/MobileDisclose.tsx
@@ -397,15 +397,9 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                           }}
                                         />
                                       ) : null}
-                                      <Tippy
-                                        placement="left"
-                                        content="Vertical Ellipsis"
-                                        className="!text-xs"
-                                      >
-                                        <Menu.Button className="p-0.5 text-slate-500 outline-none">
-                                          <MoreVertical className="h-4" />
-                                        </Menu.Button>
-                                      </Tippy>
+                                      <Menu.Button className="p-0.5 text-slate-500 outline-none">
+                                        <MoreVertical className="h-4" />
+                                      </Menu.Button>
                                       <MenuTransition>
                                         <Menu.Items
                                           className={classNames(

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -335,11 +335,9 @@ export const columns = [
                 }}
               />
             ) : null}
-            <Tippy placement="left" content="Vertical Ellipsis" className="!text-xs">
-              <Menu.Button className="p-0.5 text-slate-500 outline-none">
-                <MoreVertical className="h-4" />
-              </Menu.Button>
-            </Tippy>
+            <Menu.Button className="p-0.5 text-slate-500 outline-none">
+              <MoreVertical className="h-4" />
+            </Menu.Button>
             <MenuTransition>
               <Menu.Items
                 className={classNames(


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-184

## Definition of Done
- [x] Readded previously removed filed offset modal in DTRManagement page
- [x] Remove `Vertical Ellipsis` tooltip in MyDTR and DTRManagement pages

## Notes
- revision PR of #153 

## Pre-condition
- run `docker compose up --build`
- go to `MyDTR`/`DTRManagement` page and click the `Action` menu

## Expected Output
- `Filed Offset` option should be in the option list in `DTRManagement` page
- There should be no `Vertical Ellipsis` tooltip on Action button in MyDTR and DTRManagement pages

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/111718037/229455460-de4bd21d-c021-480a-a5d9-185b6cdd5845.png)
