### PR TITLE
HRIS-228 [Bugfix] Disable stretch functionality for the Employee Management page.

### DIFF
--- a/client/src/components/molecules/EmployeeManagementTable/columns.tsx
+++ b/client/src/components/molecules/EmployeeManagementTable/columns.tsx
@@ -6,14 +6,14 @@ import { createColumnHelper } from '@tanstack/react-table'
 
 import SortIcon from '~/utils/icons/SortIcon'
 import Avatar from '~/components/atoms/Avatar'
-import { IEmployeeManagement } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/Button'
+import { IEmployeeManagement } from '~/utils/interfaces'
 
 const columnHelper = createColumnHelper<IEmployeeManagement>()
 
 const CellHeader = ({ label }: { label: string }): JSX.Element => {
   return (
-    <span className="group flex w-[14.7vw] items-center font-normal text-slate-500">
+    <span className="group flex w-[273px] items-center font-normal text-slate-500">
       {label}
       <SortIcon className="ml-2 h-3 w-3 shrink-0 fill-current group-active:scale-95" />
     </span>


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-228

## Definition of Done

- [x] Disable stretch functionality for the Employee Management page.

## Pre-condition

run docker or npm run dev and dotnet run
go to http://localhost:3000/employee-management

## Expected Output

Disable stretch functionality for the Employee Management page.

## Screenshots/Recordings

Proof:

[screen-capture (2).webm](https://user-images.githubusercontent.com/109579325/236107735-42ad8d23-93af-40d1-9fff-145dd12d08c9.webm)
