### PR TITLE
HRIS-226 [Bugfix] Enable scrolling for the schedule list on the Schedule Management page when there are many schedules created

### DIFF
--- a/client/src/components/templates/ScheduleManagementLayout/ScheduleList/ScheduleItem.tsx
+++ b/client/src/components/templates/ScheduleManagementLayout/ScheduleList/ScheduleItem.tsx
@@ -1,0 +1,132 @@
+import React, { FC } from 'react'
+import classNames from 'classnames'
+import toast from 'react-hot-toast'
+import { useRouter } from 'next/router'
+import { Calendar, Trash2 } from 'react-feather'
+import { confirmAlert } from 'react-confirm-alert'
+
+import Card from '~/components/atoms/Card'
+import useUserQuery from '~/hooks/useUserQuery'
+import { queryClient } from '~/lib/queryClient'
+import Button from '~/components/atoms/Buttons/Button'
+import useEmployeeSchedule from '~/hooks/useEmployeeSchedule'
+import ButtonAction from '~/components/atoms/Buttons/ButtonAction'
+import { IGetAllEmployeeSchedule } from '~/utils/types/employeeScheduleTypes'
+
+type Props = {
+  item: IGetAllEmployeeSchedule
+  closeModal?: () => void
+}
+
+const ScheduleItem: FC<Props> = (props): JSX.Element => {
+  const item = props.item
+  const closeModal = props.closeModal ?? (() => {})
+
+  const router = useRouter()
+  const id = Number(router.query.id)
+
+  // USER QUERY HOOK
+  const { handleUserQuery } = useUserQuery()
+  const { data: user } = handleUserQuery()
+
+  // EMPLOYEE SCHEDULE HOOK
+  const { handleDeleteEmployeeScheduleMutation } = useEmployeeSchedule()
+  const deleteEmployeeScheduleMutation = handleDeleteEmployeeScheduleMutation()
+  const active = item.id === id
+
+  // FOR CONFIRMATION ONLY
+  const handleRemoveConfirmation = (item: IGetAllEmployeeSchedule): void => {
+    confirmAlert({
+      customUI: ({ onClose }) => {
+        return (
+          <Card className="w-full max-w-xs px-8 py-6" shadow-size="xl" rounded="lg">
+            <h1 className="text-center text-xl font-bold">Confirmation</h1>
+            <p className="mt-2 text-sm font-medium">
+              Are you sure you want to delete{' '}
+              <b className="text-amber-500 underline">{item.scheduleName}</b> schedule?
+            </p>
+            <div className="mt-6 flex items-center justify-center space-x-2 text-white">
+              <ButtonAction
+                variant="danger"
+                onClick={() => handleDeleteSchedule(onClose, item.id)}
+                className="w-full py-1 px-4"
+              >
+                Yes
+              </ButtonAction>
+              <ButtonAction
+                onClick={onClose}
+                variant="secondary"
+                className="w-full py-1 px-4 text-slate-500"
+              >
+                No
+              </ButtonAction>
+            </div>
+          </Card>
+        )
+      }
+    })
+  }
+
+  // THIS WILL MUTATE THE DELETE ACTION
+  const handleDeleteSchedule = (onClose: () => void, id: Number): void => {
+    deleteEmployeeScheduleMutation.mutate(
+      {
+        employeeScheduleId: Number(id),
+        userId: user?.userById.id as number
+      },
+      {
+        onSuccess: () => {
+          void queryClient.invalidateQueries({
+            queryKey: ['GET_ALL_EMPLOYEE_SCHEDULE']
+          })
+          void router.replace({
+            pathname: router.pathname
+          })
+          toast.success('Deleted Successfully!')
+        }
+      }
+    )
+    onClose()
+  }
+
+  return (
+    <li
+      className={classNames(
+        'group relative flex cursor-pointer select-none items-center',
+        'justify-between transition duration-75 ease-in-out hover:bg-amber-50',
+        active ? 'bg-amber-50 text-amber-600 hover:text-amber-600' : 'text-slate-600'
+      )}
+    >
+      <div
+        onClick={() => {
+          void router
+            .replace({
+              pathname: router.pathname,
+              query: {
+                id: item.id
+              }
+            })
+            .then(() => closeModal())
+        }}
+        className={classNames('w-full py-2.5 pr-4 pl-8 hover:bg-amber-50 md:pl-4')}
+      >
+        <div className="flex items-center space-x-2">
+          <Calendar className="h-5 w-5 stroke-1" />
+          <span className="text-sm md:text-xs">{item.scheduleName}</span>
+        </div>
+      </div>
+      <div
+        className={classNames(
+          'insert-y-0 absolute right-6 z-50 flex items-center group-hover:opacity-100 md:right-5',
+          active ? 'opacity-100' : 'opacity-0 '
+        )}
+      >
+        <Button type="button" onClick={() => handleRemoveConfirmation(item)}>
+          <Trash2 className="h-5 w-5 stroke-1" />
+        </Button>
+      </div>
+    </li>
+  )
+}
+
+export default ScheduleItem

