### PR TITLE
HRIS-225 [Bugfix] Update Leave Count when Leave is Filed

### DIFF
--- a/api/DTOs/UserDTO.cs
+++ b/api/DTOs/UserDTO.cs
@@ -20,6 +20,7 @@ namespace api.DTOs
             TimeEntry = user.TimeEntries != null ? checkLatestTimeEntry(user) : null;
             AvatarLink = $"{domain}/media/{user.ProfileImage?.CollectionName}/{user.ProfileImage?.FileName}";
             Position = user.Position;
+            PaidLeaves = user.PaidLeaves;
         }
         private TimeEntry? checkLatestTimeEntry(User user)
         {

--- a/api/Enums/ErrorMessageEnum.cs
+++ b/api/Enums/ErrorMessageEnum.cs
@@ -11,5 +11,6 @@ namespace api.Enums
         public const string FAILED_SCHEDULE_DELETE_USER = "Schedule has currently assigned Employees. Failed to delete schedule!";
         public const string MAXIMUM_LIMIT_OF_PAID_LEAVES = " has 0 remaining paid leaves!";
         public const string EXCEEDS_MAXIMUM_REMAINING_PAID_LEAVES = " does not have enough remaining paid leaves!";
+        public const string LEAVE_USERDETAILS_NULL_IDENTIFIER = "Leave or userDetails is null";
     }
 }

--- a/api/Enums/ErrorMessageEnum.cs
+++ b/api/Enums/ErrorMessageEnum.cs
@@ -9,5 +9,7 @@ namespace api.Enums
         public const string FAILED_ADDING_USER_TO_SCHEDULE = "Failed to add user to schedule!";
         public const string FAILED_SCHEDULE_DELETE = "Failed to delete schedule!";
         public const string FAILED_SCHEDULE_DELETE_USER = "Schedule has currently assigned Employees. Failed to delete schedule!";
+        public const string MAXIMUM_LIMIT_OF_PAID_LEAVES = " has 0 remaining paid leaves!";
+        public const string EXCEEDS_MAXIMUM_REMAINING_PAID_LEAVES = " does not have enough remaining paid leaves!";
     }
 }

--- a/api/NotificationDataClasses/LeaveData.cs
+++ b/api/NotificationDataClasses/LeaveData.cs
@@ -9,6 +9,7 @@ namespace api.NotificationDataClasses
         public string Type { get; set; } = default!;
         public string Status { get; set; } = default!;
         public string? Remarks { get; set; } = default!;
+        public bool? IsWithPay { get; set; } = default!;
     }
 
     public class LeaveManagerData : LeaveData

--- a/api/Services/ApprovalService.cs
+++ b/api/Services/ApprovalService.cs
@@ -202,23 +202,21 @@ namespace api.Services
 
         private static void UpdatePaidLeaves(Leave? leave, User? userDetails)
         {
+            if (leave == null || userDetails == null)
+            {
+                throw new GraphQLException(ErrorBuilder.New().SetMessage(ErrorMessageEnum.LEAVE_USERDETAILS_NULL_IDENTIFIER).Build());
+            }
+
             if (leave!.IsLeaderApproved == true && leave!.IsManagerApproved == true && leave!.IsWithPay)
             {
-
                 if (leave.Days > userDetails?.PaidLeaves)
                 {
                     if (userDetails?.PaidLeaves <= 0)
                     {
-                        throw new GraphQLException(ErrorBuilder.New()
-                                                        .SetMessage(userDetails?.Name + ErrorMessageEnum.MAXIMUM_LIMIT_OF_PAID_LEAVES)
-                                                        .Build());
+                        throw new GraphQLException(ErrorBuilder.New().SetMessage(userDetails?.Name + ErrorMessageEnum.MAXIMUM_LIMIT_OF_PAID_LEAVES).Build());
                     }
-                    else
-                    {
-                        throw new GraphQLException(ErrorBuilder.New()
-                                    .SetMessage(userDetails?.Name + ErrorMessageEnum.EXCEEDS_MAXIMUM_REMAINING_PAID_LEAVES)
-                                    .Build());
-                    }
+
+                    throw new GraphQLException(ErrorBuilder.New().SetMessage(userDetails?.Name + ErrorMessageEnum.EXCEEDS_MAXIMUM_REMAINING_PAID_LEAVES).Build());
                 }
                 else
                 {

--- a/api/Services/NotificationService.cs
+++ b/api/Services/NotificationService.cs
@@ -62,7 +62,8 @@ namespace api.Services
                     DateFiled = (DateTime)leave.CreatedAt!,
                     Type = NotificationDataTypeEnum.REQUEST,
                     Status = _leaveService.GetLeaveRequestStatus(leave),
-                    Remarks = leave.Reason
+                    Remarks = leave.Reason,
+                    IsWithPay = leave.IsWithPay
                 }
                     );
 
@@ -93,7 +94,8 @@ namespace api.Services
                         DateFiled = (DateTime)leave.CreatedAt,
                         Type = NotificationDataTypeEnum.REQUEST,
                         Status = _leaveService.GetLeaveRequestStatus(leave),
-                        Remarks = leave.Reason
+                        Remarks = leave.Reason,
+                        IsWithPay = leave.IsWithPay
                     }
                     );
                     var notificationToProjectLeader = new LeaveNotification

