### PR TITLE
HRIS-267 [Bugfix] Fix user login where it skips the selection of email if there's only one email currently saved

### DIFF
--- a/client/src/pages/api/auth/[...nextauth].ts
+++ b/client/src/pages/api/auth/[...nextauth].ts
@@ -5,7 +5,12 @@ export default NextAuth({
   providers: [
     GoogleProvider({
       clientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID as string,
-      clientSecret: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET as string
+      clientSecret: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET as string,
+      authorization: {
+        params: {
+          prompt: 'consent'
+        }
+      }
     })
   ],
   secret: process.env.NEXT_PUBLIC_JWT_SECRET


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-267

## Definition of Done

- [x] Users can choose email even if there's only one currently saved

## Notes
- BUGFIX

## Pre-condition
- In the root directory ``` docker compose up db api client -d ```

## Expected Output
- When the login button is click, it should direct afterwards to the selection of email(s)

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/109492180/4937a400-f2ff-434c-8bd3-6cea60e186e7