--- a/client/src/components/templates/ScheduleManagementLayout/ScheduleList/index.tsx
+++ b/client/src/components/templates/ScheduleManagementLayout/ScheduleList/index.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from 'react'
+
+import ScheduleItem from './ScheduleItem'
+import useEmployeeSchedule from '~/hooks/useEmployeeSchedule'
+
+type Props = {
+  searchedVal: string
+  closeModal?: () => void
+}
+
+const ScheduleList: FC<Props> = ({ searchedVal, closeModal }): JSX.Element => {
+  // EMPLOYEE SCHEDULE HOOKS
+  const { getAllEmployeeScheduleQuery } = useEmployeeSchedule()
+  const { data } = getAllEmployeeScheduleQuery()
+  const allEmployeeSchedule = data?.allEmployeeScheduleDetails
+
+  return (
+    <>
+      {allEmployeeSchedule
+        ?.filter(
+          (row) =>
+            searchedVal?.length === 0 ||
+            row?.scheduleName
+              .toString()
+              .toLowerCase()
+              .includes(searchedVal.toString().toLowerCase())
+        )
+        ?.map((item) => (
+          <ScheduleItem
+            key={item.id}
+            {...{
+              item,
+              closeModal
+            }}
+          />
+        ))}
+    </>
+  )
+}
+
+export default ScheduleList

--- a/client/src/components/templates/ScheduleManagementLayout/ScheduleListModal.tsx
+++ b/client/src/components/templates/ScheduleManagementLayout/ScheduleListModal.tsx
@@ -1,0 +1,77 @@
+import classNames from 'classnames'
+import { Calendar, Search } from 'react-feather'
+import React, { FC, useEffect, useState } from 'react'
+
+import ScheduleList from './ScheduleList'
+import Input from '~/components/atoms/Input'
+import ModalTemplate from './../ModalTemplate'
+import ModalHeader from './../ModalTemplate/ModalHeader'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+}
+
+const ScheduleListModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
+  const [searchedVal, setSearchedVal] = useState<string>('')
+
+  useEffect(() => {
+    if (isOpen) {
+      setSearchedVal('')
+    }
+  }, [isOpen])
+
+  return (
+    <ModalTemplate
+      {...{
+        isOpen,
+        closeModal
+      }}
+      className="w-full max-w-lg"
+    >
+      {/* Custom Modal Header */}
+      <ModalHeader
+        {...{
+          closeModal,
+          Icon: Calendar,
+          hasBorder: true,
+          title: 'Schedule List'
+        }}
+      />
+      <main>
+        {/* For Search Field */}
+        <section className="group relative px-7 py-4">
+          <div className="absolute inset-y-0 flex items-center pl-3">
+            <Search className="h-5 w-5 text-slate-400/70 group-focus-within:text-amber-500" />
+          </div>
+          <Input
+            type="text"
+            color="warning"
+            placeholder="Find Schedules"
+            onChange={(e: { target: { value: React.SetStateAction<string> } }) =>
+              setSearchedVal(e.target.value)
+            }
+            className="py-2.5 pl-10 text-sm text-slate-800"
+          />
+        </section>
+
+        <div
+          className={classNames(
+            'default-scrollbar mb-3 h-full max-h-[350px] min-h-[350px]',
+            'overflow-y-auto scrollbar-track-slate-100'
+          )}
+        >
+          {/* List of all Members */}
+          <ScheduleList
+            {...{
+              searchedVal,
+              closeModal
+            }}
+          />
+        </div>
+      </main>
+    </ModalTemplate>
+  )
+}
+
+export default ScheduleListModal

