### PR TITLE
HRIS-258 [FE/BE] Change the order record for DTR to be latest to oldest

### DIFF
--- a/api/Services/TimeSheetService.cs
+++ b/api/Services/TimeSheetService.cs
@@ -63,6 +63,7 @@ namespace api.Services
                         .ThenInclude(x => x.ProfileImage)
                     .Include(entry => entry.Overtime)
                     .Where(c => c.UserId == id)
+                    .OrderByDescending(entry => entry.Date)
                     .Select(x => ToTimeEntryDTO(x, leaves, domain, changeShift, eslChangeShift))
                     .ToListAsync();
             }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-258

## Definition of Done
- DTR query `timeEntriesByEmployeeId` now return record from latest to oldest

## Notes
- The change can also be seen immediately in `My Daily Time Record` page in the frontend

## Pre-condition
- (docker) run `docker compose up db api --build -d`
- go to `http://localhost:5257/graphql/`
- try this query
```
query {
    timeEntriesByEmployeeId(id: <user_id>) {
      id
      date
    }
  }
```

## Expected Output
- The query result should have in order from latest to oldest date

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/111718037/559c65da-41a7-4146-ac69-89c52d417537