--- a/client/src/components/molecules/AddNewLeaveModal/LeaveTab.tsx
+++ b/client/src/components/molecules/AddNewLeaveModal/LeaveTab.tsx
@@ -60,6 +60,9 @@ const LeaveTab: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
     label: '',
     value: ''
   }
+  const paidLeaves = user?.userById.paidLeaves
+
+  const hasRemainingPaidLeaves = paidLeaves !== undefined ? paidLeaves <= 0 : false
 
   // modify custom style control
   customStyles.control = (provided: Record<string, unknown>, state: any): any => ({
@@ -466,14 +469,21 @@ const LeaveTab: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
                 <div className="shrink-0">
                   <label className="flex items-center">
                     <input
+                      disabled={hasRemainingPaidLeaves}
                       type="checkbox"
                       className={classNames(
-                        'h-4 w-4 rounded border-slate-300 bg-slate-100',
+                        `h-4 w-4 rounded border-slate-300 bg-slate-100 ${
+                          hasRemainingPaidLeaves ? 'opacity-30' : ''
+                        }`,
                         'text-primary focus:ring-primary'
                       )}
                       {...register(`leave_date.${index}.is_with_pay` as any)}
                     />
-                    <span className="ml-2 select-none text-xs capitalize text-slate-500">
+                    <span
+                      className={`ml-2 select-none text-xs capitalize text-slate-500 ${
+                        hasRemainingPaidLeaves ? 'opacity-30' : ''
+                      }`}
+                    >
                       With Pay
                     </span>
                   </label>

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -168,9 +168,18 @@ const Header: FC<Props> = (props): JSX.Element => {
         query: getLeaveNotificationSubQuery(userId)
       },
       {
-        next: ({ data }: any) => {
+        next: () => {
           // TO DO: change implementation when integrating with notification modal
-          void queryClient.invalidateQueries({ queryKey: ['GET_ALL_USER_NOTIFICATION'] })
+          void queryClient
+            .invalidateQueries({
+              queryKey: ['GET_ALL_USER_NOTIFICATION']
+            })
+            .then(() => {
+              // Updates the remaining paid leaves counter
+              void queryClient.invalidateQueries({
+                queryKey: ['GET_ALL_REQUESTED_LEAVES', userId]
+              })
+            })
         },
         error: () => toast.error('There was a network error'),
         complete: () => null

--- a/client/src/graphql/queries/UserQuery.ts
+++ b/client/src/graphql/queries/UserQuery.ts
@@ -5,6 +5,7 @@ export const GET_USER_QUERY = gql`
       id
       name
       avatarLink
+      paidLeaves
       position {
         id
         name

--- a/client/src/hooks/useLeave.ts
+++ b/client/src/hooks/useLeave.ts
@@ -97,8 +97,9 @@ const useLeave = (): returnType => {
       onSuccess: async () => {
         toast.success('Success!')
       },
-      onError: async () => {
-        toast.error('Something went wrong')
+      onError: async (err: Error) => {
+        const [errorMessage] = err.message.split(/:\s/, 2)
+        toast.error(errorMessage)
       }
     })
 

--- a/client/src/utils/types/userTypes.ts
+++ b/client/src/utils/types/userTypes.ts
@@ -7,6 +7,7 @@ export type User = {
   timeEntry: TimeEntry
   employeeSchedule: EmployeeSchedule
   avatarLink: string
+  paidLeaves: number
 }
 export type Position = {
   id: number


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-225

## Definition of Done

- [x] Approved leave will update the Remaining paid leave counter if it is with pay
- [x] Disables the IsWithPay checkbox if the remaining paid leaves reaches zero
- [x] Updated Error messages on approving leaves 

## Notes
- BE and FE bugfix
- Manager and Leader should approve the leave to see the update on the counter
- We can add a tooltip on the disabled WithPay option

## Pre-condition
- There should be a pending leave request
- Upon the approval of the Manager/Leader, the PaidLeaves column on the Users table will be updated if isWithPay option is enabled

## Expected Output
- It should update the value of the column PaidLeaves on the Users table if isWithPay option is enabled
- It should do a live update on FE upon approval

## Screenshots/Recordings
#### Approval

https://user-images.githubusercontent.com/109492180/236162192-65e68aaf-81b5-45f5-888b-42cf3ec3a3b0.mp4


#### Insufficient number of leaves

https://user-images.githubusercontent.com/109492180/236162486-91f3da01-cc63-4f68-8b00-2f23b6108706.mp4



#### Reached zero leaves

https://user-images.githubusercontent.com/109492180/236162696-31c513a8-9b8e-40b6-bc14-b331b9946273.mp4


#### Disabled IsWithPay if zero remaining paid leaves has reached

https://user-images.githubusercontent.com/109492180/236163179-fecb5632-18f2-48d7-b3ae-a03037bdb87e.mp4


