### PR TITLE
HRIS-210 [FE] Implement UI feature to display list of employees assigned to a selected schedule

### DIFF
--- a/api/DTOs/EmployeeScheduleDTO.cs
+++ b/api/DTOs/EmployeeScheduleDTO.cs
@@ -8,12 +8,14 @@ namespace api.DTOs
         public new int? Id { get; set; }
         public string? ScheduleName { get; set; }
         public ICollection<Day> Days { get; set; }
+        public int MemberCount { get; set; }
 
         public EmployeeScheduleDTO(EmployeeSchedule employeeSchedule)
         {
             Id = employeeSchedule.Id;
             ScheduleName = employeeSchedule.Name;
             Days = new List<Day>();
+            MemberCount = employeeSchedule.Users.Count();
             if (employeeSchedule.WorkingDayTimes is not null)
             {
                 string[]? DaysOfTheWeek = { DaysOfTheWeekEnum.MONDAY, DaysOfTheWeekEnum.TUESDAY, DaysOfTheWeekEnum.WEDNESDAY, DaysOfTheWeekEnum.THURSDAY, DaysOfTheWeekEnum.FRIDAY, DaysOfTheWeekEnum.SATURDAY, DaysOfTheWeekEnum.SUNDAY };

--- a/api/Services/EmployeeScheduleService.cs
+++ b/api/Services/EmployeeScheduleService.cs
@@ -26,6 +26,7 @@ namespace api.Services
 
             return await context.EmployeeSchedules
                 .Include(x => x.WorkingDayTimes)
+                .Include(x => x.Users)
                 .Select(x => new EmployeeScheduleDTO(x))
                 .ToListAsync();
         }
@@ -36,6 +37,7 @@ namespace api.Services
 
             return await context.EmployeeSchedules
                 .Include(x => x.WorkingDayTimes)
+                .Include(x => x.Users)
                 .Where(x => x.Id == employeeScheduleId)
                 .Select(x => new EmployeeScheduleDTO(x))
                 .ToListAsync();

--- a/client/src/components/molecules/ViewScheduleMembersModal/index.tsx
+++ b/client/src/components/molecules/ViewScheduleMembersModal/index.tsx
@@ -8,14 +8,21 @@ import AddScheduleMembersModal from './AddScheduleMembersModal'
 import ModalTemplate from '~/components/templates/ModalTemplate'
 import { scheduleMembers } from '~/utils/constants/dummyScheduleMembers'
 import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+import { IScheduleMember } from '~/utils/interfaces/scheduleMemberInterface'
 
 type Props = {
   isOpen: boolean
   closeModal: () => void
   scheduleName: string
+  scheduleMembers: IScheduleMember[] | undefined
 }
 
-const ViewScheduleMembersModal: FC<Props> = ({ isOpen, closeModal, scheduleName }): JSX.Element => {
+const ViewScheduleMembersModal: FC<Props> = ({
+  isOpen,
+  closeModal,
+  scheduleName,
+  scheduleMembers
+}): JSX.Element => {
   const [isOpenAddNewSchedule, setIsOpenAddNewSchedule] = useState<boolean>(false)
   const [searchedVal, setSearchedVal] = useState<string>('')
 
@@ -97,6 +104,11 @@ const ViewScheduleMembersModal: FC<Props> = ({ isOpen, closeModal, scheduleName 
             ?.map((member) => (
               <MemberList key={member.id} {...{ member }} />
             ))}
+          {(scheduleMembers === undefined || scheduleMembers?.length <= 0) && (
+            <span className="absolute inset-x-0 left-0 right-0 w-full w-full flex-1 py-2 text-center font-medium text-slate-500">
+              No Data Available
+            </span>
+          )}
         </div>
       </main>
     </ModalTemplate>

--- a/client/src/graphql/queries/employeeSchedule.ts
+++ b/client/src/graphql/queries/employeeSchedule.ts
@@ -19,6 +19,7 @@ export const GET_EMPLOYEE_SCHEDULE = gql`
         timeIn
         timeOut
       }
+      memberCount
     }
   }
 `

--- a/client/src/graphql/queries/employeeSchedule.ts
+++ b/client/src/graphql/queries/employeeSchedule.ts
@@ -22,3 +22,17 @@ export const GET_EMPLOYEE_SCHEDULE = gql`
     }
   }
 `
+
+export const GET_EMPLOYEES_BY_SCHEDULE = gql`
+  query ($employeeScheduleId: Int!) {
+    employeesBySchedule(employeeScheduleId: $employeeScheduleId) {
+      id
+      name
+      avatarLink
+      position {
+        name
+      }
+      isOnline
+    }
+  }
+`

--- a/client/src/hooks/useEmployeeSchedule.ts
+++ b/client/src/hooks/useEmployeeSchedule.ts
@@ -54,7 +54,10 @@ type HookReturnType = {
   handleCreateEmployeeScheduleMutation: () => CreateEmployeeScheduleMutationType
   handleEditEmployeeScheduleMutation: () => EditEmployeeScheduleMutationType
   getEmployeeScheduleQuery: (employeeScheduleId: number) => GetEmployeeScheduleFuncReturnType
-  getEmployeesByScheduleQuery: (employeeScheduleId: number) => GetEmployeesByScheduleFuncReturnType
+  getEmployeesByScheduleQuery: (
+    employeeScheduleId: number,
+    isOpen: boolean
+  ) => GetEmployeesByScheduleFuncReturnType
 }
 
 const useEmployeeSchedule = (): HookReturnType => {
@@ -98,13 +101,14 @@ const useEmployeeSchedule = (): HookReturnType => {
     })
 
   const getEmployeesByScheduleQuery = (
-    employeeScheduleId: number
+    employeeScheduleId: number,
+    isOpen: boolean
   ): GetEmployeesByScheduleFuncReturnType =>
     useQuery({
       queryKey: ['GET_EMPLOYEES_BY_SCHEDULE', employeeScheduleId],
       queryFn: async () => await client.request(GET_EMPLOYEES_BY_SCHEDULE, { employeeScheduleId }),
       select: (data: { employeesBySchedule: IScheduleMember[] }) => data,
-      enabled: !isNaN(employeeScheduleId)
+      enabled: !isNaN(employeeScheduleId) && isOpen
     })
 
   return {

--- a/client/src/hooks/useEmployeeSchedule.ts
+++ b/client/src/hooks/useEmployeeSchedule.ts
@@ -4,7 +4,8 @@ import { useMutation, useQuery, UseQueryResult, UseMutationResult } from '@tanst
 import { client } from '~/utils/shared/client'
 import {
   GET_ALL_EMPLOYEE_SCHEDULE,
-  GET_EMPLOYEE_SCHEDULE
+  GET_EMPLOYEE_SCHEDULE,
+  GET_EMPLOYEES_BY_SCHEDULE
 } from '~/graphql/queries/employeeSchedule'
 
 import {
@@ -17,6 +18,7 @@ import {
   ICreateEmployeeScheduleRequestInput,
   IEditEmployeeScheduleRequestInput
 } from '~/utils/types/employeeScheduleTypes'
+import { IScheduleMember } from '~/utils/interfaces/scheduleMemberInterface'
 
 type GetAllEmployeeScheduleFuncReturnType = UseQueryResult<
   { allEmployeeScheduleDetails: IGetAllEmployeeSchedule[] },
@@ -42,11 +44,17 @@ type EditEmployeeScheduleMutationType = UseMutationResult<
   unknown
 >
 
+type GetEmployeesByScheduleFuncReturnType = UseQueryResult<
+  { employeesBySchedule: IScheduleMember[] },
+  unknown
+>
+
 type HookReturnType = {
   getAllEmployeeScheduleQuery: () => GetAllEmployeeScheduleFuncReturnType
   handleCreateEmployeeScheduleMutation: () => CreateEmployeeScheduleMutationType
   handleEditEmployeeScheduleMutation: () => EditEmployeeScheduleMutationType
   getEmployeeScheduleQuery: (employeeScheduleId: number) => GetEmployeeScheduleFuncReturnType
+  getEmployeesByScheduleQuery: (employeeScheduleId: number) => GetEmployeesByScheduleFuncReturnType
 }
 
 const useEmployeeSchedule = (): HookReturnType => {
@@ -89,11 +97,22 @@ const useEmployeeSchedule = (): HookReturnType => {
       }
     })
 
+  const getEmployeesByScheduleQuery = (
+    employeeScheduleId: number
+  ): GetEmployeesByScheduleFuncReturnType =>
+    useQuery({
+      queryKey: ['GET_EMPLOYEES_BY_SCHEDULE', employeeScheduleId],
+      queryFn: async () => await client.request(GET_EMPLOYEES_BY_SCHEDULE, { employeeScheduleId }),
+      select: (data: { employeesBySchedule: IScheduleMember[] }) => data,
+      enabled: !isNaN(employeeScheduleId)
+    })
+
   return {
     getEmployeeScheduleQuery,
     getAllEmployeeScheduleQuery,
     handleEditEmployeeScheduleMutation,
-    handleCreateEmployeeScheduleMutation
+    handleCreateEmployeeScheduleMutation,
+    getEmployeesByScheduleQuery
   }
 }
 

--- a/client/src/pages/schedule-management.tsx
+++ b/client/src/pages/schedule-management.tsx
@@ -30,7 +30,6 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
   const { id } = router.query
   const {
     getEmployeeScheduleQuery,
-    getEmployeesByScheduleQuery,
     handleCreateEmployeeScheduleMutation,
     handleEditEmployeeScheduleMutation
   } = useEmployeeSchedule()
@@ -41,8 +40,6 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
   const { data: user } = handleUserQuery()
   const createEmployeeScheduleMutation = handleCreateEmployeeScheduleMutation()
   const editEmployeeScheduleMutation = handleEditEmployeeScheduleMutation()
-  const { data: scheduleMembers, isLoading: isLoadingScheduleMembers } =
-    getEmployeesByScheduleQuery(Number(id))
   const [errorMessage, setErrorMessage] = useState<string>('')
   const {
     reset,
@@ -263,7 +260,7 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
 
   return (
     <ScheduleManagementLayout metaTitle="Schedule Management">
-      {isLoading && isLoadingScheduleMembers && id !== undefined ? (
+      {isLoading && id !== undefined ? (
         <div className="flex min-h-[50vh] items-center justify-center">
           <PulseLoader color="#ffb40b" size={10} />
         </div>
@@ -285,7 +282,7 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
                   >
                     <Users className="h-5 w-5" />
                     <span className="select-none text-xs font-medium">
-                      {scheduleMembers?.employeesBySchedule.length}
+                      {EmployeeSchedule?.memberCount}
                     </span>
                   </Button>
                 </Tippy>
@@ -293,8 +290,7 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
                   {...{
                     isOpen: isOpenViewScheduleMember,
                     closeModal: handleIsOpenViewScheduleMember,
-                    scheduleName: watch('scheduleName'),
-                    scheduleMembers: scheduleMembers?.employeesBySchedule
+                    scheduleName: watch('scheduleName')
                   }}
                 />
               </>

--- a/client/src/pages/schedule-management.tsx
+++ b/client/src/pages/schedule-management.tsx
@@ -30,6 +30,7 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
   const { id } = router.query
   const {
     getEmployeeScheduleQuery,
+    getEmployeesByScheduleQuery,
     handleCreateEmployeeScheduleMutation,
     handleEditEmployeeScheduleMutation
   } = useEmployeeSchedule()
@@ -40,6 +41,8 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
   const { data: user } = handleUserQuery()
   const createEmployeeScheduleMutation = handleCreateEmployeeScheduleMutation()
   const editEmployeeScheduleMutation = handleEditEmployeeScheduleMutation()
+  const { data: scheduleMembers, isLoading: isLoadingScheduleMembers } =
+    getEmployeesByScheduleQuery(Number(id))
   const [errorMessage, setErrorMessage] = useState<string>('')
   const {
     reset,
@@ -260,7 +263,7 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
 
   return (
     <ScheduleManagementLayout metaTitle="Schedule Management">
-      {isLoading && id !== undefined ? (
+      {isLoading && isLoadingScheduleMembers && id !== undefined ? (
         <div className="flex min-h-[50vh] items-center justify-center">
           <PulseLoader color="#ffb40b" size={10} />
         </div>
@@ -281,14 +284,17 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
                     )}
                   >
                     <Users className="h-5 w-5" />
-                    <span className="select-none text-xs font-medium">0</span>
+                    <span className="select-none text-xs font-medium">
+                      {scheduleMembers?.employeesBySchedule.length}
+                    </span>
                   </Button>
                 </Tippy>
                 <ViewScheduleMembersModal
                   {...{
                     isOpen: isOpenViewScheduleMember,
                     closeModal: handleIsOpenViewScheduleMember,
-                    scheduleName: watch('scheduleName')
+                    scheduleName: watch('scheduleName'),
+                    scheduleMembers: scheduleMembers?.employeesBySchedule
                   }}
                 />
               </>

--- a/client/src/utils/constants/fetchStatus.ts
+++ b/client/src/utils/constants/fetchStatus.ts
@@ -1,0 +1,5 @@
+export const FetchStatus = {
+  FETCHING: 'fetching',
+  PAUSED: 'paused',
+  IDLE: 'idle'
+}

--- a/client/src/utils/types/employeeScheduleTypes.ts
+++ b/client/src/utils/types/employeeScheduleTypes.ts
@@ -12,6 +12,7 @@ export interface IGetEmployeeSchedule {
     timeOut: string
   }[]
   scheduleName: string
+  memberCount: number
 }
 
 export interface ICreateEmployeeScheduleRequestInput {


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-210

## Definition of Done
- [x] Display the list of all employees assigned to selected schedule
- [x] The button contain the number of employees that belongs in the selected schedule
- [x] Added error handling if query/fetch failed

## Notes
- Added `memberCount` in the `getEmployeeScheduleQuery` query result, both in the FE and BE


## Pre-condition
- run `docker compose up --build`
- as an `Admin`, go to `Schedule Management` page
- Select a schedule and click the button on the upper right to open the modal

## Expected Output
- The button should display the number of employees that belongs to that schedule
- There should be a loading state when fetching is not yet done
- The modal should display the list of all employees that belongs to that schedule
- There should be `No Data Available` message if there are no employees in that schedule
- If user is offline or fetch failed, there should be `Error Fetching Data` message

## Screenshots/Recordings

https://user-images.githubusercontent.com/111718037/234492159-ce3ab329-5e02-4bfc-8f46-e76bc62eea36.mp4





