### PR TITLE
HRIS-266 [BE] Modify DTR Management Computation on both Summary and Overview table

### DIFF
--- a/api/Context/HrisContext.cs
+++ b/api/Context/HrisContext.cs
@@ -41,7 +41,7 @@ public partial class HrisContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<EmployeeSchedule>().HasData(
-            DatabaseSeeder.employeeSchedule
+            DatabaseSeeder.allEmployeeSchedules
         );
         modelBuilder.Entity<WorkingDayTime>().HasData(
             DatabaseSeeder.workingDayTime

--- a/api/DTOs/TimeEntryDTO.cs
+++ b/api/DTOs/TimeEntryDTO.cs
@@ -6,100 +6,6 @@ namespace api.DTOs
     public class TimeEntryDTO : TimeEntry
     {
         private static readonly int ONTIME = 0;
-        public TimeEntryDTO(TimeEntry timeEntry, Leave? leave, string domain, ChangeShiftRequest? changeShift, ESLChangeShiftRequest? eslChangeShift)
-        {
-            Id = timeEntry.Id;
-            UserId = timeEntry.UserId;
-            TimeInId = timeEntry.TimeInId;
-            TimeOutId = timeEntry.TimeOutId;
-            StartTime = timeEntry.StartTime.ToString(@"hh\:mm");
-            EndTime = timeEntry.EndTime.ToString(@"hh\:mm");
-
-            Date = DateOnly.FromDateTime(timeEntry.Date);
-            WorkedHours = timeEntry.WorkedHours?.Remove(timeEntry.WorkedHours.LastIndexOf(':'));
-            TrackedHours = timeEntry.TrackedHours.ToString(@"hh\:mm");
-            User = new UserDTO(timeEntry.User, domain);
-            TimeIn = timeEntry.TimeIn != null ? new TimeDTO(timeEntry.TimeIn) : null;
-            TimeOut = timeEntry.TimeOut != null ? new TimeDTO(timeEntry.TimeOut) : null;
-            Overtime = timeEntry.Overtime;   // Overtime Entity
-            Undertime = 0;
-            Late = 0;
-            ChangeShift = changeShift != null ? new ChangeShiftDTO(changeShift) : null;
-            ESLChangeShift = eslChangeShift != null ? new ESLChangeShiftDTO(eslChangeShift) : null;
-
-            TimeSpan noonBreakStart = new TimeSpan(12, 0, 0);
-            TimeSpan noonBreakEnd = new TimeSpan(13, 0, 0);
-
-            if (timeEntry.TimeIn != null && TimeSpan.Compare(timeEntry.TimeIn.TimeHour, timeEntry.StartTime) > ONTIME)
-            {
-                this.Late = (int)timeEntry.TimeIn.TimeHour.Subtract(timeEntry.StartTime).TotalMinutes;
-            }
-
-            //  Handle early logout
-            if (timeEntry.TimeOut != null && TimeSpan.Compare(timeEntry.EndTime, timeEntry.TimeOut.TimeHour) > ONTIME)
-            {
-                this.Undertime = this.Undertime + (int)timeEntry.EndTime.Subtract(timeEntry.TimeOut.TimeHour).TotalMinutes;
-
-                // handle logout during noon break
-                if (TimeSpan.Compare(timeEntry.TimeOut.TimeHour, noonBreakStart) >= 0 && TimeSpan.Compare(timeEntry.TimeOut.TimeHour, noonBreakEnd) <= 0)
-                {
-                    this.Undertime = this.Undertime - (int)(noonBreakEnd - timeEntry.TimeOut.TimeHour).TotalMinutes;
-                }
-                // handle logout before noon break
-                else if (TimeSpan.Compare(noonBreakStart, timeEntry.TimeOut.TimeHour) >= 0)
-                {
-                    this.Undertime -= (int)(noonBreakEnd - noonBreakStart).TotalMinutes;
-                }
-            }
-
-            // Handle work interruptions undertime
-            if (timeEntry.WorkInterruptions?.Count > 0)
-            {
-                foreach (var interruptions in timeEntry.WorkInterruptions)
-                {
-                    if (interruptions.TimeIn != null && interruptions.TimeOut != null)
-                    {
-                        var difference = (interruptions.TimeIn - interruptions.TimeOut).Value.TotalMinutes;
-
-                        // interruption during noon break
-                        if ((noonBreakEnd - interruptions.TimeIn)?.TotalMinutes >= 0 && (interruptions.TimeOut - noonBreakStart)?.TotalMinutes >= 0)
-                        {
-                            difference = 0;
-                        }
-                        // interruption before noon until noon break
-                        else if ((noonBreakStart - interruptions.TimeOut)?.TotalMinutes >= 0 && (interruptions.TimeIn - noonBreakStart)?.TotalMinutes > 0 && (noonBreakEnd - interruptions.TimeIn)?.TotalMinutes >= 0)
-                        {
-                            difference = difference - (interruptions.TimeIn - noonBreakStart).Value.TotalMinutes;
-                        }
-                        // interruption during noon break until after noon break
-                        else if ((noonBreakEnd - interruptions.TimeOut)?.TotalMinutes > 0 && (interruptions.TimeIn - noonBreakEnd)?.TotalMinutes >= 0 && (interruptions.TimeOut - noonBreakStart)?.TotalMinutes >= 0)
-                        {
-                            difference = difference - (noonBreakEnd - interruptions.TimeOut).Value.TotalMinutes;
-                        }
-                        // noon break in duration of interruption
-                        else if ((noonBreakStart - interruptions.TimeOut)?.TotalMinutes >= 0 && (noonBreakEnd - interruptions.TimeIn)?.TotalMinutes <= 0)
-                        {
-                            difference = difference - (noonBreakEnd - noonBreakStart).TotalMinutes;
-                        }
-
-                        this.Undertime = this.Undertime + (int)difference;
-                    }
-                }
-            }
-
-            if (leave != null)
-            {
-                Status = (leave.LeaveType.Name!).ToLower();
-            }
-            else if (timeEntry.TimeIn == null && timeEntry.TimeOut == null)
-            {
-                Status = WorkStatusEnum.ABSENT;
-            }
-            else
-            {
-                Status = WorkStatusEnum.ONDUTY;
-            }
-        }
 
         // override
         public new UserDTO User { get; set; }
@@ -117,5 +23,124 @@ namespace api.DTOs
         public string Status { get; set; }
         public ChangeShiftDTO? ChangeShift { get; set; }
         public ESLChangeShiftDTO? ESLChangeShift { get; set; }
+
+        public TimeEntryDTO(TimeEntry timeEntry, Leave? leave, string domain, ChangeShiftRequest? changeShift, ESLChangeShiftRequest? eslChangeShift)
+        {
+            Id = timeEntry.Id;
+            UserId = timeEntry.UserId;
+            TimeInId = timeEntry.TimeInId;
+            TimeOutId = timeEntry.TimeOutId;
+            StartTime = timeEntry.StartTime.ToString(@"hh\:mm");
+            EndTime = timeEntry.EndTime.ToString(@"hh\:mm");
+
+            Date = DateOnly.FromDateTime(timeEntry.Date);
+            WorkedHours = timeEntry.WorkedHours?.Remove(timeEntry.WorkedHours.LastIndexOf(':'));
+            TrackedHours = timeEntry.TrackedHours.ToString(@"hh\:mm");
+            User = new UserDTO(timeEntry.User, domain);
+            TimeIn = timeEntry.TimeIn != null ? new TimeDTO(timeEntry.TimeIn) : null;
+            TimeOut = timeEntry.TimeOut != null ? new TimeDTO(timeEntry.TimeOut) : null;
+            Overtime = OnlyApprovedOvertime(timeEntry);   // Overtime Entity
+            Undertime = 0;
+            Late = 0;
+            ChangeShift = changeShift != null ? new ChangeShiftDTO(changeShift) : null;
+            ESLChangeShift = eslChangeShift != null ? new ESLChangeShiftDTO(eslChangeShift) : null;
+
+            TimeSpan breakStart = timeEntry.BreakStartTime;
+            TimeSpan breakEnd = timeEntry.BreakEndTime;
+
+            if (timeEntry.TimeIn != null && TimeSpan.Compare(timeEntry.TimeIn.TimeHour, timeEntry.StartTime) > ONTIME)
+            {
+                this.Late = (int)timeEntry.TimeIn.TimeHour.Subtract(timeEntry.StartTime).TotalMinutes;
+            }
+
+            //  Handle early logout
+            if (timeEntry.TimeOut != null && TimeSpan.Compare(timeEntry.EndTime, timeEntry.TimeOut.TimeHour) > ONTIME && timeEntry.CreatedAt?.Day == timeEntry.TimeOut.CreatedAt?.Day)
+            {
+                this.Undertime = this.Undertime + (int)timeEntry.EndTime.Subtract(timeEntry.TimeOut.TimeHour).TotalMinutes;
+
+                // handle logout during noon break
+                if (TimeSpan.Compare(timeEntry.TimeOut.TimeHour, breakStart) >= 0 && TimeSpan.Compare(timeEntry.TimeOut.TimeHour, breakEnd) <= 0)
+                {
+                    this.Undertime = this.Undertime - (int)(breakEnd - timeEntry.TimeOut.TimeHour).TotalMinutes;
+                }
+                // handle logout before noon break
+                else if (TimeSpan.Compare(breakStart, timeEntry.TimeOut.TimeHour) >= 0)
+                {
+                    this.Undertime -= (int)(breakEnd - breakStart).TotalMinutes;
+                }
+            }
+
+            // Handle work interruptions undertime
+            if (timeEntry.WorkInterruptions?.Count > 0)
+            {
+                foreach (var interruptions in timeEntry.WorkInterruptions)
+                {
+                    if (interruptions.TimeIn != null && interruptions.TimeOut != null)
+                    {
+                        var difference = (interruptions.TimeIn - interruptions.TimeOut).Value.TotalMinutes;
+
+                        // interruption during noon break
+                        if ((breakEnd - interruptions.TimeIn)?.TotalMinutes >= 0 && (interruptions.TimeOut - breakStart)?.TotalMinutes >= 0)
+                        {
+                            difference = 0;
+                        }
+                        // interruption before noon until noon break
+                        else if ((breakStart - interruptions.TimeOut)?.TotalMinutes >= 0 && (interruptions.TimeIn - breakStart)?.TotalMinutes > 0 && (breakEnd - interruptions.TimeIn)?.TotalMinutes >= 0)
+                        {
+                            difference = difference - (interruptions.TimeIn - breakStart).Value.TotalMinutes;
+                        }
+                        // interruption during noon break until after noon break
+                        else if ((breakEnd - interruptions.TimeOut)?.TotalMinutes > 0 && (interruptions.TimeIn - breakEnd)?.TotalMinutes >= 0 && (interruptions.TimeOut - breakStart)?.TotalMinutes >= 0)
+                        {
+                            difference = difference - (breakEnd - interruptions.TimeOut).Value.TotalMinutes;
+                        }
+                        // noon break in duration of interruption
+                        else if ((breakStart - interruptions.TimeOut)?.TotalMinutes >= 0 && (breakEnd - interruptions.TimeIn)?.TotalMinutes <= 0)
+                        {
+                            difference = difference - (breakEnd - breakStart).TotalMinutes;
+                        }
+                        this.Undertime = this.Undertime + (int)difference;
+                    }
+                }
+            }
+
+            if (leave != null)
+            {
+                Status = (leave.LeaveType.Name!).ToLower();
+            }
+            else if (timeEntry.TimeIn == null && timeEntry.TimeOut == null)
+            {
+                DateTime currentDate = DateTime.Now;
+                TimeSpan currentTimeSpan = new TimeSpan(currentDate.Hour, currentDate.Minute, 0);
+                TimeSpan timeZero = TimeSpan.FromHours(0);
+                bool sameToday = timeEntry.Date.Day == currentDate.Day;
+                bool isWorkTime = currentTimeSpan <= timeEntry.EndTime;
+                bool isRestDay = timeEntry.StartTime == timeZero && timeEntry.EndTime == timeZero && timeEntry.BreakStartTime == timeZero && timeEntry.BreakEndTime == timeZero;
+
+                if (isRestDay)
+                {
+                    Status = WorkStatusEnum.REST;
+                }
+                else if (sameToday && isWorkTime)
+                {
+                    Status = WorkStatusEnum.AWAITING;
+                }
+                else
+                {
+                    Status = WorkStatusEnum.ABSENT;
+                }
+            }
+            else
+            {
+                Status = WorkStatusEnum.ONDUTY;
+            }
+        }
+
+        // private methods
+        private Overtime? OnlyApprovedOvertime(TimeEntry timeEntry)
+        {
+            if (timeEntry.Overtime != null && timeEntry.Overtime.IsLeaderApproved == true && timeEntry.Overtime.IsManagerApproved == true) return timeEntry.Overtime;
+            else return null;
+        }
     }
 }

