### PR TITLE
HRIS-230 [Bugfix] Display the desired filter type in the notification filters function

### DIFF
--- a/client/src/pages/notifications.tsx
+++ b/client/src/pages/notifications.tsx
@@ -104,6 +104,7 @@ const Notifications: NextPage = (): JSX.Element => {
           (x.status.toLowerCase() === (query.status as string).toLowerCase() ||
             (query.status as string) === STATUS_OPTIONS.ALL.toLowerCase()) &&
           (x.type.toLowerCase() === (query.type as string).toLowerCase() ||
+            x.type.toLowerCase() === (query.type as string).toLowerCase() + '_resolved' ||
             (query.type as string) === TYPE_OPTIONS.ALL.toLowerCase())
       )
 


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-230

## Definition of Done
- [x] The desired filter type in the notification filters now also filter approved notifications

## Pre-condition
- run `docker compose up --build`
- go to Notifications page or `http://localhost:3000/notifications`

## Expected Output
- Approved notifications now also included in the selected filter type

## Screenshots/Recordings
https://user-images.githubusercontent.com/111718037/236161295-5df5ebd8-740b-4ae7-877b-ac773f90e337.mp4


