### PR TITLE
HRIS-180 [FE] Integrate approve or disapprove offset request filed functionality

### DIFF
--- a/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
@@ -48,6 +48,9 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
   const { handleApproveEslOffsetMutation } = useOffsetForESL()
   const approveDisapproveEslOffsetMutation = handleApproveEslOffsetMutation()
 
+  const { handleApproveOffsetMutation } = useOffsetForESL()
+  const approveDisapproveOffsetMutation = handleApproveOffsetMutation()
+
   const handleClose = (): void => {
     void router.replace({
       pathname: '/notifications'
@@ -109,6 +112,19 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
 
     if (row.type.toLowerCase() === NOTIFICATION_TYPE.OFFSET_SCHEDULE) {
       approveDisapproveEslOffsetMutation.mutate(
+        {
+          teamLeaderId: user.id,
+          notificationId: parseInt(router.query.id as string),
+          isApproved
+        },
+        {
+          onSuccess: () => handleClose()
+        }
+      )
+    }
+
+    if (row.type.toLowerCase() === NOTIFICATION_TYPE.OFFSET) {
+      approveDisapproveOffsetMutation.mutate(
         {
           teamLeaderId: user.id,
           notificationId: parseInt(router.query.id as string),

--- a/client/src/graphql/mutations/eslOffsetMutation.ts
+++ b/client/src/graphql/mutations/eslOffsetMutation.ts
@@ -15,3 +15,11 @@ export const APROVE_DISAPPROVE_ESL_OFFSET_MUTATION = gql`
     }
   }
 `
+
+export const APROVE_DISAPPROVE_OFFSET_MUTATION = gql`
+  mutation ($request: ApproveESLChangeShiftRequestInput!) {
+    approveDisapproveChangeOffsetStatus(request: $request) {
+      id
+    }
+  }
+`

--- a/client/src/hooks/useOffsetForESL.ts
+++ b/client/src/hooks/useOffsetForESL.ts
@@ -65,7 +65,7 @@ const useOffsetForESL = (): HookReturnType => {
         })
       },
       onSuccess: async () => {
-        toast.success('Success!')
+        toast.success('Request Approved Successfully!')
       },
       onError: async () => {
         toast.error('Something went wrong')

--- a/client/src/hooks/useOffsetForESL.ts
+++ b/client/src/hooks/useOffsetForESL.ts
@@ -14,7 +14,7 @@ import {
 } from '~/graphql/mutations/eslOffsetMutation'
 
 type NewOffsetFuncReturnType = UseMutationResult<any, unknown, IESLOffsetInput, unknown>
-type handleApproveChangeShiftMutationType = UseMutationResult<
+type ApproveChangeShiftMutationType = UseMutationResult<
   any,
   unknown,
   IApproveESLOffsetInput,
@@ -23,7 +23,7 @@ type handleApproveChangeShiftMutationType = UseMutationResult<
 type handleApproveOffsetMutationType = UseMutationResult<any, unknown, IApproveOffsetInput, unknown>
 type HookReturnType = {
   handleAddNewOffsetMutation: () => NewOffsetFuncReturnType
-  handleApproveEslOffsetMutation: () => handleApproveChangeShiftMutationType
+  handleApproveEslOffsetMutation: () => ApproveChangeShiftMutationType
   handleApproveOffsetMutation: () => handleApproveOffsetMutationType
 }
 
@@ -42,7 +42,7 @@ const useOffsetForESL = (): HookReturnType => {
       }
     })
 
-  const handleApproveEslOffsetMutation = (): handleApproveChangeShiftMutationType =>
+  const handleApproveEslOffsetMutation = (): ApproveChangeShiftMutationType =>
     useMutation({
       mutationFn: async (data: IApproveESLOffsetInput) => {
         return await client.request(APROVE_DISAPPROVE_ESL_OFFSET_MUTATION, {

--- a/client/src/hooks/useOffsetForESL.ts
+++ b/client/src/hooks/useOffsetForESL.ts
@@ -59,9 +59,9 @@ const useOffsetForESL = (): HookReturnType => {
 
   const handleApproveOffsetMutation = (): handleApproveOffsetMutationType =>
     useMutation({
-      mutationFn: async (data: IApproveOffsetInput) => {
+      mutationFn: async (request: IApproveOffsetInput) => {
         return await client.request(APROVE_DISAPPROVE_OFFSET_MUTATION, {
-          request: data
+          request: request
         })
       },
       onSuccess: async () => {

--- a/client/src/hooks/useOffsetForESL.ts
+++ b/client/src/hooks/useOffsetForESL.ts
@@ -2,10 +2,15 @@ import toast from 'react-hot-toast'
 import { useMutation, UseMutationResult } from '@tanstack/react-query'
 
 import { client } from '~/utils/shared/client'
-import { IESLOffsetInput, IApproveESLOffsetInput } from '~/utils/interfaces/eslOffsetInterface'
+import {
+  IESLOffsetInput,
+  IApproveESLOffsetInput,
+  IApproveOffsetInput
+} from '~/utils/interfaces/eslOffsetInterface'
 import {
   CREATE_ESL_OFFSET_MUTATION,
-  APROVE_DISAPPROVE_ESL_OFFSET_MUTATION
+  APROVE_DISAPPROVE_ESL_OFFSET_MUTATION,
+  APROVE_DISAPPROVE_OFFSET_MUTATION
 } from '~/graphql/mutations/eslOffsetMutation'
 
 type NewOffsetFuncReturnType = UseMutationResult<any, unknown, IESLOffsetInput, unknown>
@@ -15,9 +20,11 @@ type handleApproveChangeShiftMutationType = UseMutationResult<
   IApproveESLOffsetInput,
   unknown
 >
+type handleApproveOffsetMutationType = UseMutationResult<any, unknown, IApproveOffsetInput, unknown>
 type HookReturnType = {
   handleAddNewOffsetMutation: () => NewOffsetFuncReturnType
   handleApproveEslOffsetMutation: () => handleApproveChangeShiftMutationType
+  handleApproveOffsetMutation: () => handleApproveOffsetMutationType
 }
 
 const useOffsetForESL = (): HookReturnType => {
@@ -50,9 +57,25 @@ const useOffsetForESL = (): HookReturnType => {
       }
     })
 
+  const handleApproveOffsetMutation = (): handleApproveOffsetMutationType =>
+    useMutation({
+      mutationFn: async (data: IApproveOffsetInput) => {
+        return await client.request(APROVE_DISAPPROVE_OFFSET_MUTATION, {
+          request: data
+        })
+      },
+      onSuccess: async () => {
+        toast.success('Success!')
+      },
+      onError: async () => {
+        toast.error('Something went wrong')
+      }
+    })
+
   return {
     handleAddNewOffsetMutation,
-    handleApproveEslOffsetMutation
+    handleApproveEslOffsetMutation,
+    handleApproveOffsetMutation
   }
 }
 

--- a/client/src/utils/constants/notificationTypes.ts
+++ b/client/src/utils/constants/notificationTypes.ts
@@ -14,5 +14,6 @@ export const NOTIFICATION_TYPE = {
   LEAVE_RESOLVED: 'leave_resolved',
   CHANGE_SHIFT_RESOLVED: 'change shift_resolved',
   RESOLVED: 'resolved',
+  OFFSET: 'offset',
   OFFSET_SCHEDULE: 'offset schedule'
 }

--- a/client/src/utils/interfaces/eslOffsetInterface.ts
+++ b/client/src/utils/interfaces/eslOffsetInterface.ts
@@ -12,3 +12,9 @@ export interface IApproveESLOffsetInput {
   notificationId: number
   isApproved: boolean
 }
+
+export interface IApproveOffsetInput {
+  teamLeaderId: number
+  notificationId: number
+  isApproved: boolean
+}


### PR DESCRIPTION
## Issue Link

[Backlog Link](https://framgiaph.backlog.com/view/HRIS-180)

## Definition of Done

- [x] ESL Team leader can approve/disapprove offset for ESL teachers

## Notes


## Pre-condition

run docker or run your localhost

In your graphql playground input these values to create an offset
```
mutation ($request: CreateESLOffsetRequestInput!) {
  createESLOffset(request: $request){
    id
  }
}
```
```
{
  "request": {
    "userId" : 4,
    "teamLeaderId" : 1,
    "timeEntryId" : 4,
    "timeIn" : "09:00",
    "timeOut" : "14:00",
    "description" : "test description",
    "title": "title 2"
  }
}
```
![image](https://user-images.githubusercontent.com/109579325/229957219-51ca7d30-1b5c-4791-8dbc-7a8333934822.png)

Login with the teamleader you assigned.
![image](https://user-images.githubusercontent.com/109579325/229957240-b144afba-50cf-4e1e-81f5-b69a9897ee2b.png)

Go to the notifications and click on view details

Approve or disapprove the offset.
![image](https://user-images.githubusercontent.com/109579325/229957306-65820310-0265-4183-b2b0-c8e54fd53f86.png)



## Expected Output

ESL Team leader can approve/disapprove offset for ESL teachers

## Screenshots/Recordings

Table Plus data
![image](https://user-images.githubusercontent.com/109579325/229957020-48dab9e6-2abe-49f8-92e0-eb93419042c2.png)

