### PR TITLE
HRIS-187 [FE] Integrate view filed change shift for ESL and Non-ESL functionality

### DIFF
--- a/client/src/components/molecules/InterruptionTimeEntriesModal/index.tsx
+++ b/client/src/components/molecules/InterruptionTimeEntriesModal/index.tsx
@@ -26,12 +26,9 @@ type Props = {
   closeModal: () => void
 }
 
-const InterruptionTimeEntriesModal: FC<Props> = ({
-  isOpen,
-  closeModal,
-  user,
-  timeEntryId
-}): JSX.Element => {
+const InterruptionTimeEntriesModal: FC<Props> = (props): JSX.Element => {
+  const { isOpen, closeModal, user, timeEntryId } = props
+
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState<string>('')
   const { handleGetAllWorkInterruptionsQuery } = useInterruptionType()

--- a/client/src/components/molecules/MyDailyTimeRecordTable/ChangeShiftRequestModal.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/ChangeShiftRequestModal.tsx
@@ -1,3 +1,4 @@
+import toast from 'react-hot-toast'
 import classNames from 'classnames'
 import isEmpty from 'lodash/isEmpty'
 import ReactSelect from 'react-select'
@@ -14,6 +15,7 @@ import useProject from '~/hooks/useProject'
 import Input from '~/components/atoms/Input'
 import { Roles } from '~/utils/constants/roles'
 import useUserQuery from '~/hooks/useUserQuery'
+import { queryClient } from '~/lib/queryClient'
 import useChangeShift from '~/hooks/useChangeShift'
 import SpinnerIcon from '~/utils/icons/SpinnerIcon'
 import { User as UserType } from '~/utils/types/userTypes'
@@ -130,10 +132,14 @@ const ChangeShiftRequestModal: FC<Props> = ({ isOpen, timeEntry, closeModal }): 
         },
         {
           onSuccess: () => {
-            closeModal()
-          },
-          onSettled: () => {
-            resolve()
+            void queryClient
+              .invalidateQueries({ queryKey: ['GET_EMPLOYEE_TIMESHEET'] })
+              .then(() => {
+                handleReset()
+                closeModal()
+                resolve()
+                toast.success('Change Shift Request Successfully')
+              })
           }
         }
       )

--- a/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/ChangeShiftDetails.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/ChangeShiftDetails.tsx
@@ -3,27 +3,34 @@ import React, { FC } from 'react'
 import { IChangeShift } from '~/utils/types/timeEntryTypes'
 
 type Props = {
-  timeEntry: IChangeShift | undefined
+  changeShift: IChangeShift
 }
 
-const ChangeShiftDetails: FC<Props> = ({ timeEntry }): JSX.Element => {
+const ChangeShiftDetails: FC<Props> = ({ changeShift }): JSX.Element => {
+  const {
+    manager: { name },
+    timeIn,
+    timeOut,
+    description
+  } = changeShift
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Manager: </span>
-        <span className="flex items-center font-medium">{timeEntry?.manager.name}</span>
+        <span className="flex items-center font-medium">{name}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time In: </span>
-        <span className="flex items-center font-medium">{timeEntry?.timeIn}</span>
+        <span className="flex items-center font-medium">{timeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time Out: </span>
-        <span className="flex items-center font-medium">{timeEntry?.timeOut}</span>
+        <span className="flex items-center font-medium">{timeOut}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>
-        <span className="font-medium">{timeEntry?.description}</span>
+        <span className="font-medium">{description}</span>
       </li>
     </>
   )

--- a/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/ChangeShiftDetails.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/ChangeShiftDetails.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react'
+
+import { IChangeShift } from '~/utils/types/timeEntryTypes'
+
+type Props = {
+  timeEntry: IChangeShift | undefined
+}
+
+const ChangeShiftDetails: FC<Props> = ({ timeEntry }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Manager: </span>
+        <span className="flex items-center font-medium">{timeEntry?.manager.name}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time In: </span>
+        <span className="flex items-center font-medium">{timeEntry?.timeIn}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time Out: </span>
+        <span className="flex items-center font-medium">{timeEntry?.timeOut}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Description: </span>
+        <span className="font-medium">{timeEntry?.description}</span>
+      </li>
+    </>
+  )
+}
+
+export default ChangeShiftDetails

--- a/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/ESLChangeShiftDetails.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/ESLChangeShiftDetails.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react'
+
+import { IESLChangeShift } from '~/utils/types/timeEntryTypes'
+
+type Props = {
+  timeEntry: IESLChangeShift | undefined
+}
+
+const ESLChangeShiftDetails: FC<Props> = ({ timeEntry }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Team Leader: </span>
+        <span className="flex items-center font-medium">{timeEntry?.teamLeader.name}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time In: </span>
+        <span className="flex items-center font-medium">{timeEntry?.timeIn}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Time Out: </span>
+        <span className="flex items-center font-medium">{timeEntry?.timeOut}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Description: </span>
+        <span className="font-medium">{timeEntry?.description}</span>
+      </li>
+    </>
+  )
+}
+
+export default ESLChangeShiftDetails

