### PR TITLE
HRIS-197 [BE] Implement display schedule functionality

### DIFF
--- a/api/DTOs/EmployeeScheduleDTO.cs
+++ b/api/DTOs/EmployeeScheduleDTO.cs
@@ -1,0 +1,54 @@
+using api.Entities;
+using api.Enums;
+
+namespace api.DTOs
+{
+    public class EmployeeScheduleDTO : WorkingDayTime
+    {
+        public new int? Id { get; set; }
+        public string? ScheduleName { get; set; }
+        public ICollection<Day> Days { get; set; }
+
+        public EmployeeScheduleDTO(EmployeeSchedule employeeSchedule)
+        {
+            Id = employeeSchedule.Id;
+            ScheduleName = employeeSchedule.Name;
+            Days = new List<Day>();
+            if (employeeSchedule.WorkingDayTimes is not null)
+            {
+                string[]? DaysOfTheWeek = { DaysOfTheWeekEnum.MONDAY, DaysOfTheWeekEnum.TUESDAY, DaysOfTheWeekEnum.WEDNESDAY, DaysOfTheWeekEnum.THURSDAY, DaysOfTheWeekEnum.FRIDAY, DaysOfTheWeekEnum.SATURDAY, DaysOfTheWeekEnum.SUNDAY };
+
+                // For included days of the week
+                foreach (var workingDayTime in employeeSchedule.WorkingDayTimes)
+                {
+                    Day workingDayTimes = new(workingDayTime.Day, workingDayTime.From.ToString(@"hh\:mm"), workingDayTime.To.ToString(@"hh\:mm"), true);
+                    DaysOfTheWeek = DaysOfTheWeek.Where(val => val.ToLower() != workingDayTime.Day?.ToLower()).ToArray();
+                    Days.Add(workingDayTimes);
+                }
+
+                // For exluded days of the week
+                foreach (var DayOfTheWeek in DaysOfTheWeek)
+                {
+                    Day workingDayTimes = new(DayOfTheWeek, "", "", false);
+                    Days.Add(workingDayTimes);
+                }
+            }
+        }
+    }
+
+    public class Day
+    {
+        public bool? IsDaySelected { get; set; }
+        public string? WorkingDay { get; set; }
+        public string? TimeIn { get; set; }
+        public string? TimeOut { get; set; }
+
+        public Day(string? workingDay, string timeIn, string timeOut, bool selected)
+        {
+            IsDaySelected = selected;
+            WorkingDay = workingDay;
+            TimeIn = timeIn;
+            TimeOut = timeOut;
+        }
+    }
+}

