### PR TITLE
HRIS-193 [BE] Implement Create Schedule Functionality

### DIFF
--- a/api/Enums/ErrorMessageEnum.cs
+++ b/api/Enums/ErrorMessageEnum.cs
@@ -4,5 +4,6 @@ namespace api.Enums
     {
         public const string FAILED_OVERTIME_REQUEST = "Overtime Request Failed.";
         public const string FAILED_LEAVE_REQUEST = "Leave/Undertime Request Failed.";
+        public const string FAILED_SHCEDULE_CREATION = "Failed to create schedule!";
     }
 }

--- a/api/Enums/InputValidationMessageEnum.cs
+++ b/api/Enums/InputValidationMessageEnum.cs
@@ -16,13 +16,20 @@ namespace api.Enums
         public const string INVALID_ESL_OFFSET_IDS = "Invalid ESL Offset IDs";
         public const string INVALID_DATE = "Invalid Date";
         public const string INVALID_LEAVE_TYPE = "Invalid leave type";
+        public const string INVALID_DAY = "Invalid Day";
+        public const string INVALID_END_TIME = "Invalid End Time";
+        public const string INVALID_START_TIME = "Invalid Start Time";
+        public const string INVALID_SCHEDULE = "Schedule doesn't exist";
+        public const string INVALID_SCHEDULE_NAME = "Invalid Schedule Name";
         public const string MISSING_LEAVE_DATES = "Leave Date/s is required";
         public const string MISSING_PROJECTS = "Project/s is required";
         public const string MISSING_APPROVED_MINUTES = "Approved minutes is required";
         public const string INVALID_NOTIFICATION = "Invalid Notification";
         public const string NOT_MANAGER_PROJECT_LEADER = "User is not Manager or Project Leader";
+        public const string NOT_HR_ADMIN = "User is not an HR Admin";
         public const string MISMATCH_PROJECT_LEADER = "Project Leader doesn't match";
         public const string MISMATCH_MANAGER = "Manager doesn't match";
         public const string DUPLICATE_REQUEST = "There's already an existing request!";
+        public const string DUPLICATE_SCHEDULE_NAME = "Schedule name already exists!";
     }
 }