--- a/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/ESLChangeShiftDetails.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/ESLChangeShiftDetails.tsx
@@ -3,27 +3,34 @@ import React, { FC } from 'react'
 import { IESLChangeShift } from '~/utils/types/timeEntryTypes'
 
 type Props = {
-  timeEntry: IESLChangeShift | undefined
+  eslChangeShift: IESLChangeShift
 }
 
-const ESLChangeShiftDetails: FC<Props> = ({ timeEntry }): JSX.Element => {
+const ESLChangeShiftDetails: FC<Props> = ({ eslChangeShift }): JSX.Element => {
+  const {
+    teamLeader: { name },
+    timeIn,
+    timeOut,
+    description
+  } = eslChangeShift
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Team Leader: </span>
-        <span className="flex items-center font-medium">{timeEntry?.teamLeader.name}</span>
+        <span className="flex items-center font-medium">{name}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time In: </span>
-        <span className="flex items-center font-medium">{timeEntry?.timeIn}</span>
+        <span className="flex items-center font-medium">{timeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time Out: </span>
-        <span className="flex items-center font-medium">{timeEntry?.timeOut}</span>
+        <span className="flex items-center font-medium">{timeOut}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>
-        <span className="font-medium">{timeEntry?.description}</span>
+        <span className="font-medium">{description}</span>
       </li>
     </>
   )

--- a/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/index.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/index.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react'
 import { Eye, X } from 'react-feather'
-import Button from '~/components/atoms/Buttons/ButtonAction'
 
 import ChangeShiftDetails from './ChangeShiftDetails'
 import ESLChangeShiftDetails from './ESLChangeShiftDetails'
+import Button from '~/components/atoms/Buttons/ButtonAction'
 import ModalTemplate from '~/components/templates/ModalTemplate'
 import { IEmployeeTimeEntry } from '~/utils/types/timeEntryTypes'
 import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
@@ -36,14 +36,14 @@ const ViewFiledChangeShiftModal: FC<Props> = ({ isOpen, closeModal, timeEntry })
           {timeEntry?.changeShift !== null ? (
             <ChangeShiftDetails
               {...{
-                timeEntry: timeEntry?.changeShift
+                changeShift: timeEntry?.changeShift
               }}
             />
           ) : null}
           {timeEntry?.eslChangeShift !== null ? (
             <ESLChangeShiftDetails
               {...{
-                timeEntry: timeEntry?.eslChangeShift
+                eslChangeShift: timeEntry?.eslChangeShift
               }}
             />
           ) : null}

--- a/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/index.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/index.tsx
@@ -1,0 +1,67 @@
+import React, { FC } from 'react'
+import { Eye, X } from 'react-feather'
+import Button from '~/components/atoms/Buttons/ButtonAction'
+
+import ChangeShiftDetails from './ChangeShiftDetails'
+import ESLChangeShiftDetails from './ESLChangeShiftDetails'
+import ModalTemplate from '~/components/templates/ModalTemplate'
+import { IEmployeeTimeEntry } from '~/utils/types/timeEntryTypes'
+import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
+import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+  timeEntry: IEmployeeTimeEntry
+}
+
+const ViewFiledChangeShiftModal: FC<Props> = ({ isOpen, closeModal, timeEntry }): JSX.Element => {
+  return (
+    <ModalTemplate
+      {...{
+        isOpen,
+        closeModal
+      }}
+      className="w-full max-w-lg"
+    >
+      <ModalHeader
+        {...{
+          title: 'Filed Change Shift',
+          closeModal,
+          Icon: Eye
+        }}
+      />
+      <main className="px-8 py-4 text-sm  text-slate-700">
+        <ul className="flex flex-col space-y-3 divide-y divide-slate-200">
+          {timeEntry?.changeShift !== null ? (
+            <ChangeShiftDetails
+              {...{
+                timeEntry: timeEntry?.changeShift
+              }}
+            />
+          ) : null}
+          {timeEntry?.eslChangeShift !== null ? (
+            <ESLChangeShiftDetails
+              {...{
+                timeEntry: timeEntry?.eslChangeShift
+              }}
+            />
+          ) : null}
+        </ul>
+      </main>
+      <ModalFooter>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={closeModal}
+          className="flex items-center space-x-2 px-4 py-1 text-sm"
+        >
+          <X className="h-4 w-4" />
+          <span>Close</span>
+        </Button>
+      </ModalFooter>
+    </ModalTemplate>
+  )
+}
+
+export default ViewFiledChangeShiftModal

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -22,6 +22,7 @@ import { USER_POSITIONS } from '~/utils/constants/userPositions'
 import { IEmployeeTimeEntry } from '~/utils/types/timeEntryTypes'
 import MenuTransition from '~/components/templates/MenuTransition'
 import InterruptionTimeEntriesModal from './../InterruptionTimeEntriesModal'
+import ViewFiledChangeShiftModal from './ViewFiledChangeShiftModal'
 
 const columnHelper = createColumnHelper<IEmployeeTimeEntry>()
 const EMPTY = 'N/A'
@@ -263,18 +264,33 @@ export const columns = [
       const [isOpenNewOffset, setIsOpenNewOffset] = useState<boolean>(false)
       const [isOpenChangeShiftRequest, setIsOpenChangeShiftRequest] = useState<boolean>(false)
       const [isOpenFiledOffset, setIsOpenFiledOffset] = useState<boolean>(false)
+      const [isOpenViewFiledOffset, setIsOpenViewFiledOffset] = useState<boolean>(false)
 
       // CURRENT USER QUERY HOOKS
       const { handleUserQuery } = useUserQuery()
       const { data: user } = handleUserQuery()
 
-      const handleIsOpenTimeEntryToggle = (id?: string | undefined): void => {
+      const handleIsOpenTimeEntryToggle = (id?: string | undefined): void =>
         setIsOpenTimeEntry(!isOpenTimeEntry)
+
+      const handleIsOpenNewOffsetToggle = (): void => {
+        if (timeEntry.changeShift === null && timeEntry.eslChangeShift === null) {
+          setIsOpenNewOffset(!isOpenNewOffset)
+        } else {
+          handleIsOpenViewFiledOffset()
+        }
       }
 
-      const handleIsOpenNewOffsetToggle = (): void => setIsOpenNewOffset(!isOpenNewOffset)
-      const handleIsOpenChangeShiftRequestToggle = (): void =>
-        setIsOpenChangeShiftRequest(!isOpenChangeShiftRequest)
+      const handleIsOpenViewFiledOffset = (): void =>
+        setIsOpenViewFiledOffset(!isOpenViewFiledOffset)
+
+      const handleIsOpenChangeShiftRequestToggle = (): void => {
+        if (timeEntry.changeShift === null && timeEntry.eslChangeShift === null) {
+          setIsOpenChangeShiftRequest(!isOpenChangeShiftRequest)
+        } else {
+          handleIsOpenViewFiledOffset()
+        }
+      }
       const handleIsOpenFiledOffsetToggle = (): void => setIsOpenFiledOffset(!isOpenFiledOffset)
 
       const menuItemButton = 'px-3 py-2 text-left text-xs hover:text-slate-700 text-slate-500'
@@ -333,6 +349,17 @@ export const columns = [
                     isLoading: false,
                     isError: false
                   }
+                }}
+              />
+            ) : null}
+
+            {/* This will View the Filed Change Shift Modal */}
+            {isOpenViewFiledOffset ? (
+              <ViewFiledChangeShiftModal
+                {...{
+                  isOpen: isOpenViewFiledOffset,
+                  closeModal: handleIsOpenViewFiledOffset,
+                  timeEntry
                 }}
               />
             ) : null}

