### PR TITLE
HRIS-208 [Markup] Create Schedule Modal

### DIFF
--- a/client/src/components/atoms/TabLink/index.tsx
+++ b/client/src/components/atoms/TabLink/index.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import React, { FC } from 'react'
 import classNames from 'classnames'
 import { Table } from 'react-feather'
+import { motion } from 'framer-motion'
 import { useRouter } from 'next/router'
 
 type Props = {
@@ -17,20 +18,31 @@ const TabLink: FC<Props> = ({ href, name, Icon }): JSX.Element => {
     <Link
       href={href}
       className={classNames(
-        'flex select-none items-center space-x-2 border-b-[3px]',
-        'border-transparent py-2.5 focus:outline-none',
+        'relative flex select-none items-center',
+        'border-b-[3px] border-transparent py-2.5 focus:outline-none',
+        'transition duration-150 ease-in-out',
         router.pathname.includes(href)
-          ? '!border-amber-500 font-medium text-amber-500'
+          ? 'font-medium text-amber-500'
           : classNames(
               'font-normal text-slate-500 focus:border-slate-300',
               'hover:border-slate-300 hover:text-slate-600'
             )
       )}
+      style={{
+        WebkitTapHighlightColor: 'transparent'
+      }}
     >
+      {router.pathname.includes(href) && (
+        <motion.span
+          layoutId="bubble"
+          className="absolute inset-0 -bottom-1 z-10 border-b-[3px] border-amber-500"
+          transition={{ type: 'spring', bounce: 0.2, duration: 0.6 }}
+        />
+      )}
       <Icon
         className={classNames('h-4 w-4 shrink-0', router.pathname !== href ? 'stroke-1' : '')}
       />
-      <span className="flex-shrink-0">{name}</span>
+      <span className="relative ml-2 flex-shrink-0">{name}</span>
     </Link>
   )
 }

--- a/client/src/components/molecules/ViewScheduleMembersModal/MemberList.tsx
+++ b/client/src/components/molecules/ViewScheduleMembersModal/MemberList.tsx
@@ -1,0 +1,79 @@
+import React, { FC } from 'react'
+import classNames from 'classnames'
+import { Menu } from '@headlessui/react'
+import { CornerDownRight, MoreVertical } from 'react-feather'
+
+import Button from '~/components/atoms/Buttons/Button'
+import MenuTransition from '~/components/templates/MenuTransition'
+import { IScheduleMember } from '~/utils/interfaces/scheduleMemberInterface'
+
+type Props = {
+  member: IScheduleMember
+}
+
+const MemberList: FC<Props> = ({ member }): JSX.Element => {
+  return (
+    <section
+      className={classNames(
+        'group flex items-center justify-between px-7 py-2.5 transition',
+        'duration-100 ease-in-out hover:bg-slate-100'
+      )}
+    >
+      {/* Member Details */}
+      <div className="flex items-center space-x-4">
+        <div className="relative">
+          <img src={member.avatarLink} className="h-9 w-9 shrink rounded-md" />
+          {/* This will act as online and offline */}
+          <span
+            className={classNames(
+              'absolute right-0 -bottom-1 h-2.5 w-2.5 rounded-full ring-2 ring-white',
+              member.isOnline ? 'bg-green-500 ' : 'bg-slate-400'
+            )}
+          ></span>
+        </div>
+        <div className="leading-4">
+          <h3 className="text-sm font-medium text-slate-800 line-clamp-1">{member.name}</h3>
+          <small className="text-xs font-light text-slate-600 line-clamp-1">
+            {member.position.name}
+          </small>
+        </div>
+      </div>
+
+      {/* Menu Dropdown Options For Re-assigned Member */}
+      <div className="flex items-center text-slate-600">
+        <Menu as="div" className="relative z-30 flex w-full text-left">
+          {({ open }) => (
+            <>
+              <Menu.Button
+                className={classNames(
+                  'border border-slate-200 p-1.5 transition duration-100',
+                  'rounded ease-in-out hover:border-slate-400',
+                  open ? 'border-slate-400 opacity-100' : 'opacity-0 group-hover:opacity-100'
+                )}
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Menu.Button>
+              <MenuTransition>
+                <Menu.Items
+                  className={classNames(
+                    'absolute right-0 -bottom-12 flex w-48 flex-col overflow-hidden rounded-md',
+                    'bg-white py-1 shadow-xl shadow-slate-200 ring-1 ring-black ring-opacity-5 focus:outline-none'
+                  )}
+                >
+                  <Menu.Item>
+                    <Button className="flex items-center space-x-2 px-3 py-2 text-xs hover:text-slate-700">
+                      <CornerDownRight className="h-5 w-5 stroke-0.5" aria-hidden="true" />
+                      <span className="text-xs">Re-assigned Schedule</span>
+                    </Button>
+                  </Menu.Item>
+                </Menu.Items>
+              </MenuTransition>
+            </>
+          )}
+        </Menu>
+      </div>
+    </section>
+  )
+}
+
+export default MemberList