--- a/api/Entities/TimeEntry.cs
+++ b/api/Entities/TimeEntry.cs
@@ -13,6 +13,8 @@ namespace api.Entities
         public int? TimeOutId { get; set; }
         public TimeSpan StartTime { get; set; }
         public TimeSpan EndTime { get; set; }
+        public TimeSpan BreakStartTime { get; set; }
+        public TimeSpan BreakEndTime { get; set; }
         public DateTime Date { get; set; }
         public string? WorkedHours { get; set; }
         public TimeSpan TrackedHours { get; set; }

--- a/api/Entities/WorkingDayTime.cs
+++ b/api/Entities/WorkingDayTime.cs
@@ -12,6 +12,8 @@ namespace api.Entities
         public string? Day { get; set; }
         public TimeSpan From { get; set; }
         public TimeSpan To { get; set; }
+        public TimeSpan BreakFrom { get; set; }
+        public TimeSpan BreakTo { get; set; }
         public EmployeeSchedule EmployeeSchedule { get; set; } = default!;
     }
 }

--- a/api/Enums/WorkStatusEnum.cs
+++ b/api/Enums/WorkStatusEnum.cs
@@ -4,5 +4,7 @@ namespace api.Enums
     {
         public const string ONDUTY = "present";
         public const string ABSENT = "absent";
+        public const string REST = "rest day";
+        public const string AWAITING = "";
     }
 }