--- a/client/src/components/molecules/NotificationList/NotificationTypeDetails/ESLChangeShiftDetails.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationTypeDetails/ESLChangeShiftDetails.tsx
@@ -1,0 +1,44 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+
+import { INotification } from '~/utils/interfaces'
+
+type Props = {
+  notification: INotification
+}
+
+const ESLChangeShiftDetails: FC<Props> = ({ notification }): JSX.Element => {
+  return (
+    <>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Requested Time In: </span>
+        <span className="flex items-center font-medium">{notification.requestedTimeIn}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3">
+        <span className="text-slate-600">Requested Time Out: </span>
+        <span className="flex items-center font-medium">{notification.requestedTimeOut}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date: </span>
+        <span className="flex items-center font-medium">{notification.date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Date Filed: </span>
+        <span className="flex items-center font-medium">
+          {moment(new Date(notification.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(notification.dateFiled)).fromNow()}
+        </span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Status: </span>
+        <span className="flex items-center font-medium">{notification.status}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Description: </span>
+        <span className="font-medium">{notification.description}</span>
+      </li>
+    </>
+  )
+}
+
+export default ESLChangeShiftDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal.tsx
@@ -24,6 +24,7 @@ import ChangeShiftDetails from './NotificationTypeDetails/ChangeShiftDetails'
 import LeaveResolvedDetails from './NotificationTypeDetails/LeaveResolvedDetails'
 import OffsetScheduleDetails from './NotificationTypeDetails/OffsetScheduleDetails'
 import OffsetResolvedDetails from './NotificationTypeDetails/OffsetResolvedDetails'
+import ESLChangeShiftDetails from './NotificationTypeDetails/ESLChangeShiftDetails'
 import ChangeShiftResolvedDetails from './NotificationTypeDetails/ChangeShiftResolved'
 import OvertimeResolvedDetails from './NotificationTypeDetails/OvertimeResolvedDetails'
 import UndertimeResolvedDetails from './NotificationTypeDetails/UndertimeResolvedDetails'
@@ -149,7 +150,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
     >
       <ModalHeader
         {...{
-          title: `${row.name}'s ${row.type.split('_')[0]} request`,
+          title: `${row.name}'s ${row.type.split('_')[0]} ${row.specificType}`,
           closeModal: handleClose,
           hasAvatar: true,
           avatar: row.userAvatarLink
@@ -248,6 +249,14 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {/* DETAILS FOR OFFSET RESOLVED DATA */}
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OFFSET_RESOLVED && (
             <OffsetResolvedDetails
+              {...{
+                notification: row
+              }}
+            />
+          )}
+          {/* DETAILS FOR ESL CHANGE SHIFT REQUEST */}
+          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.ESL_CHANGE_SHIFT && (
+            <ESLChangeShiftDetails
               {...{
                 notification: row
               }}

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/ChangeShiftDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/ChangeShiftDetails.tsx
@@ -4,49 +4,48 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const OvertimeResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+const ChangeShiftDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { project, date, requestedTimeIn, requestedTimeOut, dateFiled, status, description } =
+    notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Project: </span>
-        <span className="flex items-center font-medium">{row.project}</span>
+        <span className="flex items-center font-medium">{project}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
-      </li>
-      <li className="inline-flex items-center space-x-3 pt-2">
-        <span className="text-slate-600">Duration: </span>
-        <span className="flex items-center font-medium">{row.duration}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time In: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+        <span className="flex items-center font-medium">{requestedTimeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time Out: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+        <span className="flex items-center font-medium">{requestedTimeOut}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
-        <span className="text-slate-600">Remarks: </span>
-        <span className="font-medium">{row.remarks}</span>
+        <span className="text-slate-600">Description: </span>
+        <span className="font-medium">{description}</span>
       </li>
     </>
   )
 }
 
-export default OvertimeResolvedDetails
+export default ChangeShiftDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/ChangeShiftResolved.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/ChangeShiftResolved.tsx
@@ -4,42 +4,45 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const ChangeShiftResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+const ChangeShiftResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { project, date, requestedTimeIn, requestedTimeOut, dateFiled, status, description } =
+    notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Project: </span>
-        <span className="flex items-center font-medium">{row.project}</span>
+        <span className="flex items-center font-medium">{project}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time In: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+        <span className="flex items-center font-medium">{requestedTimeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time Out: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+        <span className="flex items-center font-medium">{requestedTimeOut}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>
-        <span className="font-medium">{row.description}</span>
+        <span className="font-medium">{description}</span>
       </li>
     </>
   )

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/ESLChangeShiftDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/ESLChangeShiftDetails.tsx
@@ -4,41 +4,43 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const OffsetDetails: FC<Props> = ({ row }): JSX.Element => {
+const ESLChangeShiftDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { requestedTimeIn, requestedTimeOut, date, dateFiled, status, description } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time In: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+        <span className="flex items-center font-medium">{requestedTimeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time Out: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+        <span className="flex items-center font-medium">{requestedTimeOut}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>
-        <span className="font-medium">{row.description}</span>
+        <span className="font-medium">{description}</span>
       </li>
     </>
   )
 }
 
-export default OffsetDetails
+export default ESLChangeShiftDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/LeaveDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/LeaveDetails.tsx
@@ -4,41 +4,43 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const LeaveResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+const LeaveDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { project, date, duration, dateFiled, status, remarks } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Project: </span>
-        <span className="flex items-center font-medium">{row.project}</span>
+        <span className="flex items-center font-medium">{project}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Duration: </span>
-        <span className="flex items-center font-medium">{row.duration}</span>
+        <span className="flex items-center font-medium">{duration}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>
-        <span className="font-medium">{row.remarks}</span>
+        <span className="font-medium">{remarks}</span>
       </li>
     </>
   )
 }
 
-export default LeaveResolvedDetails
+export default LeaveDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/LeaveResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/LeaveResolvedDetails.tsx
@@ -4,41 +4,43 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const UndertimeDetails: FC<Props> = ({ row }): JSX.Element => {
+const LeaveResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { project, date, duration, dateFiled, status, remarks } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Project: </span>
-        <span className="flex items-center font-medium">{row.project}</span>
+        <span className="flex items-center font-medium">{project}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Duration: </span>
-        <span className="flex items-center font-medium">{row.duration}</span>
+        <span className="flex items-center font-medium">{duration}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>
-        <span className="font-medium">{row.remarks}</span>
+        <span className="font-medium">{remarks}</span>
       </li>
     </>
   )
 }
 