--- a/client/src/components/molecules/ViewScheduleMembersModal/index.tsx
+++ b/client/src/components/molecules/ViewScheduleMembersModal/index.tsx
@@ -1,0 +1,90 @@
+import classNames from 'classnames'
+import React, { FC, useState } from 'react'
+import { Coffee, Search, UserPlus } from 'react-feather'
+
+import Input from '~/components/atoms/Input'
+import ModalTemplate from '~/components/templates/ModalTemplate'
+import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+import { scheduleMembers } from '~/utils/constants/dummyScheduleMembers'
+import MemberList from './MemberList'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+  scheduleName: string
+}
+
+const ViewScheduleMembersModal: FC<Props> = ({ isOpen, closeModal, scheduleName }): JSX.Element => {
+  const [searchedVal, setSearchedVal] = useState<string>('')
+
+  return (
+    <ModalTemplate
+      {...{
+        isOpen,
+        closeModal
+      }}
+      className="w-full max-w-lg"
+    >
+      <ModalHeader
+        {...{
+          isOpen,
+          closeModal,
+          Icon: Coffee,
+          title: scheduleName
+        }}
+        className="px-7 py-4"
+      />
+      <main>
+        {/* For Search Field */}
+        <section className="group relative px-7 py-4">
+          <div className="absolute inset-y-0 flex items-center pl-3">
+            <Search className="h-5 w-5 text-slate-400/70 group-focus-within:text-amber-500" />
+          </div>
+          <Input
+            type="text"
+            color="warning"
+            placeholder="Find Members"
+            className="py-2.5 pl-10 text-sm text-slate-800"
+            onChange={(e: { target: { value: React.SetStateAction<string> } }) =>
+              setSearchedVal(e.target.value)
+            }
+          />
+        </section>
+
+        {/* For Add New Member Button */}
+        <section
+          className={classNames(
+            'flex items-center px-7 py-2 transition',
+            'duration-100 ease-in-out hover:bg-slate-100',
+            'cursor-pointer space-x-4'
+          )}
+        >
+          <div className="rounded border border-amber-100 bg-amber-50 p-2">
+            <UserPlus className="h-5 w-5 stroke-1 text-amber-500" />
+          </div>
+          <span className="text-sm font-medium text-slate-800">Add member</span>
+        </section>
+
+        <div
+          className={classNames(
+            'default-scrollbar mb-3 h-full max-h-[350px] min-h-[350px]',
+            'overflow-y-auto scrollbar-track-slate-100'
+          )}
+        >
+          {/* List of all Members */}
+          {scheduleMembers
+            ?.filter(
+              (row) =>
+                searchedVal?.length === 0 ||
+                row?.name.toString().toLowerCase().includes(searchedVal.toString().toLowerCase())
+            )
+            ?.map((member) => (
+              <MemberList key={member.id} {...{ member }} />
+            ))}
+        </div>
+      </main>
+    </ModalTemplate>
+  )
+}
+
+export default ViewScheduleMembersModal

--- a/client/src/components/templates/ModalTemplate/ModalHeader.tsx
+++ b/client/src/components/templates/ModalTemplate/ModalHeader.tsx
@@ -1,7 +1,8 @@
 import React, { FC } from 'react'
+import classNames from 'classnames'
 import { Plus, X } from 'react-feather'
-import Avatar from '~/components/atoms/Avatar'
 
