### PR TITLE
HRIS-217 [BE] Implement re-assign employee schedule functionality

### DIFF
--- a/api/Enums/SuccessMessageEnum.cs
+++ b/api/Enums/SuccessMessageEnum.cs
@@ -3,8 +3,9 @@ namespace api.Enums
     public static class SuccessMessageEnum
     {
         public const string SCHEDULE_CREATED = "Successfully created a schedule!";
+        public const string SCHEDULE_DELETED = "Successfully deleted a schedule!";
         public const string SCHEDULE_UPDATED = "Successfully updated a schedule!";
         public const string EMPLOYEE_ADDED = "Employee(s) sccessfully added to the schedule!";
-        public const string SCHEDULE_DELETED = "Successfully deleted a schedule!";
+        public const string EMPLOYEE_SCHEDULE_UPDATED = "Employee schedule sccessfully updated!";
     }
 }

--- a/api/Requests/UpdateMemberScheduleRequest.cs
+++ b/api/Requests/UpdateMemberScheduleRequest.cs
@@ -1,0 +1,9 @@
+namespace api.Requests
+{
+    public class UpdateMemberScheduleRequest
+    {
+        public int UserId { get; set; }
+        public int EmployeeId { get; set; }
+        public int ScheduleId { get; set; }
+    }
+}

--- a/api/Schema/Mutations/EmployeeScheduleMutation.cs
+++ b/api/Schema/Mutations/EmployeeScheduleMutation.cs
@@ -59,6 +59,23 @@ namespace api.Schema.Mutations
             }
         }
 
+        public async Task<string> UpdateMemberSchedule([Service] IDbContextFactory<HrisContext> contextFactory, [Service] EmployeeScheduleService _employeeSchedueleService, UpdateMemberScheduleRequest request)
+        {
+            using HrisContext context = contextFactory.CreateDbContext();
+            try
+            {
+                using var transaction = context.Database.BeginTransaction();
+                var updatedEmployeeSchedule = await _employeeSchedueleService.UpdateMemberSchedule(request, context);
+
+                transaction.Commit();
+                return updatedEmployeeSchedule;
+            }
+            catch (GraphQLException)
+            {
+                throw;
+            }
+        }
+
         public async Task<string> DeleteEmployeeSchedule([Service] IDbContextFactory<HrisContext> contextFactory, [Service] EmployeeScheduleService _employeeSchedueleService, DeleteEmployeeScheduleRequest request)
         {
             using HrisContext context = contextFactory.CreateDbContext();

--- a/api/Services/EmployeeScheduleService.cs
+++ b/api/Services/EmployeeScheduleService.cs
@@ -130,6 +130,39 @@ namespace api.Services
             return SuccessMessageEnum.EMPLOYEE_ADDED;
         }
 
+        public async Task<string> UpdateMemberSchedule(UpdateMemberScheduleRequest request, HrisContext context)
+        {
+            // Validate input request
+            UpdateMemberScheduleInputValidation(request, context);
+
+            try
+            {
+                var user = context.Users.Find(request.EmployeeId);
+
+                // Update employee schedule
+                user!.EmployeeScheduleId = request.ScheduleId;
+
+                await context.SaveChangesAsync();
+            }
+            catch
+            {
+                throw new GraphQLException(ErrorBuilder.New()
+                                    .SetMessage(ErrorMessageEnum.FAILED_ADDING_USER_TO_SCHEDULE)
+                                    .Build());
+            }
+
+            return SuccessMessageEnum.EMPLOYEE_SCHEDULE_UPDATED;
+        }
+
+        private void UpdateMemberScheduleInputValidation(UpdateMemberScheduleRequest request, HrisContext context)
+        {
+            var errors = _customInputValidation.CheckUpdateMemberScheduleRequestInput(request, context);
+            if (errors.Count > 0)
+            {
+                throw new GraphQLException(errors);
+            }
+        }
+
         private static void AddEmployeeToSchedule(List<User> users, AddMemberToScheduleRequest request)
         {
             users.ForEach(c => c.EmployeeScheduleId = request.ScheduleId);

--- a/api/Utils/Validation.cs
+++ b/api/Utils/Validation.cs
@@ -633,5 +633,30 @@ namespace api.Utils
 
             return errors;
         }
+
+        internal List<IError> CheckUpdateMemberScheduleRequestInput(UpdateMemberScheduleRequest request, HrisContext context)
+        {
+            var errors = new List<IError>();
+            // Check HR role
+            if (!CheckHrRole(request.UserId))
+                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_HR_ADMIN));
+
+            // Check Schedule exists
+            if (CheckScheduleExist(request.ScheduleId))
+                errors.Add(buildError(nameof(request.ScheduleId), InputValidationMessageEnum.INVALID_SCHEDULE_ID));
+
+            // Check if employee exists
+            if (!checkUserExist(request.EmployeeId))
+                errors.Add(buildError(nameof(request.EmployeeId), InputValidationMessageEnum.INVALID_EMPLOYEE));
+
+            // Check if the employee already in the schedule
+            if (CheckEmployeeWithinSchedule(request.EmployeeId, request.ScheduleId, context))
+            {
+                User? user = context.Users.Find(request.EmployeeId);
+                errors.Add(buildError(nameof(request.ScheduleId), user!.Name + InputValidationMessageEnum.DUPLICATE_EMPLOYEE));
+            }
+
+            return errors;
+        }
     }
 }


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-217

## Definition of Done

- [x] Users can update the specific employee/member schedule

## Notes
- BE integration only

## Pre-condition
- In the api directory, ``` dotnet run ```
- To test the pr, run this mutation:
#### Mutation
```
mutation ($request: UpdateMemberScheduleRequestInput!) {
  updateMemberSchedule(request: $request)
}
```

#### Variables
```
{
  "request": {
  "userId": 57,
  "employeeId": 1,
  "scheduleId": 1001
  }
}
```

## Expected Output
- It should change the scheduleId of that specific user
- Returns error(s) if input(s) is/are invalid
- Returns success message if the query went through

## Screenshots/Recordings

https://user-images.githubusercontent.com/109492180/235048981-779541f4-5798-46fe-90aa-376b94d737fa.mp4

