### PR TITLE
HRIS-224 [Bugfix] Add Horizontal Scrollbar to Overtime Management Page

### DIFF
--- a/client/src/pages/overtime-management.tsx
+++ b/client/src/pages/overtime-management.tsx
@@ -149,7 +149,7 @@ const OvertimeManagement: NextPage = (): JSX.Element => {
     <Layout metaTitle="Overtime Management">
       <section
         className={classNames(
-          'default-scrollbar relative h-screen min-h-full',
+          'default-scrollbar relative h-full min-h-full',
           'overflow-auto text-xs text-slate-800'
         )}
       >


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-224

## Definition of Done

- [x] Replace `h-screen` utility to `h-full`

## Notes

- For Developer: Please be careful to change single utility
- The current problem was related to the inability of the page to display horizontal scroll, which made it difficult for users to navigate through the content

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet run watch`

## Expected Output

- Overtime Management Page will now have horizontal scrollabar
- To resolve the horizontal scroll issue, I implemented a fix by changing `h-screen` to `h-full`  utility property to the Overtime Management Page. The proposed will be testing through rigorous quality assurance testing to ensure that it does not impact any other functionality of the page.

## Screenshots/Recordings
[overtime scrollable page.webm](https://user-images.githubusercontent.com/108642414/235827183-4af11f0b-77e1-4340-903e-1a9e4a92c58a.webm)

