### PR TITLE
HRIS-219 [BE] Implement search employee functionality

### DIFF
--- a/api/Requests/SearchEmployeesByScheduleRequest.cs
+++ b/api/Requests/SearchEmployeesByScheduleRequest.cs
@@ -1,0 +1,8 @@
+namespace api.Requests
+{
+    public class SearchEmployeesByScheduleRequest
+    {
+        public int employeeScheduleId { get; set; }
+        public string searchKey { get; set; } = default!;
+    }
+}

--- a/api/Schema/Queries/EmployeeScheduleQuery.cs
+++ b/api/Schema/Queries/EmployeeScheduleQuery.cs
@@ -1,4 +1,5 @@
 using api.DTOs;
+using api.Requests;
 using api.Services;
 
 namespace api.Schema.Queries
@@ -25,6 +26,11 @@ namespace api.Schema.Queries
         public async Task<List<UserDTO>> GetEmployeesBySchedule(int employeeScheduleId)
         {
             return await _employeeScheduleService.GetEmployeesBySchedule(employeeScheduleId);
+        }
+
+        public async Task<List<UserDTO>> SearchEmployeesBySchedule(SearchEmployeesByScheduleRequest request)
+        {
+            return await _employeeScheduleService.SearchEmployeesBySchedule(request);
         }
     }
 }

--- a/api/Services/EmployeeScheduleService.cs
+++ b/api/Services/EmployeeScheduleService.cs
@@ -212,6 +212,28 @@ namespace api.Services
                 .Select(x => new UserDTO(x, domain))
                 .ToListAsync();
         }
+
+        public async Task<List<UserDTO>> SearchEmployeesBySchedule(SearchEmployeesByScheduleRequest request)
+        {
+            var domain = _httpService.getDomainURL();
+            using HrisContext context = _contextFactory.CreateDbContext();
+
+            return await context.Users
+                .Include(i => i.Role)
+                .Include(i => i.Position)
+                .Include(i => i.EmployeeSchedule)
+                .Include(i => i.ProfileImage)
+                .Include(i => i.Position)
+                .Where(x =>
+                    x.EmployeeScheduleId == request.employeeScheduleId && (
+                        x.Name!.ToLower().Contains(request.searchKey.ToLower()) ||
+                        x.Email!.ToLower().Contains(request.searchKey.ToLower()) ||
+                        x.Position.Name.ToLower().Contains(request.searchKey.ToLower())
+                    )
+                )
+                .Select(x => new UserDTO(x, domain))
+                .ToListAsync();
+        }
         public async Task<string> Delete(DeleteEmployeeScheduleRequest request, HrisContext context)
         {
             var error = ErrorMessageEnum.FAILED_SCHEDULE_DELETE;

--- a/api/Services/EmployeeScheduleService.cs
+++ b/api/Services/EmployeeScheduleService.cs
@@ -226,9 +226,9 @@ namespace api.Services
                 .Include(i => i.Position)
                 .Where(x =>
                     x.EmployeeScheduleId == request.employeeScheduleId && (
-                        x.Name!.ToLower().Contains(request.searchKey.ToLower()) ||
-                        x.Email!.ToLower().Contains(request.searchKey.ToLower()) ||
-                        x.Position.Name.ToLower().Contains(request.searchKey.ToLower())
+                        x.Name!.Contains(request.searchKey) ||
+                        x.Email!.Contains(request.searchKey) ||
+                        x.Position.Name.Contains(request.searchKey)
                     )
                 )
                 .Select(x => new UserDTO(x, domain))


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-219

## Definition of Done
- [x] Users can search for employees in a specific schedule
- [x] Search criteria is based on employees' name, email or position

## Pre-condition
- (docker) run `docker compose up --build`
- (local) run `dotnet run`
- go to `http://localhost:5257/graphql/`
- use the following query
```
query($request: SearchEmployeesByScheduleRequestInput!) {
  searchEmployeesBySchedule (request: $request) {
    id
    name
    avatarLink
    position{
      name
    }
    isOnline
  }
}

# Variables
{
  "request": {
    "employeeScheduleId": 1001,
    "searchKey": "sample"
  }
}
```

## Expected Output
- The query should return employees that belongs to schedule with id equal to `employeeScheduleId` and the name, email or positions contains the string from variable `searchKey`

## Screenshots/Recordings

https://user-images.githubusercontent.com/111718037/234754667-6d02caeb-e456-4858-bb9b-8bc3b3b5cadc.mp4


