### PR TITLE
HRIS-192 [BE] Modify display of ESL Change Shift and Notification Approve/Disapprove Functionality

### DIFF
--- a/api/DTOs/ESLOffsetDTO.cs
+++ b/api/DTOs/ESLOffsetDTO.cs
@@ -28,4 +28,37 @@ namespace api.DTOs
 
         }
     }
+
+    public class ESLOffsetNotificationDTO
+    {
+        public int Id { get; set; }
+        public int UserId { get; set; }
+        public int TimeEntryId { get; set; }
+        public int TeamLeaderId { get; set; }
+        public int? ESLChangeShiftRequestId { get; set; }
+        public string Title { get; set; } = default!;
+        public string Description { get; set; } = default!;
+        public bool? IsLeaderApproved { get; set; }
+        public bool IsUsed { get; set; }
+        public string TimeIn { get; set; } = default!;
+        public string TimeOut { get; set; } = default!;
+
+        public ESLOffsetNotificationDTO(ESLOffset eslOffset)
+        {
+            if (eslOffset != null)
+            {
+                Id = eslOffset.Id;
+                UserId = eslOffset.UserId;
+                TimeEntryId = eslOffset.TimeEntryId;
+                TeamLeaderId = eslOffset.TeamLeaderId;
+                TimeIn = eslOffset.TimeIn.ToString(@"hh\:mm");
+                TimeOut = eslOffset.TimeOut.ToString(@"hh\:mm");
+                Title = eslOffset.Title;
+                Description = eslOffset.Description;
+                IsLeaderApproved = eslOffset.IsLeaderApproved;
+                IsUsed = eslOffset.IsUsed;
+            }
+
+        }
+    }
 }

--- a/api/NotificationDataClasses/ChangeShiftData.cs
+++ b/api/NotificationDataClasses/ChangeShiftData.cs
@@ -1,3 +1,5 @@
+using api.DTOs;
+
 namespace api.NotificationDataClasses
 {
     public class ChangeShiftData
@@ -20,5 +22,10 @@ namespace api.NotificationDataClasses
     public class ChangeShiftLeaderData : ChangeShiftData
     {
         public List<string> Projects { get; set; } = default!;
+    }
+
+    public class ESLChangeShiftData : ChangeShiftData
+    {
+        public List<ESLOffsetNotificationDTO> Offsets { get; set; } = default!;
     }
 }

--- a/api/Services/NotificationService.cs
+++ b/api/Services/NotificationService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using api.Context;
+using api.DTOs;
 using api.Entities;
 using api.Enums;
 using api.NotificationDataClasses;
@@ -286,8 +287,9 @@ namespace api.Services
             {
                 var user = await context.Users.FindAsync(request.UserId);
                 var timeEntry = await context.TimeEntries.FindAsync(request.TimeEntryId);
+                var offsets = await context.ESLOffsets.Where(x => x.ESLChangeShiftRequestId == request.Id).Select(x => new ESLOffsetNotificationDTO(x)).ToListAsync();
 
-                var data = JsonSerializer.Serialize(new ChangeShiftData
+                var data = JsonSerializer.Serialize(new ESLChangeShiftData
                 {
                     User = new NotificationUser
                     {
@@ -302,6 +304,7 @@ namespace api.Services
                     Type = NotificationDataTypeEnum.REQUEST,
                     Description = request.Description,
                     Status = _eslChangeShiftService.GetRequestStatus(request),
+                    Offsets = offsets
                 }
                 );
 
@@ -602,9 +605,10 @@ namespace api.Services
             {
                 var user = await context.Users.FindAsync(request.UserId);
                 var timeEntry = await context.TimeEntries.FindAsync(request.TimeEntryId);
+                var offsets = await context.ESLOffsets.Where(x => x.ESLChangeShiftRequestId == request.Id).Select(x => new ESLOffsetNotificationDTO(x)).ToListAsync();
 
 
-                var dataToUser = JsonSerializer.Serialize(new ChangeShiftData
+                var dataToUser = JsonSerializer.Serialize(new ESLChangeShiftData
                 {
                     User = new NotificationUser
                     {
@@ -619,6 +623,7 @@ namespace api.Services
                     Type = request.IsLeaderApproved == true ? NotificationDataTypeEnum.APPROVE : NotificationDataTypeEnum.DISAPPROVE,
                     Description = request.Description,
                     Status = _eslChangeShiftService.GetRequestStatus(request),
+                    Offsets = offsets
                 }
                 );
 
@@ -627,7 +632,7 @@ namespace api.Services
                 {
                     RecipientId = request.UserId,
                     ESLChangeShiftRequestId = request.Id,
-                    Type = NotificationTypeEnum.ESL_OFFSET_RESOLVED,
+                    Type = NotificationTypeEnum.ESL_OFFSET_SCHEDULE_RESOLVED,
                     Data = dataToUser
                 };
 


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-192

## Definition of Done
- [x] Included list of ESLOffsets data on Request/Approve/Disapprove notifications
- [x] Set `isUsed` attribute of ESLOffsets if quest is disapproved

## Notes
- To create ESL change shift request, refer to this PR #147 
- Also fixed the `type` of approved/disapproved ESLChangeShift notification
- You can also approve/disapprove through the notifications in FE
- `Offsets` object inside ESLChangeShift notification data is a list with the following attibutes: 
```
Id
UserId
TimeEntryId
TeamLeaderId
TimeIn
TimeOut
Title
Description
IsLeaderApproved
IsUsed
```

## Pre-condition
- run `docker compose up --build`
- go to `http://localhost:5257/graphql/`
- to approve/disapprove a request, use the following mutation
```
mutation ($request: ApproveESLChangeShiftRequestInput!) {
  approveDisapproveESLChangeShiftStatus(request: $request){
    id
  }
}

# Variables
# change according to you database values
{
  "request": {
    "teamLeaderId" : 3,
    "notificationId" : 9052,
    "isApproved" : false
  }
}
```

## Expected Output
- Approving/Disapprove ESLChangeShift request will create notification with ESLOffset data included in `Data` attribute
- Disapproving ESLChangeShift request will set `isUsed` attribute of all related ESLOffset to `false`

## Screenshots/Recordings
### Sample ESLChangeShift Approve/Disapprove notification data
![image](https://user-images.githubusercontent.com/111718037/232372541-f2ea70c4-5f31-4e48-9af4-61bed8bc1e15.png)

### Sample ESLOffset data after disapprove
![image](https://user-images.githubusercontent.com/111718037/232372793-2b4e7303-e88d-4daa-9ae1-e7cbb7226e64.png)