+import Avatar from '~/components/atoms/Avatar'
 import Button from '~/components/atoms/Buttons/Button'
 
 type Props = {
@@ -10,11 +11,20 @@ type Props = {
   closeModal: () => void
   hasAvatar?: boolean
   avatar?: string
+  className?: string | undefined
 }
 
-const ModalHeader: FC<Props> = ({ title, Icon, closeModal, hasAvatar, avatar }): JSX.Element => {
+const ModalHeader: FC<Props> = (props): JSX.Element => {
+  const { title, Icon, closeModal, hasAvatar, avatar, className } = props
+
   return (
-    <header className="flex w-full items-center justify-between border-b border-slate-200 px-5 py-4">
+    <header
+      className={classNames(
+        'flex w-full items-center justify-between',
+        'border-b border-slate-200 px-5 py-4',
+        className
+      )}
+    >
       <div className="flex items-center space-x-2 text-slate-700">
         {hasAvatar === true ? (
           <Avatar src={avatar} size="md" rounded="md" />
@@ -34,7 +44,8 @@ ModalHeader.defaultProps = {
   title: 'Title',
   Icon: Plus,
   hasAvatar: false,
-  avatar: ''
+  avatar: '',
+  className: ''
 }
 
 export default ModalHeader

--- a/client/src/pages/schedule-management.tsx
+++ b/client/src/pages/schedule-management.tsx
@@ -120,7 +120,7 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
                 queryKey: ['GET_ALL_EMPLOYEE_SCHEDULE']
               })
               .then(() => {
-                toast.success('Added New Schedule Successfully')
+                toast.success('The schedule has been added successfully!')
                 handleReset()
               })
           },
@@ -147,7 +147,7 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
         {
           onSuccess: () => {
             void queryClient.invalidateQueries().then(() => {
-              toast.success('Updated Successfully')
+              toast.success('The schedule has been updated successfully!')
             })
           },
           onSettled: () => {

--- a/client/src/utils/constants/dummyScheduleMembers.ts
+++ b/client/src/utils/constants/dummyScheduleMembers.ts
@@ -1,0 +1,90 @@
+import { IScheduleMember } from '../interfaces/scheduleMemberInterface'
+
+export const scheduleMembers: IScheduleMember[] = [
+  {
+    id: 1,
+    avatarLink:
+      'https://png.pngtree.com/png-vector/20220709/ourmid/pngtree-businessman-user-avatar-wearing-suit-with-red-tie-png-image_5809521.png',
+    name: 'James Bond 007',
+    position: {
+      name: 'Jr. Web Developer'
+    },
+    isOnline: true
+  },
+  {
+    id: 2,
+    avatarLink:
+      'https://www.kindpng.com/picc/m/163-1636340_user-avatar-icon-avatar-transparent-user-icon-png.png',
+    name: 'Jaxson Siphron',
+    position: {
+      name: 'Sr. Fullstack Developer'
+    },
+    isOnline: true
+  },
+  {
+    id: 3,
+    avatarLink: 'https://www.pngarts.com/files/6/User-Avatar-in-Suit-PNG.png',
+    name: 'Angel Press',
+    position: {
+      name: 'Jr. Web Developer'
+    },
+    isOnline: true
+  },
+  {
+    id: 4,
+    avatarLink: 'https://www.pngmart.com/files/22/User-Avatar-Profile-PNG-Isolated-Transparent.png',
+    name: 'Ryan Levin',
+    position: {
+      name: 'Web Developer'
+    },
+    isOnline: false
+  },
+  {
+    id: 5,
+    avatarLink:
+      'https://www.kindpng.com/picc/m/163-1636340_user-avatar-icon-avatar-transparent-user-icon-png.png',
+    name: 'Roger Press',
+    position: {
+      name: 'Jr. Web Developer'
+    },
+    isOnline: true
+  },
+  {
+    id: 6,
+    avatarLink: 'https://www.pngarts.com/files/6/User-Avatar-in-Suit-PNG.png',
+    name: 'Lincoln Carder',
+    position: {
+      name: 'Web Developer'
+    },
+    isOnline: true
+  },
+  {
+    id: 7,
+    avatarLink: 'https://www.pngmart.com/files/22/User-Avatar-Profile-PNG-Isolated-Transparent.png',
+    name: 'Nolan Baptista',
+    position: {
+      name: 'Backend Developer'
+    },
+    isOnline: false
+  },
+  {
+    id: 8,
+    avatarLink:
+      'https://png.pngtree.com/png-vector/20220709/ourmid/pngtree-businessman-user-avatar-wearing-suit-with-red-tie-png-image_5809521.png',
+    name: 'Danilo Granada',
+    position: {
+      name: 'Frontend Developer'
+    },
+    isOnline: true
+  },
+  {
+    id: 9,
+    avatarLink:
+      'https://png.pngtree.com/png-vector/20220709/ourmid/pngtree-businessman-user-avatar-wearing-suit-with-red-tie-png-image_5809521.png',
+    name: 'Jame Reid',
+    position: {
+      name: 'Jr. Web Developer'
+    },
+    isOnline: true
+  }
+]

--- a/client/src/utils/interfaces/scheduleMemberInterface.ts
+++ b/client/src/utils/interfaces/scheduleMemberInterface.ts
@@ -1,0 +1,9 @@
+export interface IScheduleMember {
+  id: number
+  name: string
+  avatarLink: string
+  position: {
+    name: string
+  }
+  isOnline: boolean
+}


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-208

## Definition of Done

- [x] Created `ViewScheduleMembersModal`
- [x] Displayed Member List 
- [x] Implement Simple Client Side Search Functionality
- [x] Improve Tab Page Animation with Framer motion

## Notes

Figma Design
- https://www.figma.com/file/w3lR4Elj1q5yZgK3Xw0eIx/HRIS-Wireframe?node-id=2576-28630&t=jhFnYMvC5XGJg7j5-4

## Pre-condition

#### Docker
run `docker compose up --build`

#### Local
- run `cd client && npm run dev`
- run `cd api && dotnet run watch`

## Expected Output

- It should now have a markup modal for View Schedule Members
- Simple Client Side Search Functionality of a Members

## Screenshots/Recording
[modal.webm](https://user-images.githubusercontent.com/108642414/234168144-c0b9ca86-ae21-44e0-9f04-10cd05bddc14.webm)


#### Animated Tab
[animated tab.webm](https://user-images.githubusercontent.com/108642414/234168270-07056046-f62e-4961-91b3-202880014a04.webm)