-export default UndertimeDetails
+export default LeaveResolvedDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetDetails.tsx
@@ -7,38 +7,40 @@ type Props = {
   notification: INotification
 }
 
-const OffsetResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
+const OffsetDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { requestedTimeIn, requestedTimeOut, date, dateFiled, status, description } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time In: </span>
-        <span className="flex items-center font-medium">{notification.requestedTimeIn}</span>
+        <span className="flex items-center font-medium">{requestedTimeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time Out: </span>
-        <span className="flex items-center font-medium">{notification.requestedTimeOut}</span>
+        <span className="flex items-center font-medium">{requestedTimeOut}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{notification.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(notification.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(notification.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{notification.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>
-        <span className="font-medium">{notification.description}</span>
+        <span className="font-medium">{description}</span>
       </li>
     </>
   )
 }
 
-export default OffsetResolvedDetails
+export default OffsetDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetResolvedDetails.tsx
@@ -4,41 +4,43 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const OffsetScheduleDetails: FC<Props> = ({ row }): JSX.Element => {
+const OffsetResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { requestedTimeIn, requestedTimeOut, date, dateFiled, status, description } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time In: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+        <span className="flex items-center font-medium">{requestedTimeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time Out: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+        <span className="flex items-center font-medium">{requestedTimeOut}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>
-        <span className="font-medium">{row.description}</span>
+        <span className="font-medium">{description}</span>
       </li>
     </>
   )
 }
 
-export default OffsetScheduleDetails
+export default OffsetResolvedDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetScheduleDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetScheduleDetails.tsx
@@ -7,38 +7,40 @@ type Props = {
   notification: INotification
 }
 
-const ESLChangeShiftDetails: FC<Props> = ({ notification }): JSX.Element => {
+const OffsetScheduleDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { requestedTimeIn, requestedTimeOut, date, dateFiled, status, description } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time In: </span>
-        <span className="flex items-center font-medium">{notification.requestedTimeIn}</span>
+        <span className="flex items-center font-medium">{requestedTimeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Requested Time Out: </span>
-        <span className="flex items-center font-medium">{notification.requestedTimeOut}</span>
+        <span className="flex items-center font-medium">{requestedTimeOut}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{notification.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(notification.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(notification.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{notification.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>
-        <span className="font-medium">{notification.description}</span>
+        <span className="font-medium">{description}</span>
       </li>
     </>
   )
 }
 
-export default ESLChangeShiftDetails
+export default OffsetScheduleDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OvertimeDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OvertimeDetails.tsx
@@ -4,37 +4,43 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const ResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+const OvertimeDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { project, date, duration, dateFiled, status, remarks } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Project: </span>
-        <span className="flex items-center font-medium">{row.project}</span>
+        <span className="flex items-center font-medium">{project}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Duration: </span>
+        <span className="flex items-center font-medium">{duration}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>
-        <span className="font-medium">{row.remarks}</span>
+        <span className="font-medium">{remarks}</span>
       </li>
     </>
   )
 }
 
-export default ResolvedDetails
+export default OvertimeDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OvertimeResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OvertimeResolvedDetails.tsx
@@ -4,45 +4,52 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const ChangeShiftDetails: FC<Props> = ({ row }): JSX.Element => {
+const OvertimeResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { project, date, duration, requestedTimeIn, requestedTimeOut, dateFiled, status, remarks } =
+    notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Project: </span>
-        <span className="flex items-center font-medium">{row.project}</span>
+        <span className="flex items-center font-medium">{project}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
+      </li>
+      <li className="inline-flex items-center space-x-3 pt-2">
+        <span className="text-slate-600">Duration: </span>
+        <span className="flex items-center font-medium">{duration}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time In: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeIn}</span>
+        <span className="flex items-center font-medium">{requestedTimeIn}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Time Out: </span>
-        <span className="flex items-center font-medium">{row.requestedTimeOut}</span>
+        <span className="flex items-center font-medium">{requestedTimeOut}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
-        <span className="text-slate-600">Description: </span>
-        <span className="font-medium">{row.description}</span>
+        <span className="text-slate-600">Remarks: </span>
+        <span className="font-medium">{remarks}</span>
       </li>
     </>
   )
 }
 
-export default ChangeShiftDetails
+export default OvertimeResolvedDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/ResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/ResolvedDetails.tsx
@@ -4,41 +4,39 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const UndertimeResolvedDetails: FC<Props> = ({ row }): JSX.Element => {
+const ResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { project, date, dateFiled, status, remarks } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Project: </span>
-        <span className="flex items-center font-medium">{row.project}</span>
+        <span className="flex items-center font-medium">{project}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
-      </li>
-      <li className="inline-flex items-center space-x-3 pt-2">
-        <span className="text-slate-600">Duration: </span>
-        <span className="flex items-center font-medium">{row.duration}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>
-        <span className="font-medium">{row.remarks}</span>
+        <span className="font-medium">{remarks}</span>
       </li>
     </>
   )
 }
 
-export default UndertimeResolvedDetails
+export default ResolvedDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/UndertimeDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/UndertimeDetails.tsx
@@ -4,41 +4,43 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const LeaveDetails: FC<Props> = ({ row }): JSX.Element => {
+const UndertimeDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { project, date, duration, dateFiled, status, remarks } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Project: </span>
-        <span className="flex items-center font-medium">{row.project}</span>
+        <span className="flex items-center font-medium">{project}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Duration: </span>
-        <span className="flex items-center font-medium">{row.duration}</span>
+        <span className="flex items-center font-medium">{duration}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>
-        <span className="font-medium">{row.remarks}</span>
+        <span className="font-medium">{remarks}</span>
       </li>
     </>
   )
 }
 
-export default LeaveDetails
+export default UndertimeDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/UndertimeResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/UndertimeResolvedDetails.tsx
@@ -4,41 +4,43 @@ import React, { FC } from 'react'
 import { INotification } from '~/utils/interfaces'
 
 type Props = {
-  row: INotification
+  notification: INotification
 }
 
-const OvertimeDetails: FC<Props> = ({ row }): JSX.Element => {
+const UndertimeResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
+  const { project, date, duration, dateFiled, status, remarks } = notification
+
   return (
     <>
       <li className="inline-flex items-center space-x-3">
         <span className="text-slate-600">Project: </span>
-        <span className="flex items-center font-medium">{row.project}</span>
+        <span className="flex items-center font-medium">{project}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date: </span>
-        <span className="flex items-center font-medium">{row.date}</span>
+        <span className="flex items-center font-medium">{date}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Duration: </span>
-        <span className="flex items-center font-medium">{row.duration}</span>
+        <span className="flex items-center font-medium">{duration}</span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Date Filed: </span>
         <span className="flex items-center font-medium">
-          {moment(new Date(row.dateFiled)).format('MMM DD, YYYY')} &bull; {``}
-          {moment(new Date(row.dateFiled)).fromNow()}
+          {moment(new Date(dateFiled)).format('MMM DD, YYYY')} &bull; {``}
+          {moment(new Date(dateFiled)).fromNow()}
         </span>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{row.status}</span>
+        <span className="flex items-center font-medium">{status}</span>
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>
-        <span className="font-medium">{row.remarks}</span>
+        <span className="font-medium">{remarks}</span>
       </li>
     </>
   )
 }
 
-export default OvertimeDetails
+export default UndertimeResolvedDetails

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/index.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/index.tsx
@@ -3,31 +3,31 @@ import { useRouter } from 'next/router'
 import { Check, X } from 'react-feather'
 
 import useLeave from '~/hooks/useLeave'
+import LeaveDetails from './LeaveDetails'
+import OffsetDetails from './OffsetDetails'
 import useOvertime from '~/hooks/useOvertime'
 import { User } from '~/utils/types/userTypes'
+import OvertimeDetails from './OvertimeDetails'
+import ResolvedDetails from './ResolvedDetails'
 import { Roles } from '~/utils/constants/roles'
+import UndertimeDetails from './UndertimeDetails'
 import { INotification } from '~/utils/interfaces'
 import useChangeShift from '~/hooks/useChangeShift'
+import ChangeShiftDetails from './ChangeShiftDetails'
 import useOffsetForESL from '~/hooks/useOffsetForESL'
+import LeaveResolvedDetails from './LeaveResolvedDetails'
+import OffsetScheduleDetails from './OffsetScheduleDetails'
+import OffsetResolvedDetails from './OffsetResolvedDetails'
+import ESLChangeShiftDetails from './ESLChangeShiftDetails'
 import Button from '~/components/atoms/Buttons/ButtonAction'
+import ChangeShiftResolvedDetails from './ChangeShiftResolved'
+import OvertimeResolvedDetails from './OvertimeResolvedDetails'
 import ModalTemplate from '~/components/templates/ModalTemplate'
-import LeaveDetails from './NotificationTypeDetails/LeaveDetails'
-import OffsetDetails from './NotificationTypeDetails/OffsetDetails'
+import UndertimeResolvedDetails from './UndertimeResolvedDetails'
 import { STATUS_OPTIONS } from '~/utils/constants/notificationFilter'
 import { NOTIFICATION_TYPE } from '~/utils/constants/notificationTypes'
-import OvertimeDetails from './NotificationTypeDetails/OvertimeDetails'
-import ResolvedDetails from './NotificationTypeDetails/ResolvedDetails'
-import UndertimeDetails from './NotificationTypeDetails/UndertimeDetails'
 import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
 import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
-import ChangeShiftDetails from './NotificationTypeDetails/ChangeShiftDetails'
-import LeaveResolvedDetails from './NotificationTypeDetails/LeaveResolvedDetails'
-import OffsetScheduleDetails from './NotificationTypeDetails/OffsetScheduleDetails'
-import OffsetResolvedDetails from './NotificationTypeDetails/OffsetResolvedDetails'
-import ESLChangeShiftDetails from './NotificationTypeDetails/ESLChangeShiftDetails'
-import ChangeShiftResolvedDetails from './NotificationTypeDetails/ChangeShiftResolved'
-import OvertimeResolvedDetails from './NotificationTypeDetails/OvertimeResolvedDetails'
-import UndertimeResolvedDetails from './NotificationTypeDetails/UndertimeResolvedDetails'
 
 type Props = {
   isOpen: boolean
@@ -162,7 +162,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OVERTIME && (
             <OvertimeDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -170,7 +170,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.UNDERTIME && (
             <UndertimeDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -178,7 +178,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.LEAVE && (
             <LeaveDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -186,7 +186,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.CHANGE_SHIFT && (
             <ChangeShiftDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -194,7 +194,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OVERTIME_RESOLVED && (
             <OvertimeResolvedDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -202,7 +202,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.UNDERTIME_RESOLVED && (
             <UndertimeResolvedDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -210,7 +210,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.LEAVE_RESOLVED && (
             <LeaveResolvedDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -218,7 +218,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.CHANGE_SHIFT_RESOLVED && (
             <ChangeShiftResolvedDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -226,7 +226,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.RESOLVED && (
             <ResolvedDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -234,7 +234,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OFFSET_SCHEDULE && (
             <OffsetScheduleDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}
@@ -242,7 +242,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OFFSET && (
             <OffsetDetails
               {...{
-                row
+                notification: row
               }}
             />
           )}

--- a/client/src/graphql/queries/timesheetQueries.ts
+++ b/client/src/graphql/queries/timesheetQueries.ts
@@ -69,6 +69,24 @@ export const GET_EMPLOYEE_TIMESHEET = gql`
         isManagerApproved
       }
       status
+      changeShift {
+        id
+        manager {
+          name
+        }
+        timeIn
+        timeOut
+        description
+      }
+      eslChangeShift {
+        id
+        teamLeader {
+          name
+        }
+        timeIn
+        timeOut
+        description
+      }
     }
   }
 `

--- a/client/src/hooks/useChangeShift.ts
+++ b/client/src/hooks/useChangeShift.ts
@@ -37,9 +37,6 @@ const useChangeShift = (): returnType => {
           changeShiftRequest: data
         })
       },
-      onSuccess: async () => {
-        toast.success('Success!')
-      },
       onError: async (error: any) => {
         if (error.response.errors[0].message !== undefined)
           toast.error(error.response.errors[0].message)

--- a/client/src/hooks/useOffsetForESL.ts
+++ b/client/src/hooks/useOffsetForESL.ts
@@ -33,9 +33,6 @@ const useOffsetForESL = (): HookReturnType => {
       mutationFn: async (request: IESLOffsetInput) => {
         return await client.request(CREATE_ESL_OFFSET_MUTATION, { request })
       },
-      onSuccess: async () => {
-        toast.success('Added New Offset Successfully')
-      },
       onError: async (err: Error) => {
         const [errorMessage] = err.message.split(/:\s/, 2)
         toast.error(errorMessage)

--- a/client/src/utils/constants/notificationTypes.ts
+++ b/client/src/utils/constants/notificationTypes.ts
@@ -16,5 +16,6 @@ export const NOTIFICATION_TYPE = {
   RESOLVED: 'resolved',
   OFFSET_SCHEDULE: 'offset schedule',
   OFFSET: 'offset',
-  OFFSET_RESOLVED: 'offset_resolved'
+  OFFSET_RESOLVED: 'offset_resolved',
+  ESL_CHANGE_SHIFT: 'esl change shift'
 }

--- a/client/src/utils/types/timeEntryTypes.ts
+++ b/client/src/utils/types/timeEntryTypes.ts
@@ -21,8 +21,8 @@ export interface IEmployeeTimeEntry {
   undertime: number
   overtime: ITimeEntryOvertime
   status: string
-  changeShift?: IChangeShift
-  eslChangeShift?: IESLChangeShift
+  changeShift: IChangeShift
+  eslChangeShift: IESLChangeShift
 }
 
 export interface IChangeShift {

--- a/client/src/utils/types/timeEntryTypes.ts
+++ b/client/src/utils/types/timeEntryTypes.ts
@@ -21,6 +21,28 @@ export interface IEmployeeTimeEntry {
   undertime: number
   overtime: ITimeEntryOvertime
   status: string
+  changeShift?: IChangeShift
+  eslChangeShift?: IESLChangeShift
+}
+
+export interface IChangeShift {
+  id: number
+  manager: {
+    name: string
+  }
+  timeIn: string
+  timeOut: string
+  description: string
+}
+
+export interface IESLChangeShift {
+  id: number
+  teamLeader: {
+    name: string
+  }
+  timeIn: string
+  timeOut: string
+  description: string
 }
 
 export type ITimeEntryOvertime = {


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-187

## Definition of Done

- [x] Added `changeShift` and `eslChangeShift` data from `timeSheet` query
- [x] Displayed Filed Change Shift Modal when the User already requested
- [x] Fixed the `InterruptionTimeEntriesModal` from previous integration due to the inconsistent data display during Mobile Disclose
- [x] Fixed the Notification Modal Details for ESL Change Shift 

## Notes

- #162 
- Refactor Mobile Disclose My daily time Record Table that moved outside the Disclose Component due to the fact that it will eventually getting darker the bg of Modal when multiple Disclose open 

## Pre-condition

- run `cd client && npm run dev`
- run `cd api && dotnet run watch`

## Expected Output

- ESL and Non-ESL User will now be able to view the requested File Change
- Previous integration also work fine when filing  change shift request

## Screenshots/Recordings
[filing.webm](https://user-images.githubusercontent.com/108642414/231392714-498cede5-46af-4fe2-b9ea-4f9643f9588d.webm)