--- a/api/Migrations/20230523074842_AddBreakTime.Designer.cs
+++ b/api/Migrations/20230523074842_AddBreakTime.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Context;
 
@@ -11,9 +12,11 @@ using api.Context;
 namespace api.Migrations
 {
     [DbContext(typeof(HrisContext))]
-    partial class HrisContextModelSnapshot : ModelSnapshot
+    [Migration("20230523074842_AddBreakTime")]
+    partial class AddBreakTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/20230523074842_AddBreakTime.cs
+++ b/api/Migrations/20230523074842_AddBreakTime.cs
@@ -1,0 +1,237 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBreakTime : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<TimeSpan>(
+                name: "BreakFrom",
+                table: "WorkingDayTimes",
+                type: "time",
+                nullable: false,
+                defaultValue: new TimeSpan(0, 0, 0, 0, 0));
+
+            migrationBuilder.AddColumn<TimeSpan>(
+                name: "BreakTo",
+                table: "WorkingDayTimes",
+                type: "time",
+                nullable: false,
+                defaultValue: new TimeSpan(0, 0, 0, 0, 0));
+
+            migrationBuilder.AddColumn<TimeSpan>(
+                name: "BreakEndTime",
+                table: "TimeEntries",
+                type: "time",
+                nullable: false,
+                defaultValue: new TimeSpan(0, 0, 0, 0, 0));
+
+            migrationBuilder.AddColumn<TimeSpan>(
+                name: "BreakStartTime",
+                table: "TimeEntries",
+                type: "time",
+                nullable: false,
+                defaultValue: new TimeSpan(0, 0, 0, 0, 0));
+
+            migrationBuilder.InsertData(
+                table: "EmployeeSchedules",
+                columns: new[] { "Id", "CreatedAt", "Name", "UpdatedAt" },
+                values: new object[] { 2, new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "Afternoon Shift", new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(2907), new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(2909) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(4411), new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(4414) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(4744), new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(4745) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(4748), new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(4749) });
+
+            migrationBuilder.UpdateData(
+                table: "Notifications",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(5932), new DateTime(2023, 5, 23, 15, 48, 37, 472, DateTimeKind.Local).AddTicks(5936) });
+
+            migrationBuilder.UpdateData(
+                table: "TimeEntries",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "BreakEndTime", "BreakStartTime" },
+                values: new object[] { new TimeSpan(0, 0, 0, 0, 0), new TimeSpan(0, 0, 0, 0, 0) });
+
+            migrationBuilder.UpdateData(
+                table: "TimeEntries",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "BreakEndTime", "BreakStartTime" },
+                values: new object[] { new TimeSpan(0, 0, 0, 0, 0), new TimeSpan(0, 0, 0, 0, 0) });
+
+            migrationBuilder.UpdateData(
+                table: "TimeEntries",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "BreakEndTime", "BreakStartTime" },
+                values: new object[] { new TimeSpan(0, 0, 0, 0, 0), new TimeSpan(0, 0, 0, 0, 0) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "BreakFrom", "BreakTo" },
+                values: new object[] { new TimeSpan(0, 12, 0, 0, 0), new TimeSpan(0, 13, 0, 0, 0) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "BreakFrom", "BreakTo" },
+                values: new object[] { new TimeSpan(0, 12, 0, 0, 0), new TimeSpan(0, 13, 0, 0, 0) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "BreakFrom", "BreakTo" },
+                values: new object[] { new TimeSpan(0, 12, 0, 0, 0), new TimeSpan(0, 13, 0, 0, 0) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "BreakFrom", "BreakTo" },
+                values: new object[] { new TimeSpan(0, 12, 0, 0, 0), new TimeSpan(0, 13, 0, 0, 0) });
+
+            migrationBuilder.UpdateData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 5,
+                columns: new[] { "BreakFrom", "BreakTo" },
+                values: new object[] { new TimeSpan(0, 12, 0, 0, 0), new TimeSpan(0, 13, 0, 0, 0) });
+
+            migrationBuilder.InsertData(
+                table: "WorkingDayTimes",
+                columns: new[] { "Id", "BreakFrom", "BreakTo", "CreatedAt", "Day", "EmployeeScheduleId", "From", "To", "UpdatedAt" },
+                values: new object[,]
+                {
+                    { 6, new TimeSpan(0, 17, 0, 0, 0), new TimeSpan(0, 18, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "Monday", 2, new TimeSpan(0, 13, 0, 0, 0), new TimeSpan(0, 22, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 7, new TimeSpan(0, 17, 0, 0, 0), new TimeSpan(0, 18, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "Tuesday", 2, new TimeSpan(0, 13, 0, 0, 0), new TimeSpan(0, 22, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 8, new TimeSpan(0, 17, 0, 0, 0), new TimeSpan(0, 18, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "Wednesday", 2, new TimeSpan(0, 13, 0, 0, 0), new TimeSpan(0, 22, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 9, new TimeSpan(0, 17, 0, 0, 0), new TimeSpan(0, 18, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "Thursday", 2, new TimeSpan(0, 13, 0, 0, 0), new TimeSpan(0, 22, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) },
+                    { 10, new TimeSpan(0, 17, 0, 0, 0), new TimeSpan(0, 18, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827), "Friday", 2, new TimeSpan(0, 13, 0, 0, 0), new TimeSpan(0, 22, 0, 0, 0), new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827) }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 6);
+
+            migrationBuilder.DeleteData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 7);
+
+            migrationBuilder.DeleteData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 8);
+
+            migrationBuilder.DeleteData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 9);
+
+            migrationBuilder.DeleteData(
+                table: "WorkingDayTimes",
+                keyColumn: "Id",
+                keyValue: 10);
+
+            migrationBuilder.DeleteData(
+                table: "EmployeeSchedules",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DropColumn(
+                name: "BreakFrom",
+                table: "WorkingDayTimes");
+
+            migrationBuilder.DropColumn(
+                name: "BreakTo",
+                table: "WorkingDayTimes");
+
+            migrationBuilder.DropColumn(
+                name: "BreakEndTime",
+                table: "TimeEntries");
+
+            migrationBuilder.DropColumn(
+                name: "BreakStartTime",
+                table: "TimeEntries");
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(3145), new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(3147) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(5411), new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(5417) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(5754), new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(5756) });
+
+            migrationBuilder.UpdateData(
+                table: "MultiProjects",
+                keyColumn: "Id",
+                keyValue: 4,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(5758), new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(5759) });
+
+            migrationBuilder.UpdateData(
+                table: "Notifications",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "CreatedAt", "UpdatedAt" },
+                values: new object[] { new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(6627), new DateTime(2023, 5, 16, 11, 43, 8, 757, DateTimeKind.Local).AddTicks(6629) });
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -89,6 +89,26 @@ builder.Services.AddScoped<EmployeeService>();
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var services = scope.ServiceProvider;
+    try
+    {
+        var dbFactory = services.GetRequiredService<IDbContextFactory<HrisContext>>();
+        using var dbContext = dbFactory.CreateDbContext();
+
+        if (dbContext.Database.CanConnect())
+        {
+            dbContext.Database.Migrate();
+        }
+    }
+    catch (Exception ex)
+    {
+        // Handle any exceptions that occur during database migration
+        Console.WriteLine("An error occurred while migrating the database: " + ex.Message);
+    }
+}
+
 app.UseForwardedHeaders(new ForwardedHeadersOptions
 {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto

--- a/api/Seeders/DatabaseSeeder.cs
+++ b/api/Seeders/DatabaseSeeder.cs
@@ -32,6 +32,19 @@ namespace api.Seeders
             CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
             UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
         };
+
+        public static EmployeeSchedule employeeAfternoonSchedule = new EmployeeSchedule
+        {
+            Id = 2,
+            Name = "Afternoon Shift",
+            CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+            UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+        };
+
+        public static List<EmployeeSchedule> allEmployeeSchedules = new List<EmployeeSchedule>() {
+            employeeSchedule, employeeAfternoonSchedule
+        };
+
         public static List<WorkingDayTime> workingDayTime = new List<WorkingDayTime>(){
             new WorkingDayTime {
                 Id = 1,
@@ -39,6 +52,8 @@ namespace api.Seeders
                 Day = "Monday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0),
+                BreakFrom = new TimeSpan(12, 0, 0),
+                BreakTo = new TimeSpan(13, 0, 0),
                 CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                 UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
             },
@@ -48,6 +63,8 @@ namespace api.Seeders
                 Day = "Tuesday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0),
+                BreakFrom = new TimeSpan(12, 0, 0),
+                BreakTo = new TimeSpan(13, 0, 0),
                 CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                 UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
             },
@@ -57,6 +74,8 @@ namespace api.Seeders
                 Day = "Wednesday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0),
+                BreakFrom = new TimeSpan(12, 0, 0),
+                BreakTo = new TimeSpan(13, 0, 0),
                 CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                 UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
             },
