### PR TITLE
HRIS-186 [BE] Implement view filed change shift for ESL and Non-ESL functionality

### DIFF
--- a/api/DTOs/ChangeShiftDTO.cs
+++ b/api/DTOs/ChangeShiftDTO.cs
@@ -1,0 +1,27 @@
+using api.Entities;
+
+namespace api.DTOs
+{
+    public class ChangeShiftDTO : ChangeShiftRequest
+    {
+        public new string TimeIn { get; set; } = default!;
+        public new string TimeOut { get; set; } = default!;
+        public ChangeShiftDTO(ChangeShiftRequest changeShift)
+        {
+            Id = changeShift.Id;
+            UserId = changeShift.UserId;
+            TimeEntryId = changeShift.TimeEntryId;
+            ManagerId = changeShift.ManagerId;
+            TimeIn = changeShift.TimeIn.ToString(@"hh\:mm");
+            TimeOut = changeShift.TimeOut.ToString(@"hh\:mm");
+            OtherProject = changeShift.OtherProject;
+            Description = changeShift.Description;
+            IsManagerApproved = changeShift.IsLeaderApproved;
+            IsLeaderApproved = changeShift.IsLeaderApproved;
+            User = changeShift.User;
+            Manager = changeShift.Manager;
+            TimeEntry = changeShift.TimeEntry;
+            MultiProjects = changeShift.MultiProjects;
+        }
+    }
+}

--- a/api/DTOs/ESLChangeShiftDTO.cs
+++ b/api/DTOs/ESLChangeShiftDTO.cs
@@ -1,0 +1,24 @@
+using api.Entities;
+
+namespace api.DTOs
+{
+    public class ESLChangeShiftDTO : ESLChangeShiftRequest
+    {
+        public new string TimeIn { get; set; } = default!;
+        public new string TimeOut { get; set; } = default!;
+        public ESLChangeShiftDTO(ESLChangeShiftRequest changeShift)
+        {
+            Id = changeShift.Id;
+            UserId = changeShift.UserId;
+            TimeEntryId = changeShift.TimeEntryId;
+            TeamLeaderId = changeShift.TeamLeaderId;
+            TimeIn = changeShift.TimeIn.ToString(@"hh\:mm");
+            TimeOut = changeShift.TimeOut.ToString(@"hh\:mm");
+            Description = changeShift.Description;
+            IsLeaderApproved = changeShift.IsLeaderApproved;
+            User = changeShift.User;
+            TeamLeader = changeShift.TeamLeader;
+            TimeEntry = changeShift.TimeEntry;
+        }
+    }
+}

--- a/api/DTOs/TimeEntryDTO.cs
+++ b/api/DTOs/TimeEntryDTO.cs
@@ -6,7 +6,7 @@ namespace api.DTOs
     public class TimeEntryDTO : TimeEntry
     {
         private static readonly int ONTIME = 0;
-        public TimeEntryDTO(TimeEntry timeEntry, Leave? leave, string domain)
+        public TimeEntryDTO(TimeEntry timeEntry, Leave? leave, string domain, ChangeShiftRequest? changeShift, ESLChangeShiftRequest? eslChangeShift)
         {
             Id = timeEntry.Id;
             UserId = timeEntry.UserId;
@@ -14,6 +14,7 @@ namespace api.DTOs
             TimeOutId = timeEntry.TimeOutId;
             StartTime = timeEntry.StartTime.ToString(@"hh\:mm");
             EndTime = timeEntry.EndTime.ToString(@"hh\:mm");
+
             Date = DateOnly.FromDateTime(timeEntry.Date);
             WorkedHours = timeEntry.WorkedHours?.Remove(timeEntry.WorkedHours.LastIndexOf(':'));
             TrackedHours = timeEntry.TrackedHours.ToString(@"hh\:mm");
@@ -23,6 +24,8 @@ namespace api.DTOs
             Overtime = timeEntry.Overtime;   // Overtime Entity
             Undertime = 0;
             Late = 0;
+            ChangeShift = changeShift != null ? new ChangeShiftDTO(changeShift) : null;
+            ESLChangeShift = eslChangeShift != null ? new ESLChangeShiftDTO(eslChangeShift) : null;
 
             TimeSpan noonBreakStart = new TimeSpan(12, 0, 0);
             TimeSpan noonBreakEnd = new TimeSpan(13, 0, 0);
@@ -112,5 +115,7 @@ namespace api.DTOs
         public int Undertime { get; set; }
 
         public string Status { get; set; }
+        public ChangeShiftDTO? ChangeShift { get; set; }
+        public ESLChangeShiftDTO? ESLChangeShift { get; set; }
     }
 }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-186

## Definition of Done
- [x] Created DTOs for `ChangeShift` and `ESLChangeShift`
- [x] Added ChangeShift (ESL and Non-ESL) in time entry by employee query (in MyDTR)

## Pre-condition
- run `docker compose up --build`
- go to `http://localhost:5257/graphql/`
- run query
```
query ($id: Int!) {
    timeEntriesByEmployeeId(id: $id) {
      id
      date
      timeIn {
        id
        timeHour
        remarks
        createdAt
      }
      timeOut {
        id
        timeHour
        remarks
        createdAt
      }
      startTime
      endTime
      workedHours
      trackedHours
      late
      undertime
      overtime {
        requestedMinutes
        approvedMinutes
        isLeaderApproved
        isManagerApproved
      }
      status
      changeShift{
        id
        manager{
          name
        }
        timeIn
        timeOut
        description
      }
      eslChangeShift{
        id
        teamLeader{
          name
        }
        timeIn
        timeOut
        description
      }
    }
  }
}

#Variable
{
  "id":4
}
```

## Expected Output
- There should be `changeShift` and `eslChangeShift` in the time entry query result

## Screenshots/Recordings
- Sample Query
![image](https://user-images.githubusercontent.com/111718037/231072391-4a21c5b7-076a-4919-a945-2bdf6b9e6f3d.png)
