### PR TITLE
HRIS-246 [Bugfix] Resolve Error Thrown on Notifications Page Visit

### DIFF
--- a/client/src/pages/notifications.tsx
+++ b/client/src/pages/notifications.tsx
@@ -41,8 +41,8 @@ const Notifications: NextPage = (): JSX.Element => {
     user?.userById.id as number
   )
 
-  const [notifications, setNotifications] = useState<INotification[]>()
-  const [filteredNotifications, setFilteredNotifications] = useState<INotification[]>()
+  const [notifications, setNotifications] = useState<INotification[]>([])
+  const [filteredNotifications, setFilteredNotifications] = useState<INotification[]>([])
   const [loading, setLoading] = useState(true)
   const [globalFilter, setGlobalFilter] = useState<string>('')
   const [filters, setFilters] = useState({
@@ -161,7 +161,7 @@ const Notifications: NextPage = (): JSX.Element => {
           <NotificationList
             {...{
               query: {
-                data: filteredNotifications as INotification[]
+                data: filteredNotifications
               },
               table: {
                 columns,


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-246

## Definition of Done

- [x] Users can visit the notifications page without error even if the user has 0 notifications

## Notes
- Bugtask only

## Pre-condition
- In the root directory run ``` docker compose up ```
- Go to ``` http://localhost:3000/notifications ```

## Expected Output
- It should display the notification page without error, with or without existing notification(s)

## Screenshots/Recordings

https://user-images.githubusercontent.com/109492180/237031495-2c27c41f-35fe-4c9e-804a-38bfcd3443f7.mp4