@@ -66,6 +85,8 @@ namespace api.Seeders
                 Day = "Thursday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0),
+                BreakFrom = new TimeSpan(12, 0, 0),
+                BreakTo = new TimeSpan(13, 0, 0),
                 CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                 UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
             },
@@ -75,6 +96,63 @@ namespace api.Seeders
                 Day = "Friday",
                 From = new TimeSpan(9, 30, 0),
                 To = new TimeSpan(18, 30, 0),
+                BreakFrom = new TimeSpan(12, 0, 0),
+                BreakTo = new TimeSpan(13, 0, 0),
+                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+            },
+            new WorkingDayTime {
+                Id = 6,
+                EmployeeScheduleId = employeeAfternoonSchedule.Id,
+                Day = "Monday",
+                From = new TimeSpan(13, 0, 0),
+                To = new TimeSpan(22, 00, 0),
+                BreakFrom = new TimeSpan(17, 0, 0),
+                BreakTo = new TimeSpan(18, 0, 0),
+                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+            },
+            new WorkingDayTime {
+                Id = 7,
+                EmployeeScheduleId = employeeAfternoonSchedule.Id,
+                Day = "Tuesday",
+                From = new TimeSpan(13, 0, 0),
+                To = new TimeSpan(22, 00, 0),
+                BreakFrom = new TimeSpan(17, 0, 0),
+                BreakTo = new TimeSpan(18, 0, 0),
+                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+            },
+            new WorkingDayTime {
+                Id = 8,
+                EmployeeScheduleId = employeeAfternoonSchedule.Id,
+                Day = "Wednesday",
+                From = new TimeSpan(13, 0, 0),
+                To = new TimeSpan(22, 00, 0),
+                BreakFrom = new TimeSpan(17, 0, 0),
+                BreakTo = new TimeSpan(18, 0, 0),
+                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+            },
+            new WorkingDayTime {
+                Id = 9,
+                EmployeeScheduleId = employeeAfternoonSchedule.Id,
+                Day = "Thursday",
+                From = new TimeSpan(13, 0, 0),
+                To = new TimeSpan(22, 00, 0),
+                BreakFrom = new TimeSpan(17, 0, 0),
+                BreakTo = new TimeSpan(18, 0, 0),
+                CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
+                UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
+            },
+            new WorkingDayTime {
+                Id = 10,
+                EmployeeScheduleId = employeeAfternoonSchedule.Id,
+                Day = "Friday",
+                From = new TimeSpan(13, 0, 0),
+                To = new TimeSpan(22, 00, 0),
+                BreakFrom = new TimeSpan(17, 0, 0),
+                BreakTo = new TimeSpan(18, 0, 0),
                 CreatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827),
                 UpdatedAt = new DateTime(2023, 1, 27, 16, 28, 6, 79, DateTimeKind.Local).AddTicks(7827)
             },