--- a/client/src/components/templates/ScheduleManagementLayout/index.tsx
+++ b/client/src/components/templates/ScheduleManagementLayout/index.tsx
@@ -1,21 +1,18 @@
-import toast from 'react-hot-toast'
+import Tippy from '@tippyjs/react'
 import classNames from 'classnames'
+import { Plus } from 'react-feather'
 import { useRouter } from 'next/router'
-import { confirmAlert } from 'react-confirm-alert'
+import { BsCalendar2Plus } from 'react-icons/bs'
 import React, { FC, ReactNode, useState } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
-import { Calendar, ChevronDown, Plus, Trash2 } from 'react-feather'
 
 import Layout from './../Layout'
+import ScheduleList from './ScheduleList'
 import CustomSearch from './CustomSearch'
 import Card from '~/components/atoms/Card'
-import { queryClient } from '~/lib/queryClient'
-import useUserQuery from '~/hooks/useUserQuery'
+import ScheduleListModal from './ScheduleListModal'
 import Button from '~/components/atoms/Buttons/Button'
-import useEmployeeSchedule from '~/hooks/useEmployeeSchedule'
-import ButtonAction from '~/components/atoms/Buttons/ButtonAction'
+import useScreenCondition from '~/hooks/useScreenCondition'
 import MaxWidthContainer from '~/components/atoms/MaxWidthContainer'
