### PR TITLE
HRIS-265 [BE] Update 'Add Employee' Feature to Enable Employee Schedule Creation

### DIFF
--- a/api/Services/EmployeeService.cs
+++ b/api/Services/EmployeeService.cs
@@ -32,6 +32,46 @@ namespace api.Services
 
             try
             {
+                // Create new schedule
+                EmployeeSchedule newSchedule = new EmployeeSchedule
+                {
+                    Name = $"{capitalizedName}{(capitalizedName[^1] == 's' ? "'" : "'s")} Shift"
+                };
+
+                // Create WorkingDays for new schedule
+                List<WorkingDayTime> newWorkingDayTimes = new List<WorkingDayTime>() {
+                    new WorkingDayTime {
+                        EmployeeSchedule = newSchedule,
+                        From = new TimeSpan(9, 30, 0),
+                        To = new TimeSpan(18, 30, 0),
+                        Day = DaysOfTheWeekEnum.MONDAY
+                    },
+                    new WorkingDayTime {
+                        EmployeeSchedule = newSchedule,
+                        From = new TimeSpan(9, 30, 0),
+                        To = new TimeSpan(18, 30, 0),
+                        Day = DaysOfTheWeekEnum.TUESDAY
+                    },
+                    new WorkingDayTime {
+                        EmployeeSchedule = newSchedule,
+                        From = new TimeSpan(9, 30, 0),
+                        To = new TimeSpan(18, 30, 0),
+                        Day = DaysOfTheWeekEnum.WEDNESDAY
+                    },
+                    new WorkingDayTime {
+                        EmployeeSchedule = newSchedule,
+                        From = new TimeSpan(9, 30, 0),
+                        To = new TimeSpan(18, 30, 0),
+                        Day = DaysOfTheWeekEnum.THURSDAY
+                    },
+                    new WorkingDayTime {
+                        EmployeeSchedule = newSchedule,
+                        From = new TimeSpan(9, 30, 0),
+                        To = new TimeSpan(18, 30, 0),
+                        Day = DaysOfTheWeekEnum.FRIDAY
+                    },
+                };
+
                 var newEmployee = new User
                 {
                     Name = capitalizedName,
@@ -41,6 +81,14 @@ namespace api.Services
                     Position = position!,
                     EmployeeScheduleId = newEmployeeData.ScheduleId != null ? (int)newEmployeeData.ScheduleId : 1
                 };
+
+                // Add to context if ESL Teacher
+                if (newEmployeeData.PositionId == PositionEnum.ESL_TEACHER)
+                {
+                    context.EmployeeSchedules.Add(newSchedule);
+                    context.WorkingDayTimes.AddRange(newWorkingDayTimes);
+                    newEmployee.EmployeeSchedule = newSchedule;
+                }
 
                 context.Users.Add(newEmployee);
 


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-265

## Definition of Done
- [x] New schedule is created if new employee has position of ESL

## Notes
- ESL positionId : `5`

## Pre-condition
- (docker) run `docker compose up db api -d`
- (local api) run `dotnet run`
- go to `http://localhost:5257/graphql/`
- run the following mutation
```
mutation ($request: AddNewEmployeeRequestInput!) {
  addNewEmployee(request: $request)
}

# Variables
{
  "request": {
    "email": "test@test.com",
    "positionId" : 5,
    "roleId" : 3,
    "firstName": "Juan",
    "middleName": "middle",
    "lastName": "Manuel"
  }
}
```

## Expected Output
- If the position of the new employee is not ESL, it should only create new user
- If the position of the new employee is ESL, it should also create new schedule data in tables `EmployeeSchedules` and `WorkingDayTimes`
- If the position of the new employee is ESL, its `scheduleId` should be the `Id` of newly created schedule

## Screenshots/Recordings
https://github.com/framgia/sph-hris/assets/111718037/ae356234-b5e9-4699-96a5-4cc036d279b0


