### PR TITLE
HRIS-262 [FE/BE] Fix notification counter not updating the 'isRead' property when clicking the bell icon

### DIFF
--- a/api/Schema/Mutations/NotificationMutation.cs
+++ b/api/Schema/Mutations/NotificationMutation.cs
@@ -1,3 +1,4 @@
+using api.Entities;
 using api.Requests;
 using api.Services;
 
@@ -14,6 +15,11 @@ namespace api.Schema.Mutations
         public async Task<string> ReadNotification(NotificationRequest notification)
         {
             return await _notificationService.ReadNotification(notification);
+        }
+
+        public async Task<List<Notification>> IsReadAll(int id)
+        {
+            return await _notificationService.IsReadAll(id);
         }
     }
 }

--- a/api/Schema/Queries/NotificationQuery.cs
+++ b/api/Schema/Queries/NotificationQuery.cs
@@ -17,9 +17,5 @@ namespace api.Schema.Queries
             return await _notificationService.getByRecipientId(id);
         }
 
-        public async Task<List<Notification>> GetIsReadAll(int id)
-        {
-            return await _notificationService.IsReadAll(id);
-        }
     }
 }

--- a/client/src/components/molecules/NotificationPopOver/index.tsx
+++ b/client/src/components/molecules/NotificationPopOver/index.tsx
@@ -13,6 +13,8 @@ import { switchMessage } from '~/utils/notificationHelpers'
 import useNotificationMutation from '~/hooks/useNotificationMutation'
 import { NOTIFICATION_TYPE } from '~/utils/constants/notificationTypes'
 import PopoverTransition from '~/components/templates/PopoverTransition'
+import { NotificationRequestInput } from '~/utils/types/notificationTypes'
+import useUserQuery from '~/hooks/useUserQuery'
 
 type Props = {
   className: string
@@ -30,11 +32,20 @@ const NotificationPopover: FC<Props> = (props): JSX.Element => {
   )
   const main =
     'default-scrollbar max-h-[25vh] min-h-[25vh] divide-y divide-slate-200 bg-white scrollbar-thumb-slate-300'
-  const { handleNotificationMutation } = useNotificationMutation()
+  const { handleNotificationMutation, handleReadAllNotificationMutation } =
+    useNotificationMutation()
   const notificationMutations = handleNotificationMutation()
+  const readAllNotifications = handleReadAllNotificationMutation()
+  const { handleUserQuery } = useUserQuery()
+  const { data: user } = handleUserQuery()
+  const userId = user?.userById.id as unknown as NotificationRequestInput
 
   const handleLink = (id: number, open: boolean): void => {
     void notificationMutations.mutate({ id }, { onSuccess: () => checkNotification(open) })
+  }
+
+  const handleReadAllNotifications = (id: NotificationRequestInput): void => {
+    void readAllNotifications.mutate(id)
   }
 
   return (
@@ -55,6 +66,7 @@ const NotificationPopover: FC<Props> = (props): JSX.Element => {
                 open ? 'bg-slate-100' : ' text-slate-400'
               )}
               fill={open ? 'currentColor' : 'transparent'}
+              onClick={() => handleReadAllNotifications(userId)}
             />
           </Popover.Button>
           <PopoverTransition>

--- a/client/src/graphql/mutations/notificationMutation.ts
+++ b/client/src/graphql/mutations/notificationMutation.ts
@@ -5,3 +5,12 @@ export const NOTIFICATION_READ_AT_MUTATION = gql`
     readNotification(notification: $notification)
   }
 `
+export const READ_ALL_NOTIFICATIONS = gql`
+  mutation ($id: Int!) {
+    isReadAll(id: $id) {
+      id
+      readAt
+      isRead
+    }
+  }
+`

--- a/client/src/graphql/queries/NotificationQueries.ts
+++ b/client/src/graphql/queries/NotificationQueries.ts
@@ -12,13 +12,3 @@ export const GET_ALL_USER_NOTIFICATION = gql`
     }
   }
 `
-
-export const IS_READ = gql`
-  query ($id: Int!) {
-    isReadAll(id: $id) {
-      id
-      readAt
-      isRead
-    }
-  }
-`

--- a/client/src/hooks/useNotificationMutation.ts
+++ b/client/src/hooks/useNotificationMutation.ts
@@ -1,14 +1,20 @@
 import { useMutation, UseMutationResult } from '@tanstack/react-query'
 
 import { client } from '~/utils/shared/client'
-import { NOTIFICATION_READ_AT_MUTATION } from '~/graphql/mutations/notificationMutation'
-
-type NotificationRequestInput = {
-  id: number
-}
+import {
+  NOTIFICATION_READ_AT_MUTATION,
+  READ_ALL_NOTIFICATIONS
+} from '~/graphql/mutations/notificationMutation'
+import { NotificationRequestInput } from '~/utils/types/notificationTypes'
 
 type returnType = {
   handleNotificationMutation: () => UseMutationResult<
+    any,
+    unknown,
+    NotificationRequestInput,
+    unknown
+  >
+  handleReadAllNotificationMutation: () => UseMutationResult<
     any,
     unknown,
     NotificationRequestInput,
@@ -31,7 +37,16 @@ const useNotificationMutation = (): returnType => {
       },
       onSuccess: async () => {}
     })