--- a/api/Enums/SuccessMessageEnum.cs
+++ b/api/Enums/SuccessMessageEnum.cs
@@ -1,0 +1,7 @@
+namespace api.Enums
+{
+    public class SuccessMessageEnum
+    {
+        public const string SCHEDULE_CREATED = "Successfully created a schedule!";
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -50,7 +50,8 @@ builder.Services.AddGraphQLServer()
     .AddType<ApprovalMutation>()
     .AddType<ChangeShiftMutation>()
     .AddType<ESLChangeShiftMutation>()
-    .AddType<ESLOffsetMutation>();
+    .AddType<ESLOffsetMutation>()
+    .AddType<EmployeeScheduleMutation>();
 
 builder.Services.AddGraphQLServer().AddProjections().AddFiltering().AddSorting();
 builder.Services.AddGraphQLServer().AddInMemorySubscriptions()

--- a/api/Requests/CreateEmployeeScheduleRequest.cs
+++ b/api/Requests/CreateEmployeeScheduleRequest.cs
@@ -1,0 +1,9 @@
+namespace api.Requests
+{
+    public class CreateEmployeeScheduleRequest
+    {
+        public int UserId { get; set; }
+        public string? ScheduleName { get; set; }
+        public List<WorkingDayTimesRequest> WorkingDays { get; set; } = null!;
+    }
+}

--- a/api/Requests/EmployeeScheduleRequest.cs
+++ b/api/Requests/EmployeeScheduleRequest.cs
@@ -1,7 +1,0 @@
-namespace api.Requests
-{
-    public class EmployeeScheduleRequest
-    {
-        public int EmployeeScheduleId { get; set; }
-    }
-}

--- a/api/Requests/WorkingDayTimesRequest.cs
+++ b/api/Requests/WorkingDayTimesRequest.cs
@@ -1,0 +1,9 @@
+namespace api.Requests
+{
+    public class WorkingDayTimesRequest
+    {
+        public string? Day { get; set; }
+        public string? From { get; set; }
+        public string? To { get; set; }
+    }
+}

--- a/api/Schema/Mutations/EmployeeScheduleMutation.cs
+++ b/api/Schema/Mutations/EmployeeScheduleMutation.cs
@@ -14,7 +14,7 @@ namespace api.Schema.Mutations
             try
             {
                 using var transaction = context.Database.BeginTransaction();
-                var createEmployeeSchedule = await _employeeSchedueleService.Create(request);
+                var createEmployeeSchedule = await _employeeSchedueleService.Create(request, context);
 
                 transaction.Commit();
                 return createEmployeeSchedule;

--- a/api/Schema/Mutations/EmployeeScheduleMutation.cs
+++ b/api/Schema/Mutations/EmployeeScheduleMutation.cs
@@ -1,0 +1,28 @@
+using api.Context;
+using api.Requests;
+using api.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Schema.Mutations
+{
+    [ExtendObjectType("Mutation")]
+    public class EmployeeScheduleMutation
+    {
+        public async Task<string> CreateEmployeeSchedule([Service] IDbContextFactory<HrisContext> contextFactory, [Service] EmployeeScheduleService _employeeSchedueleService, CreateEmployeeScheduleRequest request)
+        {
+            using HrisContext context = contextFactory.CreateDbContext();
+            try
+            {
+                using var transaction = context.Database.BeginTransaction();
+                var createEmployeeSchedule = await _employeeSchedueleService.Create(request);
+
+                transaction.Commit();
+                return createEmployeeSchedule;
+            }
+            catch (GraphQLException)
+            {
+                throw;
+            }
+        }
+    }
+}

--- a/api/Services/EmployeeScheduleService.cs
+++ b/api/Services/EmployeeScheduleService.cs
@@ -39,10 +39,8 @@ namespace api.Services
                 .ToListAsync();
         }
 
-        public async Task<string> Create(CreateEmployeeScheduleRequest request)
+        public async Task<string> Create(CreateEmployeeScheduleRequest request, HrisContext context)
         {
-            using HrisContext context = _contextFactory.CreateDbContext();
-
             // validate inputs
             var errors = _customInputValidation.CheckEmployeeScheduleRequestInput(request);
 
@@ -69,7 +67,16 @@ namespace api.Services
                 context.WorkingDayTimes.Add(newWorkingDayTimes);
             }
 
-            await context.SaveChangesAsync();
+            try
+            {
+                await context.SaveChangesAsync();
+            }
+            catch
+            {
+                throw new GraphQLException(ErrorBuilder.New()
+                                    .SetMessage(ErrorMessageEnum.FAILED_SHCEDULE_CREATION)
+                                    .Build());
+            }
             return SuccessMessageEnum.SCHEDULE_CREATED;
         }
     }


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-193

## Definition of Done

- [x] Users can create a new Employee Schedule with its working days

## Notes
- Backend integration only

## Pre-condition
- In the api directory run ``` dotnet run ```
- To create a new Schedule, run the following mutations from your playground ``` http://localhost:5257/graphql/ ```

#### Mutation
```
mutation ($request: CreateEmployeeScheduleRequestInput!) {
  createEmployeeSchedule(request: $request){
  }
}
```

#### Variables. PS> the role of the userId must be ``` HR_ADMIN ```
```
{
  "request": {
    "userId": 57,
    "scheduleName": "Graveyard Shift",
    "workingDays": [
      {
        "day": "Monday",
        "from": "09:30",
        "to": "18:30"
      },
      {
        "day": "Wednesday",
        "from": "09:30",
        "to": "18:30"
      },
      {
        "day": "Thursday",
        "from": "09:30",
        "to": "18:30"
      }
    ]
  }
}
```

## Expected Output
- It should create a new Employee Schedule in the EmployeeSchedule table
- It should create new data inside the WorkingDayTimes table
- It should check if
     - the user is an HR Admin
     - the schedule name already existed
     - the working day time variables are not empty

## Screenshots/Recordings


https://user-images.githubusercontent.com/109492180/232680693-ff73e53a-e4b3-4e12-81c2-3334fd32552f.mp4



#### Error checking

https://user-images.githubusercontent.com/109492180/232680507-297ebfff-f923-4dcd-b73d-e521c73655b4.mp4

