### PR TITLE
HRIS-268 [BE/FE] Automatically update the 'Time In' and 'Time Out' columns in My DTR Page upon user clock-in and clock-out

### DIFF
--- a/client/src/hooks/useTimeInMutation.ts
+++ b/client/src/hooks/useTimeInMutation.ts
@@ -1,4 +1,6 @@
+import toast from 'react-hot-toast'
 import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query'
+
 import { UPDATE_TIME_IN_MUTATION } from '~/graphql/mutations/TimeInMutation'
 import { client } from '~/utils/shared/client'
 
@@ -27,9 +29,14 @@ const useTimeInMutation = (): returnType => {
         })
       },
       onSuccess: async () => {
-        await queryClient.invalidateQueries({
-          queryKey: ['GET_USER_QUERY']
-        })
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ['GET_USER_QUERY'] }),
+          queryClient.invalidateQueries({ queryKey: ['GET_EMPLOYEE_TIMESHEET'] })
+        ])
+      },
+      onError: (error) => {
+        const data = JSON.parse(JSON.stringify(error))
+        toast.error(data.response.errors[0].message)
       }
     })
   return { handleTimeInMutation }

--- a/client/src/hooks/useTimeOutMutation.ts
+++ b/client/src/hooks/useTimeOutMutation.ts
@@ -1,4 +1,6 @@
+import toast from 'react-hot-toast'
 import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query'
+
 import { UPDATE_TIME_OUT_MUTATION } from '~/graphql/mutations/TimeOutMutation'
 import { client } from '~/utils/shared/client'
 
@@ -24,9 +26,14 @@ const useTimeOutMutation = (): returnType => {
         })
       },
       onSuccess: async () => {
-        await queryClient.invalidateQueries({
-          queryKey: ['GET_USER_QUERY']
-        })
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ['GET_USER_QUERY'] }),
+          queryClient.invalidateQueries({ queryKey: ['GET_EMPLOYEE_TIMESHEET'] })
+        ])
+      },
+      onError: (error) => {
+        const data = JSON.parse(JSON.stringify(error))
+        toast.error(data.response.errors[0].message)
       }
     })
   return { handleTimeOutMutation }


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-268

## Definition of Done

- [x] Upon Clock In, the TimeIn time will reflect as soon as they save the time in record
- [x] Upon Clock Out, the TimeOut time will reflect as soon as they save the time out record

## Notes
- Improvement task

## Pre-condition
- In the root directory, run ``` docker compose up db api client -d ```

## Expected Output
- Time In time should be reflected real time right after saving the clock in
- Time Out time should be reflected real time right after saving the clock out

## Screenshots/Recordings


https://github.com/framgia/sph-hris/assets/109492180/4d3392c2-cc28-4d06-80b1-6b728f0d5a02