--- a/api/Services/EmployeeService.cs
+++ b/api/Services/EmployeeService.cs
@@ -44,30 +44,40 @@ namespace api.Services
                         EmployeeSchedule = newSchedule,
                         From = new TimeSpan(9, 30, 0),
                         To = new TimeSpan(18, 30, 0),
+                        BreakFrom = new TimeSpan(12, 0, 0),
+                        BreakTo = new TimeSpan(13, 0, 0),
                         Day = DaysOfTheWeekEnum.MONDAY
                     },
                     new WorkingDayTime {
                         EmployeeSchedule = newSchedule,
                         From = new TimeSpan(9, 30, 0),
                         To = new TimeSpan(18, 30, 0),
+                        BreakFrom = new TimeSpan(12, 0, 0),
+                        BreakTo = new TimeSpan(13, 0, 0),
                         Day = DaysOfTheWeekEnum.TUESDAY
                     },
                     new WorkingDayTime {
                         EmployeeSchedule = newSchedule,
                         From = new TimeSpan(9, 30, 0),
                         To = new TimeSpan(18, 30, 0),
+                        BreakFrom = new TimeSpan(12, 0, 0),
+                        BreakTo = new TimeSpan(13, 0, 0),
                         Day = DaysOfTheWeekEnum.WEDNESDAY
                     },
                     new WorkingDayTime {
                         EmployeeSchedule = newSchedule,
                         From = new TimeSpan(9, 30, 0),
                         To = new TimeSpan(18, 30, 0),
+                        BreakFrom = new TimeSpan(12, 0, 0),
+                        BreakTo = new TimeSpan(13, 0, 0),
                         Day = DaysOfTheWeekEnum.THURSDAY
                     },
                     new WorkingDayTime {
                         EmployeeSchedule = newSchedule,
                         From = new TimeSpan(9, 30, 0),
                         To = new TimeSpan(18, 30, 0),
+                        BreakFrom = new TimeSpan(12, 0, 0),
+                        BreakTo = new TimeSpan(13, 0, 0),
                         Day = DaysOfTheWeekEnum.FRIDAY
                     },
                 };

