### PR TITLE
HRIS-195 [BE] Implement edit schedule details functionality

### DIFF
--- a/api/Enums/ErrorMessageEnum.cs
+++ b/api/Enums/ErrorMessageEnum.cs
@@ -5,5 +5,6 @@ namespace api.Enums
         public const string FAILED_OVERTIME_REQUEST = "Overtime Request Failed.";
         public const string FAILED_LEAVE_REQUEST = "Leave/Undertime Request Failed.";
         public const string FAILED_SHCEDULE_CREATION = "Failed to create schedule!";
+        public const string FAILED_SHCEDULE_UPDATE = "Failed to update schedule!";
     }
 }

--- a/api/Enums/InputValidationMessageEnum.cs
+++ b/api/Enums/InputValidationMessageEnum.cs
@@ -21,6 +21,7 @@ namespace api.Enums
         public const string INVALID_START_TIME = "Invalid Start Time";
         public const string INVALID_SCHEDULE = "Schedule doesn't exist";
         public const string INVALID_SCHEDULE_NAME = "Invalid Schedule Name";
+        public const string INVALID_SCHEDULE_ID = "Employee schedule does not exist";
         public const string MISSING_LEAVE_DATES = "Leave Date/s is required";
         public const string MISSING_PROJECTS = "Project/s is required";
         public const string MISSING_APPROVED_MINUTES = "Approved minutes is required";

--- a/api/Enums/SuccessMessageEnum.cs
+++ b/api/Enums/SuccessMessageEnum.cs
@@ -3,5 +3,6 @@ namespace api.Enums
     public class SuccessMessageEnum
     {
         public const string SCHEDULE_CREATED = "Successfully created a schedule!";
+        public const string SCHEDULE_UPDATED = "Successfully updated a schedule!";
     }
 }

--- a/api/Requests/UpdateEmployeeScheduleRequest.cs
+++ b/api/Requests/UpdateEmployeeScheduleRequest.cs
@@ -1,0 +1,11 @@
+namespace api.Requests
+{
+    public class UpdateEmployeeScheduleRequest
+    {
+        public int UserId { get; set; }
+        public int EmployeeScheduleId { get; set; }
+        public string? ScheduleName { get; set; }
+        public List<WorkingDayTimesRequest> WorkingDays { get; set; } = null!;
+
+    }
+}

--- a/api/Schema/Mutations/EmployeeScheduleMutation.cs
+++ b/api/Schema/Mutations/EmployeeScheduleMutation.cs
@@ -1,5 +1,4 @@
 using api.Context;
-using api.Enums;
 using api.Requests;
 using api.Services;
 using Microsoft.EntityFrameworkCore;
@@ -22,9 +21,7 @@ namespace api.Schema.Mutations
             }
             catch (GraphQLException)
             {
-                throw new GraphQLException(ErrorBuilder.New()
-                                    .SetMessage(ErrorMessageEnum.FAILED_SHCEDULE_CREATION)
-                                    .Build());
+                throw;
             }
         }
 
@@ -41,9 +38,7 @@ namespace api.Schema.Mutations
             }
             catch (GraphQLException)
             {
-                throw new GraphQLException(ErrorBuilder.New()
-                                    .SetMessage(ErrorMessageEnum.FAILED_SHCEDULE_UPDATE)
-                                    .Build());
+                throw;
             }
         }
     }

--- a/api/Schema/Mutations/EmployeeScheduleMutation.cs
+++ b/api/Schema/Mutations/EmployeeScheduleMutation.cs
@@ -1,4 +1,5 @@
 using api.Context;
+using api.Enums;
 using api.Requests;
 using api.Services;
 using Microsoft.EntityFrameworkCore;
@@ -21,7 +22,9 @@ namespace api.Schema.Mutations
             }
             catch (GraphQLException)
             {
-                throw;
+                throw new GraphQLException(ErrorBuilder.New()
+                                    .SetMessage(ErrorMessageEnum.FAILED_SHCEDULE_CREATION)
+                                    .Build());
             }
         }
 
@@ -38,7 +41,9 @@ namespace api.Schema.Mutations
             }
             catch (GraphQLException)
             {
-                throw;
+                throw new GraphQLException(ErrorBuilder.New()
+                                    .SetMessage(ErrorMessageEnum.FAILED_SHCEDULE_UPDATE)
+                                    .Build());
             }
         }
     }

--- a/api/Schema/Mutations/EmployeeScheduleMutation.cs
+++ b/api/Schema/Mutations/EmployeeScheduleMutation.cs
@@ -24,5 +24,22 @@ namespace api.Schema.Mutations
                 throw;
             }
         }
+
+        public async Task<string> UpdateEmployeeSchedule([Service] IDbContextFactory<HrisContext> contextFactory, [Service] EmployeeScheduleService _employeeSchedueleService, UpdateEmployeeScheduleRequest request)
+        {
+            using HrisContext context = contextFactory.CreateDbContext();
+            try
+            {
+                using var transaction = context.Database.BeginTransaction();
+                var updatedEmployeeSchedule = await _employeeSchedueleService.Update(request, context);
+
+                transaction.Commit();
+                return updatedEmployeeSchedule;
+            }
+            catch (GraphQLException)
+            {
+                throw;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-195

## Definition of Done

- [x] Users can edit a specific employee schedule

## Notes
- BE integration only

## Pre-condition
- In the api directory, run ``` dotnet run ```

#### Mutation
```
mutation ($request: UpdateEmployeeScheduleRequestInput!) {
  updateEmployeeSchedule(request: $request){
  }
}
```

#### Sample Variables
```
{
  "request": {
    "userId": 57,
    "employeeScheduleId": 2057,
    "scheduleName": "Graveyard Shift stone!",
    "workingDays": [
      {
        "day": "Monday",
        "from": "10:30",
        "to": "18:30"
      },
      {
        "day": "Wednesday",
        "from": "11:30",
        "to": "18:30"
      },
      {
        "day": "Thursday",
        "from": "12:30",
        "to": "18:30"
      }
    ]
  }
}
```

## Expected Output
- If the name is being edited, it should change the Name of the employee schedule in the EmployeeSchedules table
- If the days and times are being edited, it should update the data inside the WorkingDayTimes table base on the changes the user made
- It should checks if:
      - Employee schedule exists
      - Schedule name already exists
      - Schedule name input is empty
      - Either one of the inputted working days data is/are empty or null

## Screenshots/Recordings

https://user-images.githubusercontent.com/109492180/232952968-4542abbf-477f-415f-b731-d7b3295d25cb.mp4