-import { IGetAllEmployeeSchedule } from '~/utils/types/employeeScheduleTypes'
 
 type Props = {
   children: ReactNode
@@ -24,13 +21,13 @@ type Props = {
 
 const ScheduleManagementLayout: FC<Props> = ({ children, metaTitle }): JSX.Element => {
   const router = useRouter()
+  const [isOpenScheduleList, setIsOpenScheduleList] = useState<boolean>(false)
   const [searchedVal, setSearchedVal] = useState<string>('')
-  const [isOpenSchedule, setIsOpenSchedule] = useState<boolean>(false)
-  const { getAllEmployeeScheduleQuery } = useEmployeeSchedule()
-  const { data } = getAllEmployeeScheduleQuery()
-  const allEmployeeSchedule = data?.allEmployeeScheduleDetails
 
-  const handleOpenScheduleToggle = (): void => setIsOpenSchedule(!isOpenSchedule)
+  // SCREEN SIZE CONDITION HOOKS
+  const isMediumScreen = useScreenCondition('(max-width: 768px)')
+
+  const handleIsOpenScheduleListToggle = (): void => setIsOpenScheduleList(!isOpenScheduleList)
 
   return (
     <Layout
@@ -38,79 +35,86 @@ const ScheduleManagementLayout: FC<Props> = ({ children, metaTitle }): JSX.Eleme
         metaTitle
       }}
     >
-      <div className="flex h-full min-h-screen flex-col text-xs text-slate-500 lg:flex-row">
-        <aside className="w-full shrink-0 border-b border-r border-slate-200 bg-white lg:w-[240px]">
-          <div
-            className={classNames(
-              'flex items-center px-4',
-              !isOpenSchedule ? 'border-b border-slate-200' : ''
-            )}
-          >
-            <CustomSearch
-              {...{
-                setSearchedVal
-              }}
-            />
+      <div className="flex h-full min-h-full flex-col text-xs text-slate-500 md:flex-row">
+        {isMediumScreen ? (
+          <aside className="flex items-center space-x-2 border-b border-slate-200 bg-white">
             <Button
               type="button"
-              onClick={handleOpenScheduleToggle}
               className={classNames(
-                'text-slate-400 opacity-100 transition duration-75',
-                'ease-in-out hover:text-slate-600 lg:opacity-0'
+                'flex w-full items-center space-x-2 px-4 py-3.5',
+                'text-amber-600 transition duration-75',
+                'ease-in-out hover:bg-amber-50'
               )}
+              onClick={() => {
+                void router.replace({
+                  pathname: router.pathname
+                })
+              }}
             >
-              <ChevronDown
-                className={`h-4 w-4 duration-300 ${isOpenSchedule ? '-rotate-90' : ''}`}
-              />
+              <Plus className="h-5 w-5" />
+              <span>Add New Schedule</span>
             </Button>
-          </div>
-          <AnimatePresence initial={false}>
-            {!isOpenSchedule ? (
-              <motion.nav animate={{ height: 'auto' }} initial={{ height: 0 }} exit={{ height: 0 }}>
-                <div className="py-2">
-                  <Button
-                    type="button"
-                    className={classNames(
-                      'flex w-full items-center space-x-2 px-4 py-2',
-                      'text-amber-600 transition duration-75',
-                      'ease-in-out hover:bg-amber-50'
-                    )}
-                    onClick={() => {
-                      void router.replace({
-                        pathname: router.pathname
-                      })
-                    }}
-                  >
-                    <Plus className="h-5 w-5" />
-                    <span>Add New Schedule</span>
-                  </Button>
-                </div>
-                <ul className="flex flex-col space-y-1">
-                  {allEmployeeSchedule
-                    ?.filter(
-                      (row) =>
-                        searchedVal?.length === 0 ||
-                        row?.scheduleName
-                          .toString()
-                          .toLowerCase()
-                          .includes(searchedVal.toString().toLowerCase())
-                    )
-                    ?.map((item) => (
-                      <ScheduleItem
-                        key={item.id}
-                        {...{
-                          ...item
-                        }}
-                      />
-                    ))}
-                </ul>
-              </motion.nav>
-            ) : null}
-          </AnimatePresence>
-        </aside>
+            <div className="py-2 pl-2 pr-5">
+              <Tippy content="List of Schedules" placement="left" className="!text-xs">
+                <Button
+                  type="button"
+                  onClick={handleIsOpenScheduleListToggle}
+                  className="text-slate-400 hover:text-amber-500"
+                >
+                  <BsCalendar2Plus className="h-5 w-5" />
+                </Button>
+              </Tippy>
+
+              {/* This will show the Schedule List Modal During Mobile */}
+              <ScheduleListModal
+                {...{
+                  isOpen: isOpenScheduleList,
+                  closeModal: handleIsOpenScheduleListToggle
+                }}
+              />
+            </div>
+          </aside>
+        ) : (
+          <aside className="flex h-full min-h-screen w-full shrink-0 flex-col border-b border-r border-slate-200 bg-white pb-16 md:w-[240px]">
+            <div className="border-b border-slate-200 px-4">
+              <CustomSearch
+                {...{
+                  setSearchedVal
+                }}
+              />
+            </div>
+            <div className="default-scrollbar flex flex-col overflow-y-auto">
+              <div className="py-2">
+                <Button
+                  type="button"
+                  className={classNames(
+                    'flex w-full items-center space-x-2 px-4 py-2',
+                    'text-amber-600 transition duration-75',
+                    'ease-in-out hover:bg-amber-50'
+                  )}
+                  onClick={() => {
+                    void router.replace({
+                      pathname: router.pathname
+                    })
+                  }}
+                >
+                  <Plus className="h-5 w-5" />
+                  <span>Add New Schedule</span>
+                </Button>
+              </div>
+              <ul className="flex flex-col space-y-1">
+                <ScheduleList
+                  {...{
+                    searchedVal
+                  }}
+                />
+              </ul>
+            </div>
+          </aside>
+        )}
         <div className="default-scrollbar h-full flex-1 overflow-y-auto">
           <MaxWidthContainer maxWidth="max-w-[900px]" className="mx-auto px-4 py-4 lg:py-5">
-            <Card className="mb-24">{children}</Card>
+            <Card className="mb-5">{children}</Card>
           </MaxWidthContainer>
         </div>
       </div>
@@ -120,101 +124,6 @@ const ScheduleManagementLayout: FC<Props> = ({ children, metaTitle }): JSX.Eleme
 
 ScheduleManagementLayout.defaultProps = {
   metaTitle: 'Schedule Management'
-}
-
-const ScheduleItem = (item: IGetAllEmployeeSchedule): JSX.Element => {
-  const router = useRouter()
-  const id = Number(router.query.id)
-  const { handleUserQuery } = useUserQuery()
-  const { data: user } = handleUserQuery()
-  const { handleDeleteEmployeeScheduleMutation } = useEmployeeSchedule()
-  const deleteEmployeeScheduleMutation = handleDeleteEmployeeScheduleMutation()
-  const active = item.id === id
-
-  // FOR CONFIRMATION ONLY
-  const handleRemoveConfirmation = (item: IGetAllEmployeeSchedule): void => {
-    confirmAlert({
-      customUI: ({ onClose }) => {
-        return (
-          <Card className="w-full max-w-xs px-8 py-6" shadow-size="xl" rounded="lg">
-            <h1 className="text-center text-xl font-bold">Confirmation</h1>
-            <p className="mt-2 text-sm font-medium">
-              Are you sure you want to delete{' '}
-              <b className="text-amber-500 underline">{item.scheduleName}</b> schedule?
-            </p>
-            <div className="mt-6 flex items-center justify-center space-x-2 text-white">
-              <ButtonAction
-                variant="danger"
-                onClick={() => handleDeleteSchedule(onClose, item.id)}
-                className="w-full py-1 px-4"
-              >
-                Yes
-              </ButtonAction>
-              <ButtonAction
-                onClick={onClose}
-                variant="secondary"
-                className="w-full py-1 px-4 text-slate-500"
-              >
-                No
-              </ButtonAction>
-            </div>
-          </Card>
-        )
-      }
-    })
-  }
-
-  // THIS WILL MUTATE THE DELETE ACTION
-  const handleDeleteSchedule = (onClose: () => void, id: Number): void => {
-    deleteEmployeeScheduleMutation.mutate(
-      {
-        employeeScheduleId: Number(id),
-        userId: user?.userById.id as number
-      },
-      {
-        onSuccess: () => {
-          void queryClient.invalidateQueries({
-            queryKey: ['GET_ALL_EMPLOYEE_SCHEDULE']
-          })
-          void router.replace({
-            pathname: router.pathname
-          })
-          toast.success('Deleted Successfully!')
-        }
-      }
-    )
-    onClose()
-  }
-
-  return (
-    <li
-      className={classNames(
-        'group flex w-full items-center justify-between',
-        'py-2 px-4 transition duration-75 ease-in-out',
-        'cursor-pointer select-none hover:bg-amber-50',
-        active ? 'bg-amber-50 text-amber-600 hover:text-amber-600' : ''
-      )}
-      onClick={(e) => {
-        e.preventDefault()
-        void router.replace({
-          pathname: router.pathname,
-          query: {
-            id: item.id
-          }
-        })
-      }}
-    >
-      <div className="flex items-center space-x-2">
-        <Calendar className="h-5 w-5 stroke-1" />
-        <span>{item.scheduleName}</span>
-      </div>
-      <div className={classNames('group-hover:opacity-100', active ? 'opacity-100' : 'opacity-0 ')}>
-        <Button type="button" onClick={() => handleRemoveConfirmation(item)}>
-          <Trash2 className="h-5 w-5 stroke-1" />
-        </Button>
-      </div>
-    </li>
-  )
 }
 
 export default ScheduleManagementLayout

--- a/client/src/hooks/useScreenCondition.ts
+++ b/client/src/hooks/useScreenCondition.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react'
+
+const useScreenCondition = (condition: string): boolean => {
+  const [isConditionMet, setIsConditionMet] = useState<boolean>(false)
+
+  useEffect(() => {
+    const handleResize = (): void => {
+      const conditionMet = window.matchMedia(condition).matches
+      setIsConditionMet(conditionMet)
+    }
+
+    // set initial condition
+    handleResize()
+
+    // add event listener for resizing
+    window.addEventListener('resize', handleResize)
+
+    // clean up event listener on unmount
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [condition])
+
+  return isConditionMet
+}
+
+export default useScreenCondition

--- a/client/src/pages/schedule-management.tsx
+++ b/client/src/pages/schedule-management.tsx
@@ -296,7 +296,7 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
           <form
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onSubmit={handleSubmit(handleSaveSchedule)}
-            className="mx-auto w-full max-w-full text-sm sm:max-w-xl"
+            className="mx-auto w-full max-w-full text-sm sm:max-w-2xl sm:px-4"
           >
             <main className="mt-8 flex flex-col space-y-5 text-[13px]">
               {errorMessage !== '' ? <Alert type="info" message={errorMessage} /> : null}
@@ -305,7 +305,7 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
               <section className="flex flex-col">
                 <label
                   htmlFor="schedule-name"
-                  className="flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2"
+                  className="flex flex-col space-y-2 lg:flex-row lg:items-center lg:space-y-0 lg:space-x-2"
                 >
                   <div className="shrink-0">Schedule Name</div>
                   <div className="w-full">
@@ -327,10 +327,10 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
               </section>
 
               {/* Days of Week Buttons */}
-              <section className="sm:-ml-2">
+              <section className="lg:-mx-2">
                 <label
                   htmlFor="schedule-name"
-                  className="flex flex-1 flex-col space-y-2 overflow-x-auto sm:flex-row sm:items-center sm:space-x-2 sm:space-y-0"
+                  className="flex flex-1 flex-col space-y-2 overflow-x-auto lg:flex-row lg:items-center lg:space-x-2 lg:space-y-0"
                 >
                   <span className="shrink-0">Days of the week</span>
                   <div className="flex flex-wrap items-center gap-2 rounded-lg">
@@ -402,11 +402,11 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
               </section>
 
               {/* Monday Field */}
-              <section className="sm:ml-12">
+              <section className="lg:mx-12">
                 <label
                   htmlFor="schedule-name"
                   className={classNames(
-                    'flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2',
+                    'flex flex-col space-y-2 lg:flex-row lg:items-center lg:space-y-0 lg:space-x-2',
                     !isEmpty(errors.monday?.timeIn) || !isEmpty(errors.monday?.timeOut)
                       ? 'mb-5'
                       : ''
@@ -450,11 +450,11 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
               </section>
 
               {/* Tuesday Field */}
-              <section className="sm:ml-12">
+              <section className="lg:mx-12">
                 <label
                   htmlFor="schedule-name"
                   className={classNames(
-                    'flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2',
+                    'flex flex-col space-y-2 lg:flex-row lg:items-center lg:space-y-0 lg:space-x-2',
                     !isEmpty(errors.tuesday?.timeIn) || !isEmpty(errors.tuesday?.timeOut)
                       ? 'mb-5'
                       : ''
@@ -498,11 +498,11 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
               </section>
 
               {/* Wednesday Field */}
-              <section className="sm:ml-7">
+              <section className="lg:mx-7">
                 <label
                   htmlFor="schedule-name"
                   className={classNames(
-                    'flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2',
+                    'flex flex-col space-y-2 lg:flex-row lg:items-center lg:space-y-0 lg:space-x-2',
                     !isEmpty(errors.wednesday?.timeIn) || !isEmpty(errors.wednesday?.timeOut)
                       ? 'mb-5'
                       : ''
@@ -546,11 +546,11 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
               </section>
 
               {/* Thursday Field */}
-              <section className="sm:ml-11">
+              <section className="lg:ml-11">
                 <label
                   htmlFor="schedule-name"
                   className={classNames(
-                    'flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2',
+                    'flex flex-col space-y-2 lg:flex-row lg:items-center lg:space-y-0 lg:space-x-2',
                     !isEmpty(errors.thursday?.timeIn) || !isEmpty(errors.thursday?.timeOut)
                       ? 'mb-5'
                       : ''
@@ -594,11 +594,11 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
               </section>
 
               {/* Friday Field */}
-              <section className="sm:ml-[65px]">
+              <section className="lg:ml-[65px]">
                 <label
                   htmlFor="schedule-name"
                   className={classNames(
-                    'flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2',
+                    'flex flex-col space-y-2 lg:flex-row lg:items-center lg:space-y-0 lg:space-x-2',
                     !isEmpty(errors.friday?.timeIn) || !isEmpty(errors.friday?.timeOut)
                       ? 'mb-5'
                       : ''
@@ -642,11 +642,11 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
               </section>
 
               {/* Saturday Field */}
-              <section className="sm:ml-11">
+              <section className="lg:ml-11">
                 <label
                   htmlFor="schedule-name"
                   className={classNames(
-                    'flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2',
+                    'flex flex-col space-y-2 lg:flex-row lg:items-center lg:space-y-0 lg:space-x-2',
                     !isEmpty(errors.saturday?.timeIn) || !isEmpty(errors.saturday?.timeOut)
                       ? 'mb-5'
                       : ''
@@ -690,11 +690,11 @@ const ScheduleManagement: NextPage = (): JSX.Element => {
               </section>
 
               {/* Sunday Field */}
-              <section className="sm:ml-14">
+              <section className="lg:ml-14">
                 <label
                   htmlFor="schedule-name"
                   className={classNames(
-                    'flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-2',
+                    'flex flex-col space-y-2 lg:flex-row lg:items-center lg:space-y-0 lg:space-x-2',
                     !isEmpty(errors.sunday?.timeIn) || !isEmpty(errors.sunday?.timeOut)
                       ? 'mb-5'
                       : ''


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-226
- https://framgiaph.backlog.com/view/HRIS-227

## Definition of Done

- [x] Created `ScheduleList` and `ScheduleItem` components
- [x] Created `ScheduleListModal` component for Table and Mobile Size
    - [x] Can Search, Delete and Navigate through other schedule route
- [x] Reused the Schedules components
- [x] Fixed Loading Indicator when triggering the delete schedule confirmation 
- [x] Implement Scrollable in the Sidebar Schedule List

## Notes

- I will create another figma design for this new UI that I implemented

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet run watch`

## Expected Output

-  HR/Admin will only be able to click the Schedule Icon Button during Mobile/Table Mode
- Fixed Loading Indicator when triggering the delete schedule confirmation 
- Schedule Sidebar list enable scrolling when there are many schedules created 
- Insures all existing functionality is still working

## Screenshots/Recordings

[record.webm](https://user-images.githubusercontent.com/108642414/236105093-e2a97da5-0472-49f2-a146-e8f4aa5f277f.webm)

