### PR TITLE
HRIS-200 [FE] Integrate the modified display of ESL Change Shift and Notification Approve/Disapprove Functionality

### DIFF
--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/ESLChangeShiftDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/ESLChangeShiftDetails.tsx
@@ -2,13 +2,37 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import { IESLOffset } from '~/utils/interfaces/eslOffsetInterface'
 
 type Props = {
   notification: INotification
 }
 
 const ESLChangeShiftDetails: FC<Props> = ({ notification }): JSX.Element => {
-  const { requestedTimeIn, requestedTimeOut, date, dateFiled, status, description } = notification
+  const { requestedTimeIn, requestedTimeOut, date, dateFiled, status, description, offsets } =
+    notification
+
+  const renderOffsets = (offset: IESLOffset): string => {
+    const timeIn = moment(offset.TimeIn, 'HH:mm:ss')
+    const timeOut = moment(offset.TimeOut, 'HH:mm:ss')
+
+    const difference = moment.duration(timeOut.diff(timeIn))
+    const diffHours = difference.hours()
+    const diffMinutes = difference.minutes()
+
+    let displayDiff = ''
+    if (diffHours > 0) {
+      displayDiff += `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'}`
+    }
+    if (diffMinutes > 0) {
+      displayDiff += ` ${diffMinutes} ${diffMinutes === 1 ? 'minute' : 'minutes'}`
+    }
+    if (displayDiff === '') {
+      displayDiff = '0 minutes'
+    }
+
+    return displayDiff
+  }
 
   return (
     <>
@@ -38,6 +62,14 @@ const ESLChangeShiftDetails: FC<Props> = ({ notification }): JSX.Element => {
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>
         <span className="font-medium">{description}</span>
+      </li>
+      <li className="inline-flex flex-col space-y-2 pt-2">
+        <span className="text-slate-600">Offsets: </span>
+        {offsets.map((offset) => (
+          <span key={offset.Id} className="ml-4 font-medium">
+            {`- ${offset.Title} (${date} - ${renderOffsets(offset)})`}
+          </span>
+        ))}
       </li>
     </>
   )

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/index.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/index.tsx
@@ -113,7 +113,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
       )
     }
 
-    if (row.type.toLowerCase() === NOTIFICATION_TYPE.OFFSET_SCHEDULE) {
+    if (row.type.toLowerCase() === NOTIFICATION_TYPE.ESL_CHANGE_SHIFT) {
       approveDisapproveEslOffsetMutation.mutate(
         {
           teamLeaderId: user.id,
@@ -255,7 +255,8 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
             />
           )}
           {/* DETAILS FOR ESL CHANGE SHIFT REQUEST */}
-          {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.ESL_CHANGE_SHIFT && (
+          {(row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.ESL_CHANGE_SHIFT ||
+            row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.ESL_CHANGE_SHIFT_RESOLVED) && (
             <ESLChangeShiftDetails
               {...{
                 notification: row

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -101,7 +101,8 @@ const Header: FC<Props> = (props): JSX.Element => {
           requestedTimeOut: moment(parsedData.RequestedTimeOut, 'HH:mm:ss').format('hh:mm A'),
           description: parsedData.Description,
           userAvatarLink: parsedData.User.AvatarLink,
-          createdAt: notif.createdAt
+          createdAt: notif.createdAt,
+          offsets: parsedData.Offsets
         }
         return mapped
       })

--- a/client/src/pages/notifications.tsx
+++ b/client/src/pages/notifications.tsx
@@ -71,7 +71,8 @@ const Notifications: NextPage = (): JSX.Element => {
           requestedTimeOut: moment(parsedData.RequestedTimeOut, 'HH:mm:ss').format('hh:mm A'),
           description: parsedData.Description,
           userAvatarLink: parsedData.User.AvatarLink,
-          createdAt: notif.createdAt
+          createdAt: notif.createdAt,
+          offsets: parsedData.Offsets
         }
         return mapped
       })

--- a/client/src/utils/constants/notificationTypes.ts
+++ b/client/src/utils/constants/notificationTypes.ts
@@ -17,5 +17,6 @@ export const NOTIFICATION_TYPE = {
   OFFSET_SCHEDULE: 'offset schedule',
   OFFSET: 'offset',
   OFFSET_RESOLVED: 'offset_resolved',
-  ESL_CHANGE_SHIFT: 'esl change shift'
+  ESL_CHANGE_SHIFT: 'esl change shift',
+  ESL_CHANGE_SHIFT_RESOLVED: 'esl change shift_resolved'
 }

--- a/client/src/utils/interfaces/eslOffsetInterface.ts
+++ b/client/src/utils/interfaces/eslOffsetInterface.ts
@@ -19,3 +19,17 @@ export interface IApproveOffsetInput {
   notificationId: number
   isApproved: boolean
 }
+
+export interface IESLOffset {
+  Id: number
+  UserId: number
+  TeamEntryId: number
+  TeamLeaderId: number
+  ESLChangeShiftRequestId: number
+  Title: string
+  Description: string
+  IsLeaderApproved: boolean | null
+  IsUsed: boolean | null
+  TimeIn: string
+  TimeOut: string
+}

--- a/client/src/utils/interfaces/index.tsx
+++ b/client/src/utils/interfaces/index.tsx
@@ -1,4 +1,5 @@
 import * as Icons from 'react-feather'
+import { IESLOffset } from './eslOffsetInterface'
 
 export type IconName = keyof typeof Icons
 
@@ -56,6 +57,7 @@ export interface INotification {
   description: string | null
   userAvatarLink: string
   createdAt: string
+  offsets: IESLOffset[]
 }
 
 export interface IEmployeeManagement {

--- a/client/src/utils/types/notificationTypes.ts
+++ b/client/src/utils/types/notificationTypes.ts
@@ -1,3 +1,5 @@
+import { IESLOffset } from '../interfaces/eslOffsetInterface'
+
 export type Notification = {
   id: number
   leaveId: number | null
@@ -18,6 +20,7 @@ export type NotificationData = {
     Name: string
     AvatarLink: string
   }
+  Offsets: IESLOffset[]
   ReadAt: string | null
   DateFiled: string
   DateRequested: string


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-200

## Definition of Done
- [x] Added Offsets data in ESL Change Shift Request/Approve/Disapprove notification

## Notes
- There should be existing approved `ESLOffset` data
- Approve/Disapprove can be done with 2 accounts
- Approve/Disapprove is optional in this PR, if you already have existing ESL Change Shift notification, that will do.

## Pre-condition
- run `docker compose up --build`
- If there is no ESL Change Shift request yet, create one in `My Daily Time Record` page
- then go to notification page of the recipient of the request, `http://localhost:3000/notifications`
- View the notification details, then approve/disapprove
- then go back to the sender's notification page

## Expected Output
- There should be `Offsets` in the notification details of ESL Change Shift notification (request/approve/disapprove)

## Screenshots/Recordings
### ESL Change Shift Notification Details
[ModifiedESLChangeShiftDisplay.webm](https://user-images.githubusercontent.com/111718037/232747677-d7cd89d3-a92c-4a9a-ac43-99e89a65fc33.webm)