--- a/api/Enums/DaysOfTheWeekEnum.cs
+++ b/api/Enums/DaysOfTheWeekEnum.cs
@@ -1,0 +1,13 @@
+namespace api.Enums
+{
+    public static class DaysOfTheWeekEnum
+    {
+        public const string MONDAY = "Monday";
+        public const string TUESDAY = "Tuesday";
+        public const string WEDNESDAY = "Wednesday";
+        public const string THURSDAY = "Thursday";
+        public const string FRIDAY = "Friday";
+        public const string SATURDAY = "Saturday";
+        public const string SUNDAY = "Sunday";
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -33,7 +33,8 @@ builder.Services.AddGraphQLServer()
     .AddType<OvertimeQuery>()
     .AddType<ChangeShiftQuery>()
     .AddType<ESLOffsetQuery>()
-    .AddType<ESLChangeShiftQuery>();
+    .AddType<ESLChangeShiftQuery>()
+    .AddType<EmployeeScheduleQuery>();
 
 builder.Services.AddGraphQLServer()
     .AddMutationType(q => q.Name("Mutation"))
@@ -77,6 +78,7 @@ builder.Services.AddScoped<ApprovalService>();
 builder.Services.AddScoped<ChangeShiftService>();
 builder.Services.AddScoped<ESLChangeShiftService>();
 builder.Services.AddScoped<ESLOffsetService>();
+builder.Services.AddScoped<EmployeeScheduleService>();
 
 
 var app = builder.Build();

--- a/api/Requests/EmployeeScheduleRequest.cs
+++ b/api/Requests/EmployeeScheduleRequest.cs
@@ -1,0 +1,7 @@
+namespace api.Requests
+{
+    public class EmployeeScheduleRequest
+    {
+        public int EmployeeScheduleId { get; set; }
+    }
+}

--- a/api/Schema/Queries/EmployeeScheduleQuery.cs
+++ b/api/Schema/Queries/EmployeeScheduleQuery.cs
@@ -1,0 +1,25 @@
+using api.DTOs;
+using api.Services;
+
+namespace api.Schema.Queries
+{
+    [ExtendObjectType("Query")]
+    public class EmployeeScheduleQuery
+    {
+        private readonly EmployeeScheduleService _employeeScheduleService;
+        public EmployeeScheduleQuery(EmployeeScheduleService EmployeeScheduleService)
+        {
+            _employeeScheduleService = EmployeeScheduleService;
+        }
+
+        public async Task<List<EmployeeScheduleDTO>> GetAllEmployeeScheduleDetails()
+        {
+            return await _employeeScheduleService.GetAllEmployeeScheduleDetails();
+        }
+
+        public async Task<List<EmployeeScheduleDTO>> GetEmployeeScheduleDetails(int employeeScheduleId)
+        {
+            return await _employeeScheduleService.GetEmployeeScheduleDetails(employeeScheduleId);
+        }
+    }
+}

--- a/api/Services/EmployeeScheduleService.cs
+++ b/api/Services/EmployeeScheduleService.cs
@@ -1,0 +1,36 @@
+using api.Context;
+using api.DTOs;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Services
+{
+    public class EmployeeScheduleService
+    {
+        private readonly IDbContextFactory<HrisContext> _contextFactory = default!;
+
+        public EmployeeScheduleService(IDbContextFactory<HrisContext> contextFactory)
+        {
+            _contextFactory = contextFactory;
+        }
+        public async Task<List<EmployeeScheduleDTO>> GetAllEmployeeScheduleDetails()
+        {
+            using HrisContext context = _contextFactory.CreateDbContext();
+
+            return await context.EmployeeSchedules
+                .Include(x => x.WorkingDayTimes)
+                .Select(x => new EmployeeScheduleDTO(x))
+                .ToListAsync();
+        }
+
+        public async Task<List<EmployeeScheduleDTO>> GetEmployeeScheduleDetails(int employeeScheduleId)
+        {
+            using HrisContext context = _contextFactory.CreateDbContext();
+
+            return await context.EmployeeSchedules
+                .Include(x => x.WorkingDayTimes)
+                .Where(x => x.Id == employeeScheduleId)
+                .Select(x => new EmployeeScheduleDTO(x))
+                .ToListAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-197

## Definition of Done

- [x] User can query the list of schedules
- [x] User can query a specific schedule and its corresponding working days

## Notes
- BE integration only

## Pre-condition
- In the api directory, run ``` dotnet run ```
- Go to ``` http://localhost:5257/graphql/ ```
#### Query all Schedule
```
query {
  allEmployeeScheduleDetails {
    id
    scheduleName
    days {
      isDaySelected
      workingDay
      timeIn
      timeOut
    }
  }
}
```

#### Query a specific Schedule
```
query ($employeeScheduleId: Int!) {
  employeeScheduleDetails(employeeScheduleId: $employeeScheduleId) {
    scheduleName
    days {
      isDaySelected
      workingDay
      timeIn
      timeOut
    }
  }
}
```
#### Variable
```
{
  "employeeScheduleId": 1
}
```

## Expected Output
- It should fetch the list of schedule available in the database

## Screenshots/Recordings

### All schedule
![image](https://user-images.githubusercontent.com/109492180/231966146-75d7d6b1-89dd-4a2e-8df8-dc2cdab33bc7.png)

### Specific schedule
![image](https://user-images.githubusercontent.com/109492180/231963948-94d5a311-8ce4-4429-8b82-91cf997ba174.png)
