### PR TITLE
HRIS-229 [BE] Implement Backend Authentication and Authorization

### DIFF
--- a/api/Enums/MiddlewareErrorMessageEnum.cs
+++ b/api/Enums/MiddlewareErrorMessageEnum.cs
@@ -1,0 +1,12 @@
+namespace api.Enums
+{
+    public class MiddlewareErrorMessageEnum
+    {
+        public static readonly string UNAUTHENTICATED_USER = "Unauthenticated User!";
+        public static readonly string NO_EXISTING_USER = "No Existing User!";
+        public static readonly string NOT_ADMIN_USER = "Not an Admin User!";
+        public static readonly string NOT_MANAGER_USER = "Not a Manager User!";
+        public static readonly string NOT_ESL_USER = "Not an ESL User!";
+        public static readonly string NOT_NON_ESL_USER = "Not a Non-ESL User!";
+    }
+}

--- a/api/Middlewares/AdminUser.cs
+++ b/api/Middlewares/AdminUser.cs
@@ -1,0 +1,46 @@
+using api.Context;
+using api.Entities;
+using api.Enums;
+using HotChocolate.Resolvers;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Middlewares
+{
+    public class AdminUser
+    {
+        private readonly FieldDelegate _next;
+
+        public AdminUser(FieldDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(IMiddlewareContext context, IHttpContextAccessor accessor, IDbContextFactory<HrisContext> dbContextFactory)
+        {
+            var httpContext = accessor.HttpContext;
+            try
+            {
+                if (context.Path.ToString().Contains("/createSignIn"))
+                {
+                    await _next(context);
+                }
+                else
+                {
+                    var user = httpContext!.Items["User"] != null ? (User)httpContext.Items["User"]! : null;
+
+                    if (user == null) throw new Exception(MiddlewareErrorMessageEnum.NO_EXISTING_USER);
+                    if (user.Role.Name != RoleEnum.HR_ADMIN) throw new Exception(MiddlewareErrorMessageEnum.NOT_ADMIN_USER);
+                }
+            }
+            catch (Exception e)
+            {
+                var error = ErrorBuilder.New()
+                    .SetMessage(e.Message)
+                    .Build();
+
+                throw new GraphQLException(new[] { error });
+            }
+            await _next(context);
+        }
+    }
+}

--- a/api/Middlewares/Attributes/AdminUserAttribute.cs
+++ b/api/Middlewares/Attributes/AdminUserAttribute.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HotChocolate.Types.Descriptors;
+
+namespace api.Middlewares.Attributes
+{
+    public class AdminUserAttribute : ObjectFieldDescriptorAttribute
+    {
+        public AdminUserAttribute([CallerLineNumber] int order = 0)
+        {
+            Order = order;
+        }
+
+        protected override void OnConfigure(IDescriptorContext context,
+            IObjectFieldDescriptor descriptor, MemberInfo member)
+        {
+            descriptor.Use<AdminUser>();
+        }
+    }
+
+}

--- a/api/Middlewares/Attributes/AuthorizeUserAttribute.cs
+++ b/api/Middlewares/Attributes/AuthorizeUserAttribute.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HotChocolate.Types.Descriptors;
+
+namespace api.Middlewares.Attributes
+{
+    public class AuthorizeUserAttribute : ObjectFieldDescriptorAttribute
+    {
+        public AuthorizeUserAttribute([CallerLineNumber] int order = 0)
+        {
+            Order = order;
+        }
+
+        protected override void OnConfigure(IDescriptorContext context,
+            IObjectFieldDescriptor descriptor, MemberInfo member)
+        {
+            descriptor.Use<AuthorizeUser>();
+        }
+    }
+
+}

--- a/api/Middlewares/Attributes/ESLUserAttribute.cs
+++ b/api/Middlewares/Attributes/ESLUserAttribute.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HotChocolate.Types.Descriptors;
+
+namespace api.Middlewares.Attributes
+{
+    public class ESLUserAttribute : ObjectFieldDescriptorAttribute
+    {
+        public ESLUserAttribute([CallerLineNumber] int order = 0)
+        {
+            Order = order;
+        }
+
+        protected override void OnConfigure(IDescriptorContext context,
+            IObjectFieldDescriptor descriptor, MemberInfo member)
+        {
+            descriptor.Use<ESLUser>();
+        }
+    }
+
+}

--- a/api/Middlewares/Attributes/ManagerUserAttribute.cs
+++ b/api/Middlewares/Attributes/ManagerUserAttribute.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HotChocolate.Types.Descriptors;
+
+namespace api.Middlewares.Attributes
+{
+    public class ManagerUserAttribute : ObjectFieldDescriptorAttribute
+    {
+        public ManagerUserAttribute([CallerLineNumber] int order = 0)
+        {
+            Order = order;
+        }
+
+        protected override void OnConfigure(IDescriptorContext context,
+            IObjectFieldDescriptor descriptor, MemberInfo member)
+        {
+            descriptor.Use<ManagerUser>();
+        }
+    }
+
+}

--- a/api/Middlewares/Attributes/NonESLUserAttribute.cs
+++ b/api/Middlewares/Attributes/NonESLUserAttribute.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HotChocolate.Types.Descriptors;
+
+namespace api.Middlewares.Attributes
+{
+    public class NonESLUserAttribute : ObjectFieldDescriptorAttribute
+    {
+        public NonESLUserAttribute([CallerLineNumber] int order = 0)
+        {
+            Order = order;
+        }
+
+        protected override void OnConfigure(IDescriptorContext context,
+            IObjectFieldDescriptor descriptor, MemberInfo member)
+        {
+            descriptor.Use<NonESLUser>();
+        }
+    }
+
+}

--- a/api/Middlewares/AuthorizeUser.cs
+++ b/api/Middlewares/AuthorizeUser.cs
@@ -1,0 +1,58 @@
+using api.Context;
+using api.Enums;
+using HotChocolate.Resolvers;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Middlewares
+{
+    public class AuthorizeUser
+    {
+        private readonly FieldDelegate _next;
+
+        public AuthorizeUser(FieldDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(IMiddlewareContext context, IHttpContextAccessor accessor, IDbContextFactory<HrisContext> dbContextFactory)
+        {
+            var httpContext = accessor.HttpContext!;
+            try
+            {
+                if (httpContext.Items["User"] != null || context.Path.ToString().Contains("/createSignIn"))
+                {
+                    await _next(context);
+                }
+                else
+                {
+                    using var dbContext = dbContextFactory.CreateDbContext();
+
+                    // Get the nextAuth token from the custom HTTP header
+                    string? nextAuthToken = httpContext.Request.Headers["nextauth-token"];
+                    var personalAccessToken = await dbContext.Personal_Access_Tokens
+                                            .Where(x => x.Token == nextAuthToken)
+                                            .Include(x => x.User)
+                                                .ThenInclude(user => user!.Role)
+                                            .Include(x => x.User)
+                                                .ThenInclude(user => user!.Position)
+                                            .FirstOrDefaultAsync();
+
+                    if (personalAccessToken == null) throw new Exception(MiddlewareErrorMessageEnum.UNAUTHENTICATED_USER);
+
+                    // Add the user to the context
+                    httpContext.Items["User"] = personalAccessToken?.User;
+                }
+
+            }
+            catch (Exception e)
+            {
+                var error = ErrorBuilder.New()
+                    .SetMessage(e.Message)
+                    .Build();
+
+                throw new GraphQLException(new[] { error });
+            }
+            await _next(context);
+        }
+    }
+}

--- a/api/Middlewares/ESLUser.cs
+++ b/api/Middlewares/ESLUser.cs
@@ -1,0 +1,46 @@
+using api.Context;
+using api.Entities;
+using api.Enums;
+using HotChocolate.Resolvers;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Middlewares
+{
+    public class ESLUser
+    {
+        private readonly FieldDelegate _next;
+
+        public ESLUser(FieldDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(IMiddlewareContext context, IHttpContextAccessor accessor, IDbContextFactory<HrisContext> dbContextFactory)
+        {
+            var httpContext = accessor.HttpContext;
+            try
+            {
+                if (context.Path.ToString().Contains("/createSignIn"))
+                {
+                    await _next(context);
+                }
+                else
+                {
+                    var user = httpContext!.Items["User"] != null ? (User)httpContext.Items["User"]! : null;
+
+                    if (user == null) throw new Exception(MiddlewareErrorMessageEnum.NO_EXISTING_USER);
+                    if (user.PositionId != PositionEnum.ESL_TEACHER) throw new Exception(MiddlewareErrorMessageEnum.NOT_ESL_USER);
+                }
+            }
+            catch (Exception e)
+            {
+                var error = ErrorBuilder.New()
+                    .SetMessage(e.Message)
+                    .Build();
+
+                throw new GraphQLException(new[] { error });
+            }
+            await _next(context);
+        }
+    }
+}

--- a/api/Middlewares/ManagerUser.cs
+++ b/api/Middlewares/ManagerUser.cs
@@ -1,0 +1,46 @@
+using api.Context;
+using api.Entities;
+using api.Enums;
+using HotChocolate.Resolvers;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Middlewares
+{
+    public class ManagerUser
+    {
+        private readonly FieldDelegate _next;
+
+        public ManagerUser(FieldDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(IMiddlewareContext context, IHttpContextAccessor accessor, IDbContextFactory<HrisContext> dbContextFactory)
+        {
+            var httpContext = accessor.HttpContext;
+            try
+            {
+                if (context.Path.ToString().Contains("/createSignIn"))
+                {
+                    await _next(context);
+                }
+                else
+                {
+                    var user = httpContext!.Items["User"] != null ? (User)httpContext.Items["User"]! : null;
+
+                    if (user == null) throw new Exception(MiddlewareErrorMessageEnum.NO_EXISTING_USER);
+                    if (user.Role.Name != RoleEnum.MANAGER) throw new Exception(MiddlewareErrorMessageEnum.NOT_MANAGER_USER);
+                }
+            }
+            catch (Exception e)
+            {
+                var error = ErrorBuilder.New()
+                    .SetMessage(e.Message)
+                    .Build();
+
+                throw new GraphQLException(new[] { error });
+            }
+            await _next(context);
+        }
+    }
+}

--- a/api/Middlewares/NonESLUser.cs
+++ b/api/Middlewares/NonESLUser.cs
@@ -1,0 +1,46 @@
+using api.Context;
+using api.Entities;
+using api.Enums;
+using HotChocolate.Resolvers;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Middlewares
+{
+    public class NonESLUser
+    {
+        private readonly FieldDelegate _next;
+
+        public NonESLUser(FieldDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(IMiddlewareContext context, IHttpContextAccessor accessor, IDbContextFactory<HrisContext> dbContextFactory)
+        {
+            var httpContext = accessor.HttpContext;
+            try
+            {
+                if (context.Path.ToString().Contains("/createSignIn"))
+                {
+                    await _next(context);
+                }
+                else
+                {
+                    var user = httpContext!.Items["User"] != null ? (User)httpContext.Items["User"]! : null;
+
+                    if (user == null) throw new Exception(MiddlewareErrorMessageEnum.NO_EXISTING_USER);
+                    if (user.PositionId == PositionEnum.ESL_TEACHER) throw new Exception(MiddlewareErrorMessageEnum.NOT_NON_ESL_USER);
+                }
+            }
+            catch (Exception e)
+            {
+                var error = ErrorBuilder.New()
+                    .SetMessage(e.Message)
+                    .Build();
+
+                throw new GraphQLException(new[] { error });
+            }
+            await _next(context);
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -1,4 +1,5 @@
 using api.Context;
+using api.Middlewares;
 using api.Schedulers;
 using api.Schema.Mutations;
 using api.Schema.Queries;
@@ -24,6 +25,7 @@ builder.Services.AddCors(options =>
 
 builder.Services.AddGraphQLServer()
     .AddQueryType(q => q.Name("Query"))
+    .UseField<AuthorizeUser>()
     .AddType<UserQuery>()
     .AddType<TimeSheetQuery>()
     .AddType<InterruptionQuery>()

--- a/api/Schema/Mutations/ChangeShiftMutation.cs
+++ b/api/Schema/Mutations/ChangeShiftMutation.cs
@@ -1,5 +1,6 @@
 using api.Context;
 using api.Entities;
+using api.Middlewares.Attributes;
 using api.Requests;
 using api.Services;
 using HotChocolate.Subscriptions;
@@ -10,6 +11,7 @@ namespace api.Schema.Mutations
     [ExtendObjectType("Mutation")]
     public class ChangeShiftMutation
     {
+        [NonESLUser]
         public async Task<ChangeShiftRequest> CreateChangeShift(CreateChangeShiftRequest request, [Service] ChangeShiftService _changeShiftService, [Service] NotificationService _notificationService, [Service] ITopicEventSender eventSender, [Service] IDbContextFactory<HrisContext> contextFactory)
         {
             using (HrisContext context = contextFactory.CreateDbContext())

--- a/api/Schema/Mutations/ESLChangeShiftMutation.cs
+++ b/api/Schema/Mutations/ESLChangeShiftMutation.cs
@@ -1,5 +1,6 @@
 using api.Context;
 using api.Entities;
+using api.Middlewares.Attributes;
 using api.Requests;
 using api.Services;
 using HotChocolate.Subscriptions;
@@ -10,6 +11,7 @@ namespace api.Schema.Mutations
     [ExtendObjectType("Mutation")]
     public class ESLChangeShiftMutation
     {
+        [ESLUser]
         public async Task<ESLChangeShiftRequest> CreateESLChangeShift(CreateESLChangeShiftRequest request, [Service] ESLChangeShiftService _eslChangeShiftService, [Service] NotificationService _notificationService, [Service] ITopicEventSender eventSender, [Service] IDbContextFactory<HrisContext> contextFactory)
         {
             using (HrisContext context = contextFactory.CreateDbContext())

--- a/api/Schema/Mutations/ESLOffsetMutation.cs
+++ b/api/Schema/Mutations/ESLOffsetMutation.cs
@@ -1,5 +1,6 @@
 using api.Context;
 using api.Entities;
+using api.Middlewares.Attributes;
 using api.Requests;
 using api.Services;
 using HotChocolate.Subscriptions;
@@ -10,6 +11,7 @@ namespace api.Schema.Mutations
     [ExtendObjectType("Mutation")]
     public class ESLOffsetMutation
     {
+        [ESLUser]
         public async Task<ESLOffset> CreateESLOffset(CreateESLOffsetRequest request, [Service] ESLOffsetService _eslOffsetService, [Service] NotificationService _notificationService, [Service] ITopicEventSender eventSender, [Service] IDbContextFactory<HrisContext> contextFactory)
         {
             using (HrisContext context = contextFactory.CreateDbContext())

--- a/api/Schema/Mutations/EmployeeScheduleMutation.cs
+++ b/api/Schema/Mutations/EmployeeScheduleMutation.cs
@@ -1,4 +1,5 @@
 using api.Context;
+using api.Middlewares.Attributes;
 using api.Requests;
 using api.Services;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,7 @@ namespace api.Schema.Mutations
     [ExtendObjectType("Mutation")]
     public class EmployeeScheduleMutation
     {
+        [AdminUser]
         public async Task<string> CreateEmployeeSchedule([Service] IDbContextFactory<HrisContext> contextFactory, [Service] EmployeeScheduleService _employeeSchedueleService, CreateEmployeeScheduleRequest request)
         {
             using HrisContext context = contextFactory.CreateDbContext();
@@ -25,6 +27,7 @@ namespace api.Schema.Mutations
             }
         }
 
+        [AdminUser]
         public async Task<string> UpdateEmployeeSchedule([Service] IDbContextFactory<HrisContext> contextFactory, [Service] EmployeeScheduleService _employeeSchedueleService, UpdateEmployeeScheduleRequest request)
         {
             using HrisContext context = contextFactory.CreateDbContext();
@@ -42,6 +45,7 @@ namespace api.Schema.Mutations
             }
         }
 
+        [AdminUser]
         public async Task<string> AddMembersToSchedule([Service] IDbContextFactory<HrisContext> contextFactory, [Service] EmployeeScheduleService _employeeSchedueleService, AddMemberToScheduleRequest request)
         {
             using HrisContext context = contextFactory.CreateDbContext();
@@ -59,6 +63,7 @@ namespace api.Schema.Mutations
             }
         }
 
+        [AdminUser]
         public async Task<string> UpdateMemberSchedule([Service] IDbContextFactory<HrisContext> contextFactory, [Service] EmployeeScheduleService _employeeSchedueleService, UpdateMemberScheduleRequest request)
         {
             using HrisContext context = contextFactory.CreateDbContext();
@@ -76,6 +81,7 @@ namespace api.Schema.Mutations
             }
         }
 
+        [AdminUser]
         public async Task<string> DeleteEmployeeSchedule([Service] IDbContextFactory<HrisContext> contextFactory, [Service] EmployeeScheduleService _employeeSchedueleService, DeleteEmployeeScheduleRequest request)
         {
             using HrisContext context = contextFactory.CreateDbContext();

--- a/api/Schema/Queries/EmployeeScheduleQuery.cs
+++ b/api/Schema/Queries/EmployeeScheduleQuery.cs
@@ -1,4 +1,5 @@
 using api.DTOs;
+using api.Middlewares.Attributes;
 using api.Requests;
 using api.Services;
 
@@ -28,6 +29,7 @@ namespace api.Schema.Queries
             return await _employeeScheduleService.GetEmployeesBySchedule(employeeScheduleId);
         }
 
+        [AdminUser]
         public async Task<List<UserDTO>> SearchEmployeesBySchedule(SearchEmployeesByScheduleRequest request)
         {
             return await _employeeScheduleService.SearchEmployeesBySchedule(request);

--- a/api/Schema/Queries/LeaveQuery.cs
+++ b/api/Schema/Queries/LeaveQuery.cs
@@ -1,5 +1,6 @@
 using api.DTOs;
 using api.Entities;
+using api.Middlewares.Attributes;
 using api.Services;
 
 namespace api.Schema.Queries
@@ -13,6 +14,7 @@ namespace api.Schema.Queries
             _leaveService = leaveService;
         }
 
+        [AdminUser]
         public async Task<List<LeaveDTO>> GetAllLeaves()
         {
             return await _leaveService.Index();
@@ -26,6 +28,7 @@ namespace api.Schema.Queries
             return await _leaveService.GetLeavesSummary(userId, year);
         }
 
+        [AdminUser]
         public async Task<LeavesDTO> GetYearlyAllLeaves(int year)
         {
             return await _leaveService.ShowYearlyLeavesSummary(year);

--- a/api/Schema/Queries/TimeSheetQuery.cs
+++ b/api/Schema/Queries/TimeSheetQuery.cs
@@ -1,5 +1,6 @@
 using api.DTOs;
 using api.Entities;
+using api.Middlewares.Attributes;
 using api.Services;
 
 namespace api.Schema.Queries
@@ -33,11 +34,13 @@ namespace api.Schema.Queries
             return await _timeSheetService.GetTimeEntriesByEmployeeId(id);
         }
 
+        [AdminUser]
         public async Task<List<TimeEntryDTO>> GetTimeEntries(String? date, String? status)
         {
             return await _timeSheetService.GetAll(date, status);
         }
 
+        [AdminUser]
         public async Task<List<TimeEntriesSummaryDTO>> GetTimesheetSummary(String? startDate, String? endDate)
         {
             return await _timeSheetService.GetSummary(startDate, endDate);

--- a/client/src/pages/sign-in.tsx
+++ b/client/src/pages/sign-in.tsx
@@ -11,6 +11,7 @@ import WaveStyle from '~/utils/icons/WaveStyle'
 import { getServerSideProps } from '~/utils/ssr'
 import useSignInMutation from '~/hooks/useSignInMutation'
 import MaxWidthContainer from '~/components/atoms/MaxWidthContainer'
+import { client } from '~/utils/shared/client'
 
 type Props = {
   cookies: string | null
@@ -39,7 +40,8 @@ const SignIn: FC<Props> = ({ cookies }): JSX.Element => {
   useEffect(() => {
     if (session?.data != null) setIsVerifying(true)
     if (SignInMutation?.data?.createSignIn === true) {
-      void router.push('/')
+      client.setHeaders({ 'nextauth-token': cookies as string })
+      void router.replace('/')
       toast.success('Verification Success!', { duration: 3000 })
     } else if (session?.data != null) {
       void signOut({ callbackUrl: '/sign-in' })

--- a/client/src/utils/customHttpHeaders.ts
+++ b/client/src/utils/customHttpHeaders.ts
@@ -1,0 +1,19 @@
+type headerType =
+  | {
+      'nextauth-token': string
+    }
+  | undefined
+
+export const customHttpHeader = (): headerType => {
+  let header
+  try {
+    const token = localStorage.getItem('cookies') as string
+    if (token !== undefined) {
+      header = {
+        'nextauth-token': token
+      }
+    }
+  } catch (e) {}
+
+  return header
+}

--- a/client/src/utils/shared/client.ts
+++ b/client/src/utils/shared/client.ts
@@ -1,3 +1,6 @@
 import { GraphQLClient } from 'graphql-request'
+import { customHttpHeader } from '../customHttpHeaders'
 
-export const client = new GraphQLClient(process.env.NEXT_PUBLIC_BACKEND_URL as string)
+export const client = new GraphQLClient(process.env.NEXT_PUBLIC_BACKEND_URL as string, {
+  headers: customHttpHeader()
+})


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-229

## Definition of Done
- [x] Created middleware to authenticate user in BE using nextAuth token generated from FE, which is also stored in the DB
- [x] All queries and mutations, except to sign-in mutation, is now requiring authenticated user to access
- [x] Certain functions (queries and mutations) are now only accessible to user of certain role/position
- [x] Add the nextAuth token generated from FE to headers of every requests sent to the BE

## Notes
- This task affects all queries and mutations, it might need thoroughly testing
- `nextauth-token` should now be present in headers of every http requests

## Pre-condition
- (docker) run `docker compose up --build`
- (local FE) run `npm run dev`
- (local BE) run `dotnet run`
- if currently signed-in, logout first then sign-in again
- go to `http://localhost:5257/graphql/`
- To test `Admin Only` function, you can run this query
```
query($request: SearchEmployeesByScheduleRequestInput!) {
  searchEmployeesBySchedule (request: $request) {
    id
    name
    avatarLink
    position{
      name
    }
    isOnline
  }
}

# Variables
{
  "request": {
    "employeeScheduleId": 1,
    "searchKey": "teacher"
  }
}

# HTTP Headers
nextAuth-token: <input your token from Personal_Access_Token table in DB>
```
- To test `ESL Only` function, you can run this mutation
```
mutation ($request: CreateESLOffsetRequestInput!) {
  createESLOffset(request: $request){
    id
  }
}

# Variables
{
  "request": {
    "userId" : 4,
    "teamLeaderId" : 3,
    "timeEntryId" : 4,
    "timeIn" : "09:00",
    "timeOut" : "14:00",
    "description" : "test description",
    "title": "title 2"
  }
}

# HTTP Headers
nextAuth-token: <input your token from Personal_Access_Token table in DB>
```
- To test `Non-ESL Only` function, you can try this mutation
```
mutation ($changeShiftRequest: CreateChangeShiftRequestInput!) {
  createChangeShift(request: $changeShiftRequest){
    id
  }
}

# Variables
{
  "changeShiftRequest": {
    "userId" : 4,
    "managerId" : 80,
    "timeEntryId" : 4,
    "timeIn" : "09:00",
    "timeOut" : "14:00",
    "description" : "test description",
    "otherProject" : null,
    "projects" : [
      {
        "projectId": 2,
        "projectLeaderId": 1080
      }
    ]
  }
}

# HTTP Headers
nextAuth-token: <input your token from Personal_Access_Token table in DB>
```

## Expected Output
- [BE] If there is no `nextAuth-token` in the http headers or the value is invalid, there should be `Unauthenticated User!` error message
- [BE] If the user is not ESL User and is trying to access function for ESL users only, there should be `Not an ESL User!` error message
- [BE] If the user is not Non-ESL User and is trying to access function for Non-ESL users only, there should be `Not a Non-ESL User!` error message
- [FE] there should be `nextauth-token` present in the headers of every http request (queries or mutation)

## Screenshots/Recordings

https://user-images.githubusercontent.com/111718037/236098224-32af31f8-ca84-4030-8471-86e49013a15f.mp4


https://user-images.githubusercontent.com/111718037/236098646-a4357361-a44e-4dae-97b2-dc7c3252bf04.mp4


https://user-images.githubusercontent.com/111718037/236099393-5e11274e-6a2a-4979-a54c-5b4e29a2391b.mp4


https://user-images.githubusercontent.com/111718037/236100239-2996906e-f80b-4664-b6f0-42728b96a178.mp4


https://user-images.githubusercontent.com/111718037/236102429-31c03cb2-c20e-411d-9f31-2178af6a7197.mp4


