### PR TITLE
HRIS-220 [FE] Integrate search employee functionality

### DIFF
--- a/client/src/graphql/queries/employeeSchedule.ts
+++ b/client/src/graphql/queries/employeeSchedule.ts
@@ -38,3 +38,17 @@ export const GET_EMPLOYEES_BY_SCHEDULE = gql`
     }
   }
 `
+
+export const SEARCH_EMPLOYEES_BY_SCHEDULE = gql`
+  query ($request: SearchEmployeesByScheduleRequestInput!) {
+    searchEmployeesBySchedule(request: $request) {
+      id
+      name
+      avatarLink
+      position {
+        name
+      }
+      isOnline
+    }
+  }
+`

--- a/client/src/hooks/useEmployeeSchedule.ts
+++ b/client/src/hooks/useEmployeeSchedule.ts
@@ -5,7 +5,8 @@ import { client } from '~/utils/shared/client'
 import {
   GET_ALL_EMPLOYEE_SCHEDULE,
   GET_EMPLOYEE_SCHEDULE,
-  GET_EMPLOYEES_BY_SCHEDULE
+  GET_EMPLOYEES_BY_SCHEDULE,
+  SEARCH_EMPLOYEES_BY_SCHEDULE
 } from '~/graphql/queries/employeeSchedule'
 
 import { queryClient } from '~/lib/queryClient'
@@ -21,7 +22,8 @@ import {
   ICreateEmployeeScheduleRequestInput,
   IEditEmployeeScheduleRequestInput,
   IDeleteEmployeeScheduleRequestInput,
-  IAddMemberToScheduleInput
+  IAddMemberToScheduleInput,
+  ISearchEmployeesByScheduleRequestInput
 } from '~/utils/types/employeeScheduleTypes'
 import { IScheduleMember } from '~/utils/interfaces/scheduleMemberInterface'
 
@@ -68,6 +70,11 @@ type AddMemberToScheduleReturnType = UseMutationResult<
   unknown
 >
 
+type GetSearchEmployeesByScheduleFuncReturnType = UseQueryResult<
+  { searchEmployeesBySchedule: IScheduleMember[] },
+  unknown
+>
+
 type HookReturnType = {
   getAllEmployeeScheduleQuery: () => GetAllEmployeeScheduleFuncReturnType
   handleCreateEmployeeScheduleMutation: () => CreateEmployeeScheduleMutationType
@@ -79,6 +86,10 @@ type HookReturnType = {
     employeeScheduleId: number,
     isOpen: boolean
   ) => GetEmployeesByScheduleFuncReturnType
+  getSearchEmployeesByScheduleQuery: (
+    request: ISearchEmployeesByScheduleRequestInput,
+    isOpen: boolean
+  ) => GetSearchEmployeesByScheduleFuncReturnType
 }
 
 const useEmployeeSchedule = (): HookReturnType => {
@@ -159,6 +170,17 @@ const useEmployeeSchedule = (): HookReturnType => {
       enabled: !isNaN(employeeScheduleId) && isOpen
     })
 
+  const getSearchEmployeesByScheduleQuery = (
+    request: ISearchEmployeesByScheduleRequestInput,
+    isOpen: boolean
+  ): GetSearchEmployeesByScheduleFuncReturnType =>
+    useQuery({
+      queryKey: ['SEARCH_EMPLOYEES_BY_SCHEDULE', request.employeeScheduleId, request.searchKey],
+      queryFn: async () => await client.request(SEARCH_EMPLOYEES_BY_SCHEDULE, { request }),
+      select: (data: { searchEmployeesBySchedule: IScheduleMember[] }) => data,
+      enabled: !isNaN(request.employeeScheduleId) && isOpen
+    })
+
   return {
     getEmployeeScheduleQuery,
     getAllEmployeeScheduleQuery,
@@ -166,7 +188,8 @@ const useEmployeeSchedule = (): HookReturnType => {
     handleCreateEmployeeScheduleMutation,
     handleDeleteEmployeeScheduleMutation,
     getEmployeesByScheduleQuery,
-    handleAddMemberToScheduleMutation
+    handleAddMemberToScheduleMutation,
+    getSearchEmployeesByScheduleQuery
   }
 }
 

--- a/client/src/utils/types/employeeScheduleTypes.ts
+++ b/client/src/utils/types/employeeScheduleTypes.ts
@@ -47,3 +47,8 @@ export interface IDeleteEmployeeScheduleRequestInput {
   userId: number
   employeeScheduleId: number
 }
+
+export interface ISearchEmployeesByScheduleRequestInput {
+  employeeScheduleId: number
+  searchKey: string
+}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-220

## Definition of Done
- [x] Users can search for employees in a specific schedule
- [x] Search results comes from the backend and not a filter in frontend
- [x] Querying of search key is debounced to prevent querying at every keypress

## Notes
- this integration replaced the query `getEmployeesByScheduleQuery` to `getSearchEmployeesByScheduleQuery` in `ViewScheduleMembersModal` component because it behaves the same at initial load of modal

## Pre-condition
- (docker) run `docker compose up --build`
- (local FE) run `npm run dev`
- (local BE) run `dotnet run`
- As an `admin`, go to `Schedule Management` page and click the `View all members` button on the upper right
- In the text area, enter your search key

## Expected Output
- Search key should be debounced and the query will only start after a pause on keypress
- Search key should be case-insensitive
- There should be a loading indicator while the fetching is in progress
- The search result should be employees that has the search key in the name, email or position in that specific schedule
- There should be `No Data Available` message if there is no result
- There should be `Error Fetching Data` message if fetching failed


## Screenshots/Recordings

https://user-images.githubusercontent.com/111718037/235047025-075eedfe-8839-4717-8a13-1125141f2d61.mp4


