### PR TITLE
HRIS-256 [FE] Make the DTR status visible to both the HR Admin and employee

### DIFF
--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -46,6 +46,11 @@ export const columns = [
       )
     }
   }),
+  columnHelper.accessor('status', {
+    header: () => <CellHeader label="Status" />,
+    footer: (info) => info.column.id,
+    cell: (props) => <Chip label={props.getValue()} />
+  }),
   columnHelper.accessor('timeIn.timeHour', {
     id: 'Time In',
     header: () => <CellHeader label="Time In" />,
@@ -166,11 +171,6 @@ export const columns = [
       return <span>{timeEntry.overtime != null ? timeEntry.overtime.approvedMinutes ?? 0 : 0}</span>
     },
     footer: (info) => info.column.id
-  }),
-  columnHelper.accessor('status', {
-    header: () => <CellHeader label="Status" />,
-    footer: (info) => info.column.id,
-    cell: (props) => <Chip label={props.getValue()} />
   }),
   columnHelper.display({
     id: 'id',

--- a/client/src/components/molecules/LegendTooltip/index.tsx
+++ b/client/src/components/molecules/LegendTooltip/index.tsx
@@ -29,7 +29,7 @@ const LegendTooltip: FC<Props> = ({ placement }): JSX.Element => {
             </li>
             <li className="flex items-center space-x-2">
               <HiFire className="h-5 w-4 text-red-500" />
-              <p>Beyond 7:30 rendered time</p>
+              <p>Beyond 8hrs rendered time</p>
             </li>
             <li className="flex items-center space-x-2">
               <Check className="h-4 w-4 rounded bg-green-500 p-0.5 text-white" />

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -33,6 +33,11 @@ export const columns = [
     header: () => <CellHeader label="Date" />,
     footer: (info) => info.column.id
   }),
+  columnHelper.accessor('status', {
+    header: () => <CellHeader label="Status" />,
+    footer: (info) => info.column.id,
+    cell: (props) => <Chip label={props.getValue()} />
+  }),
   columnHelper.accessor((row) => row.timeIn?.timeHour, {
     id: 'Time In',
     header: () => <CellHeader label="Time In" />,
@@ -249,11 +254,6 @@ export const columns = [
         </div>
       )
     }
-  }),
-  columnHelper.accessor('status', {
-    header: () => <CellHeader label="Status" />,
-    footer: (info) => info.column.id,
-    cell: (props) => <Chip label={props.getValue()} />
   }),
   columnHelper.display({
     id: 'id',


### PR DESCRIPTION
## Issue Link

[Backlog Link](https://framgiaph.backlog.com/view/HRIS-256)

## Definition of Done

- [x] Move the 'Status' column after the 'Name column in both the DTR Management and My DTR tables to improve user experience.
- [x] Replace Beyond 7:30 rendered time in DTR Legends to Beyond 8hrs rendered time.

## Pre-condition

run docker or npm run dev and dotnet run

## Expected Output

Move the 'Status' column after the 'Name column in both the DTR Management and My DTR tables to improve user experience.

Replace Beyond 7:30 rendered time in DTR Legends to Beyond 8hrs rendered time.

## Screenshots/Recordings

Proof:

[screen-capture.webm](https://github.com/framgia/sph-hris/assets/109579325/98ff578d-7913-4c7c-80f3-31700d6dd53d)