--- a/api/Services/TimeSheetService.cs
+++ b/api/Services/TimeSheetService.cs
@@ -90,7 +90,7 @@ namespace api.Services
         {
             using HrisContext context = _contextFactory.CreateDbContext();
             return await context.TimeEntries
-        .Include(entity => entity.User)
+                .Include(entity => entity.User)
                 .FirstOrDefaultAsync(c => c.TimeInId == id || c.TimeOutId == id);
         }
 

--- a/client/src/components/atoms/WorkStatusChip/index.tsx
+++ b/client/src/components/atoms/WorkStatusChip/index.tsx
@@ -35,6 +35,8 @@ const WorkStatusChip: FC<Props> = ({ label }): JSX.Element => {
     label === WorkStatus.UNDERTIME.toLowerCase()
       ? 'border-amber-300 bg-amber-50 text-amber-600'
       : null,
+    label === WorkStatus.REST.toLowerCase() ? 'border-sky-300 bg-sky-50 text-sky-600' : null,
+    label === WorkStatus.AWAITING.toLowerCase() ? 'invisible' : null,
     label === LeaveStatus.PENDING.toLowerCase()
       ? 'border-amber-300 bg-amber-50 text-amber-600'
       : null,

--- a/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
@@ -90,7 +90,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                     const projectName = option.project_name.label
                                     const otherProjects =
                                       option.project_name.label !== 'Others' &&
-                                      option.project_name.label.split(',')
+                                      option.project_name.label?.split(',')
 
                                     return (
                                       <div key={index}>

--- a/client/src/components/molecules/MyOvertimeTable/columns.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/columns.tsx
@@ -47,7 +47,7 @@ export const columns = [
               {original.projects.map((option, index) => {
                 const projectName = option.project_name.label
                 const otherProjects =
-                  option.project_name.label !== 'Others' && option.project_name.label.split(',')
+                  option.project_name.label !== 'Others' && option.project_name.label?.split(',')
 
                 return (
                   <div key={index}>

--- a/client/src/components/molecules/OvertimeManagementTable/columns.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/columns.tsx
@@ -98,7 +98,7 @@ export const hrColumns = [
                               selected ? 'font-medium' : 'font-normal'
                             )}
                           >
-                            {project.project_name.label.split(',').map((here, index) => {
+                            {project.project_name.label?.split(',').map((here, index) => {
                               if (here !== 'Others' && here !== '') {
                                 return (
                                   <p

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -130,19 +130,34 @@ const Header: FC<Props> = (props): JSX.Element => {
       data.userById?.timeEntry?.timeIn !== null &&
       data.userById?.timeEntry?.timeOut === null
     ) {
-      setRunning(true)
-      const now = moment(new Date()).format('YYYY-MM-DD HH:mm:ss')
-      setSeconds(0)
-      if (data.userById.timeEntry.timeIn !== null) {
-        const timeObj = parse(data?.userById.timeEntry.timeIn?.timeHour)
-        const then = `${moment(new Date(data?.userById.timeEntry.date)).format('YYYY-MM-DD')} ${
-          timeObj.hours as number
-        }:${timeObj.minutes as number}:${timeObj.seconds as number}`
-        const temp = moment.utc(moment(new Date(now)).diff(moment(new Date(then))))
-        setSeconds(moment.duration(temp as moment.DurationInputArg1).asSeconds())
+      setTimer(data)
+      const handleVisibilityChange = (): void => {
+        if (!document.hidden) {
+          setTimer(data)
+        }
+      }
+
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+
+      return () => {
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
       }
     }
   }, [status, data])
+
+  const setTimer = (data: any): void => {
+    setRunning(true)
+    const now = moment(new Date()).format('YYYY-MM-DD HH:mm:ss')
+    setSeconds(0)
+    if (data.userById.timeEntry.timeIn !== null) {
+      const timeObj = parse(data?.userById.timeEntry.timeIn?.timeHour)
+      const then = `${moment(new Date(data?.userById.timeEntry.date)).format('YYYY-MM-DD')} ${
+        timeObj.hours as number
+      }:${timeObj.minutes as number}:${timeObj.seconds as number}`
+      const temp = moment.utc(moment(new Date(now)).diff(moment(new Date(then))))
+      setSeconds(moment.duration(temp as moment.DurationInputArg1).asSeconds())
+    }
+  }
 
   useMemo(() => {
     setTime(seconds)

--- a/client/src/utils/constants/work-status.ts
+++ b/client/src/utils/constants/work-status.ts
@@ -6,7 +6,9 @@ export const WorkStatus = {
   MATERNITY_PATERNITY_LEAVE: 'Maternity/Paternity Leave',
   UNDERTIME: 'Undertime',
   ABSENT: 'Absent',
-  ON_DUTY: 'Present'
+  ON_DUTY: 'Present',
+  REST: 'Rest day',
+  AWAITING: ''
 }
 
 export const WorkInterruptionType = {

--- a/client/src/utils/myDailyTimeHelpers.ts
+++ b/client/src/utils/myDailyTimeHelpers.ts
@@ -20,5 +20,6 @@ export const statusClassNames = {
   [WorkStatus.BEREAVEMENT_LEAVE.toLowerCase()]: 'bg-gray-50 hover:bg-gray-50',
   [WorkStatus.EMERGENCY_LEAVE.toLowerCase()]: 'bg-red-50 hover:bg-red-50',
   [WorkStatus.MATERNITY_PATERNITY_LEAVE.toLowerCase()]: 'bg-violet-50 hover:bg-violet-50',
-  [WorkStatus.UNDERTIME.toLowerCase()]: 'bg-amber-50 hover:bg-amber-50'
+  [WorkStatus.UNDERTIME.toLowerCase()]: 'bg-amber-50 hover:bg-amber-50',
+  [WorkStatus.REST.toLowerCase()]: 'bg-sky-50 hover:bg-sky-50'
 }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-266

## Definition of Done
- [x] Added auto migration in BE
- [x] Added columns `BreakFrom` and `BreakTo` in `WorkingDayTimes` DB table
- [x] Added columns `BreakEndTime` and `BreakStartTime` in `TimeEntries` DB table
- [x] Added new `Afternoon Shift` schedule in `EmployeeSchedules` DB table seeder
- [x] Modified computations of `TrackedHours`, `Undertime`, `Overtime`, `Absent`
- [x] Set default `StartTime`, `EndTime` when creating `TimeEntry` in scheduler based on user's schedule. 
- [x] Added 2 new DTR status, `Rest` and `<Blank>`
- [x] Fixed `WorkHours` bug in the FE

## Notes
- You may check this PR with FE, since it's already fully integrated
- This PR also includes FE bugfix for `WorkHours`
- Simulated scheduler is not included in the code. Only for recording purposes
- Comments from sir Jem
     - https://sun-philippine.slack.com/archives/C04FYBQ4LRZ/p1684290515453809 (Undertime)
     - https://sun-philippine.slack.com/archives/C04FYBQ4LRZ/p1684377030885819 (WorkHours)
     - https://sun-philippine.slack.com/archives/C04FYBQ4LRZ/p1684389881456529 (Timer)
     - https://sun-philippine.slack.com/archives/C04FYBQ4LRZ/p1684463338119189 (Default Absent Status)
     - https://sun-philippine.slack.com/archives/C04FYBQ4LRZ/p1684735322961049 (Weekend as Absent)

## Pre-condition
- (docker) run `docker compose up db api client --build -d`
- go to `My Daily Time Record` and `DTR Management`

## Expected Output
### DB
- When running the api container, there should also be auto migration
- In the `EmployeeSchedules` DB table, there should be new `Afternoon Shift` schedule.
- There should also be new data in `WorkingDayTimes` table related to the new schedule.
- There should also new `BreakFrom` and `BreakTo` columns in `WorkingDayTimes` table
### BE
- ❗FOR WORK DAY. When new `TimeEntry` is created through the scheduler, (daily creation of TimeEntry for each user), the initial `StartTime`, `EndTime`, `BreakEndTime` and `BreakStartTime` values should be according to user's schedule 
- ❗FOR REST DAY. When new `TimeEntry` is created through the scheduler, (daily creation of TimeEntry for each user), the initial `StartTime`, `EndTime`, `BreakEndTime` and `BreakStartTime` values should be `00:00:00` 
- `Undertime` is now only computed if logged out in the same day.
- TimeEntry's `TrackedHours` should have the value of (EndTime - StartTime - Late - Undertime)
- TimeEntry's new `Rest` status should only be for entry not included in employee's schedule. Where `StartTime`, `EndTime`, `BreakEndTime` and `BreakStartTime` have values of `00:00:00`
- TimeEntry status for present day with no TimeIn yet should be blank
- `Rest` day should not be counted as `Absent`

## Screenshots/Recordings
- Sample `WorkingDayTimes` table
![image](https://github.com/framgia/sph-hris/assets/111718037/bfa54b29-8cb1-4843-a269-cd28a7a2c1ce)

- Sample `TimeEntries` table
![image](https://github.com/framgia/sph-hris/assets/111718037/d6d7e30b-51dc-415b-9339-c1df081474b0)

- Present day DTR Management Page (no statuses for no Time In record)
![image](https://github.com/framgia/sph-hris/assets/111718037/72eb1ac5-8568-49e8-a414-bfa22915c38b)

- Sample My Daily Time Record with REST day
![image](https://github.com/framgia/sph-hris/assets/111718037/10430ced-6e64-4c23-921d-d22472c8d3ea)


- [MyDTR] TimeIn: May 23, 2023 15:13 | TimeOut: May 24, 2023 15:14 (Undertime is still 0)
![image](https://github.com/framgia/sph-hris/assets/111718037/7a9ba148-d65f-41e9-b7a6-bd9cf0e876f5)


- Simulated Scheduler


https://github.com/framgia/sph-hris/assets/111718037/d846b925-0a1b-450a-b5a7-44c0d79b5317