-  return { handleNotificationMutation }
+
+  const handleReadAllNotificationMutation = (): handleNotificationMutationReturnType =>
+    useMutation({
+      mutationFn: async (id: NotificationRequestInput) => {
+        return await client.request(READ_ALL_NOTIFICATIONS, { id })
+      },
+      onSuccess: async () => {}
+    })
+
+  return { handleNotificationMutation, handleReadAllNotificationMutation }
 }
 
 export default useNotificationMutation

--- a/client/src/hooks/useNotificationQuery.ts
+++ b/client/src/hooks/useNotificationQuery.ts
@@ -2,7 +2,7 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query'
 
 import { client } from '~/utils/shared/client'
 
-import { GET_ALL_USER_NOTIFICATION, IS_READ } from '~/graphql/queries/NotificationQueries'
+import { GET_ALL_USER_NOTIFICATION } from '~/graphql/queries/NotificationQueries'
 import { UserNotifications } from '~/utils/types/notificationTypes'
 
 type getUserNotificationsQueryType = UseQueryResult<UserNotifications, unknown>
@@ -26,21 +26,3 @@ export const useNotification = (): returnType => {
 }
 
 export default useNotification
-
-export const updateIsRead = (
-  recipientId: number,
-  ready: boolean
-): UseQueryResult<
-  {
-    notificationByRecipientId: Notification[]
-  },
-  unknown
-> => {
-  const result = useQuery({
-    queryKey: ['IS_READ', recipientId],
-    queryFn: async () => await client.request(IS_READ, { id: recipientId }),
-    select: (data: { notificationByRecipientId: Notification[] }) => data,
-    enabled: !isNaN(recipientId) && ready
-  })
-  return result
-}

--- a/client/src/utils/types/notificationTypes.ts
+++ b/client/src/utils/types/notificationTypes.ts
@@ -35,3 +35,7 @@ export type NotificationData = {
   RequestedTimeOut: string | null
   Description: string | null
 }
+
+export type NotificationRequestInput = {
+  id: number
+}


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-262

## Definition of Done

- [x] Fixed notification bell counter bug where the counter does not resets when the notification is read

## Notes
- Bugtask

## Pre-condition
- New notification(s)
- In the root directory, run ``` docker compose up ```

## Expected Output
- By clicking the notification bell, it will reset the count of the notification.
     - It will also set all the notifications ```isRead``` to ``` true ``` in the notifications table
- If the notification was received while you're on the notifications page, the notification will be set to isRead true automatically

## Screenshots/Recordings


https://github.com/framgia/sph-hris/assets/109492180/0d691f0f-1615-4dd7-bdcc-618ffbe9f6ef


