### PR TITLE
HRIS-253-01 [FE] Fix: Changed the border radius for specific pages

### DIFF
--- a/client/src/components/molecules/NotificationList/NotificationItem.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationItem.tsx
@@ -117,7 +117,7 @@ const NotificationItem: FC<Props> = ({ table, isLoading }): JSX.Element => {
                             }
                             src={`${row.original.userAvatarLink}`}
                             size="md"
-                            rounded="lg"
+                            rounded="full"
                           />
                           <div
                             className={classNames(

--- a/client/src/components/molecules/NotificationPopOver/index.tsx
+++ b/client/src/components/molecules/NotificationPopOver/index.tsx
@@ -102,7 +102,7 @@ const NotificationPopover: FC<Props> = (props): JSX.Element => {
                             src={`${i.userAvatarLink}`}
                             className="mt-1"
                             size="md"
-                            rounded="lg"
+                            rounded="full"
                             alt="avatar"
                           />
                           <div

--- a/client/src/components/molecules/ViewScheduleMembersModal/MemberList.tsx
+++ b/client/src/components/molecules/ViewScheduleMembersModal/MemberList.tsx
@@ -32,7 +32,7 @@ const MemberList: FC<Props> = ({ member }): JSX.Element => {
           <img
             onError={(e) => handleImageError(e, '/images/default.png')}
             src={member.avatarLink}
-            className="h-9 w-9 shrink rounded-md"
+            className="h-9 w-9 shrink rounded-full"
           />
           {/* This will act as online and offline */}
           <span

--- a/client/src/components/templates/ModalTemplate/ModalHeader.tsx
+++ b/client/src/components/templates/ModalTemplate/ModalHeader.tsx
@@ -35,7 +35,7 @@ const ModalHeader: FC<Props> = (props): JSX.Element => {
             }
             src={avatar}
             size="md"
-            rounded="md"
+            rounded="full"
             className="flex-shrink-0"
           />
         ) : (


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-253

## Definition of Done

- [x] Fixed other pages border radius

## Notes
- A fix pr

## Pre-condition
- In the root directory run ``` docker compose up ```

## Expected Output
- It should fix the broken images border radius on:
    - Notification dropdown
    - Notification page
    - Notification modal
    - Schedule modal

## Screenshots/Recordings


https://github.com/framgia/sph-hris/assets/109492180/e8f98156-d610-4508-a7f9-3cae7bf9a096

