### PR TITLE
HRIS-232 [Bug] Fix expand fixture of menu with sub menu

### DIFF
--- a/client/src/components/atoms/Buttons/ButtonLink.tsx
+++ b/client/src/components/atoms/Buttons/ButtonLink.tsx
@@ -2,9 +2,6 @@ import Link from 'next/link'
 import React, { FC } from 'react'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
-import { ChevronRight } from 'react-feather'
-
-import Button from './Button'
 
 type Props = {
   item: {
@@ -14,12 +11,7 @@ type Props = {
     submenu: boolean | undefined
   }
   state: {
-    index: number
     isOpenSidebar: boolean
-    openIndexes: number[]
-  }
-  actions: {
-    toggleSubmenu: (index: number) => void
   }
 }
 
@@ -27,15 +19,12 @@ const ButtonLink: FC<Props> = (props): JSX.Element => {
   const router = useRouter()
 
   const {
-    item: { name, href, Icon, submenu },
-    state: { index, isOpenSidebar, openIndexes },
-    actions: { toggleSubmenu }
+    item: { name, href, Icon },
+    state: { isOpenSidebar }
   } = props
 
-  const generateHref = (href: string, isOpenSidebar: boolean, submenu?: boolean): string => {
+  const generateHref = (href: string): string => {
     switch (true) {
-      case submenu === true && isOpenSidebar:
-        return ''
       case href === '/leave-management':
         return `${href}/list-of-leave`
       case href === '/my-forms':
@@ -46,51 +35,31 @@ const ButtonLink: FC<Props> = (props): JSX.Element => {
   }
 
   return (
-    <div className="relative flex w-full items-center">
-      <Link
-        href={generateHref(href, isOpenSidebar, submenu)}
-        className={classNames(
-          'relative flex items-center transition duration-75 ease-in-out',
-          'w-full outline-none hover:bg-slate-100 hover:text-slate-700',
-          router.pathname.includes(href) && href !== '/'
-            ? 'font-medium text-slate-800'
-            : 'subpixel-antialiased',
-          router.pathname === href ? 'font-medium text-slate-800' : 'subpixel-antialiased'
-        )}
-      >
-        <span
-          className={classNames(
-            'absolute inset-y-0 border-r-[4px]',
-            router.pathname === href ? 'rounded-r-lg border-slate-600' : 'border-transparent'
-          )}
-        />
-        <div className="flex w-full items-center space-x-3 py-1.5 pr-8 pl-7">
-          <Icon className="h-5 w-5 shrink-0 stroke-0.5" />
-          <span className={`${isOpenSidebar ? 'line-clamp-1' : 'hidden'} select-none duration-300`}>
-            {name}
-          </span>
-        </div>
-      </Link>
-      {submenu === true && (
-        <Button
-          className={classNames(
-            'group absolute -right-0 z-50 ml-2 mr-4 flex items-center',
-            !isOpenSidebar && 'hidden'
-          )}
-          onClick={() => toggleSubmenu(index)}
-        >
-          <ChevronRight
-            className={classNames(
-              'h-4 w-4 shrink-0 stroke-1 duration-200 group-hover:stroke-2',
-              openIndexes.includes(index) ? 'rotate-90' : ''
-            )}
-          />
-        </Button>
+    <Link
+      href={generateHref(href)}
+      className={classNames(
+        'relative flex items-center transition duration-75 ease-in-out',
+        'w-full outline-none hover:bg-slate-100 hover:text-slate-700',
+        router.pathname.includes(href) && href !== '/'
+          ? 'font-medium text-slate-800'
+          : 'subpixel-antialiased',
+        router.pathname === href ? 'font-medium text-slate-800' : 'subpixel-antialiased'
       )}
-    </div>
+    >
+      <span
+        className={classNames(
+          'absolute inset-y-0 border-r-[4px]',
+          router.pathname === href ? 'rounded-r-lg border-slate-600' : 'border-transparent'
+        )}
+      />
+      <div className="flex w-full items-center space-x-3 py-1.5 pr-8 pl-7">
+        <Icon className="h-5 w-5 shrink-0 stroke-0.5" />
+        <span className={`${isOpenSidebar ? 'line-clamp-1' : 'hidden'} select-none duration-300`}>
+          {name}
+        </span>
+      </div>
+    </Link>
   )
 }
-
-ButtonLink.defaultProps = {}
 
 export default ButtonLink

--- a/client/src/components/molecules/NavList/index.tsx
+++ b/client/src/components/molecules/NavList/index.tsx
@@ -3,6 +3,7 @@ import Tooltip from 'rc-tooltip'
 import React, { FC } from 'react'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
+import { ChevronRight } from 'react-feather'
 import { motion, AnimatePresence } from 'framer-motion'
 import useLocalStorageState from 'use-local-storage-state'
 
@@ -50,24 +51,46 @@ const NavList: FC<Props> = ({ lists, isOpenSidebar }): JSX.Element => {
                   arrowContent={<div className="rc-tooltip-arrow-inner"></div>}
                 >
                   <div>
-                    <ButtonLink
-                      {...{
-                        item: {
-                          name: item.name,
-                          href: item.href,
-                          Icon: item.Icon,
-                          submenu: item?.submenu
-                        },
-                        state: {
-                          index,
-                          isOpenSidebar,
-                          openIndexes
-                        },
-                        actions: {
-                          toggleSubmenu
-                        }
-                      }}
-                    />
+                    {item.submenu === true && isOpenSidebar ? (
+                      <div
+                        onClick={() => toggleSubmenu(index)}
+                        className={classNames(
+                          'relative flex cursor-pointer items-center transition',
+                          'duration-75 ease-in-out hover:bg-slate-100 hover:text-slate-700'
+                        )}
+                      >
+                        <div className="flex w-full items-center space-x-3 py-1.5 pr-8 pl-7">
+                          <item.Icon className="h-5 w-5 shrink-0 stroke-0.5" />
+                          <span
+                            className={`${
+                              isOpenSidebar ? 'line-clamp-1' : 'hidden'
+                            } select-none duration-300`}
+                          >
+                            {item.name}
+                          </span>
+                        </div>
+                        <ChevronRight
+                          className={classNames(
+                            'mr-4 h-4 w-4 shrink-0 stroke-1 duration-200 group-hover:stroke-2',
+                            openIndexes.includes(index) ? 'rotate-90' : ''
+                          )}
+                        />
+                      </div>
+                    ) : (
+                      <ButtonLink
+                        {...{
+                          item: {
+                            name: item.name,
+                            href: item.href,
+                            Icon: item.Icon,
+                            submenu: item?.submenu
+                          },
+                          state: {
+                            isOpenSidebar
+                          }
+                        }}
+                      />
+                    )}
                   </div>
                 </Tooltip>
               ) : null}


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-232

## Definition of Done

- [x] Refactor `NavList` and `ButtonLink` component toexpand sub menu

## Notes

- N/A

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet run watch`

## Expected Output

- When the side menu icon clicked into the tab pages menu, the first tab page will be redirected
- Clicking `My Forms` button in sidebar or its container should display it submenus
- Clicking `Leave Management` button in sidebar or its container should display it submenus
- Clicking the main menu should display the submenu if it's not open yet and if it's already open clicking it again will collapse the the submenus

## Screenshots/Recordings
[expand.webm](https://user-images.githubusercontent.com/108642414/236158115-5b0f389d-363c-4fba-b74d-6bbfae0f885f.webm)

