### PR TITLE
HRIS-183-01 [FE] Fix Notification Offset Resolved Details

### DIFF
--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/OffsetResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/OffsetResolvedDetails.tsx
@@ -4,38 +4,38 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const OffsetResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+const OffsetResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time In: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+        <span className="flex items-center font-medium">{notification.requestedTimeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time Out: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+        <span className="flex items-center font-medium">{notification.requestedTimeOut}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{notification.date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(notification.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(notification.dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{notification.status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>
-        <span className="font-medium">{row.description}</span>
+        <span className="font-medium">{notification.description}</span>
       </li>
     </>
   )

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/OffsetResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/OffsetResolvedDetails.tsx
@@ -1,0 +1,44 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  row: INotification
+}
+
+const OffsetResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Requested Time In: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Requested Time Out: </span>
+        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{row.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(row.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{row.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Description: </span>
+        <span className="font-medium">{row.description}</span>
+      </li>
+    </>
+  )
+}
+
+export default OffsetResolvedDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
@@ -249,7 +249,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OFFSET_RESOLVED && (
             <OffsetResolvedDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
@@ -23,6 +23,7 @@ import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
 import ChangeShiftDetails from './NotificationTypeDetails/ChangeShiftDetails'
 import LeaveResolvedDetails from './NotificationTypeDetails/LeaveResolvedDetails'
 import OffsetScheduleDetails from './NotificationTypeDetails/OffsetScheduleDetails'
+import OffsetResolvedDetails from './NotificationTypeDetails/OffsetResolvedDetails'
 import ChangeShiftResolvedDetails from './NotificationTypeDetails/ChangeShiftResolved'
 import OvertimeResolvedDetails from './NotificationTypeDetails/OvertimeResolvedDetails'
 import UndertimeResolvedDetails from './NotificationTypeDetails/UndertimeResolvedDetails'
@@ -239,6 +240,14 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {/* DETAILS FOR OFFSET DATA */}
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OFFSET && (
             <OffsetDetails
+              {...{
+                row
+              }}
+            />
+          )}
+          {/* DETAILS FOR OFFSET RESOLVED DATA */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OFFSET_RESOLVED && (
+            <OffsetResolvedDetails
               {...{
                 row
               }}

--- a/client/src/utils/constants/notificationTypes.ts
+++ b/client/src/utils/constants/notificationTypes.ts
@@ -15,5 +15,6 @@ export const NOTIFICATION_TYPE = {
   CHANGE_SHIFT_RESOLVED: 'change shift_resolved',
   RESOLVED: 'resolved',
   OFFSET_SCHEDULE: 'offset schedule',
-  OFFSET: 'offset'
+  OFFSET: 'offset',
+  OFFSET_RESOLVED: 'offset_resolved'
 }


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-183

## Definition of Done

- [x] Created newly separated OffsetResolvedDetails Component 
- [x] Display Details based on the types of data 

## Notes

- Revision task #158 

## Pre-condition

- run `client && npm run dev`
- run `api && dotnet run watch`

## Expected Output

- A recipient will now be able to view the details of Offset Resolved Details  

## Screenshots/Recordings
[notifOffset.webm](https://user-images.githubusercontent.com/108642414/230042120-21514174-3623-4db4-8980-609fe20cf4cd.webm)


