### PR TITLE
HRIS-270 [BE/FE] Add an option in My DTR and DTR Management to display hours instead of minutes

### DIFF
--- a/client/src/components/atoms/CellTimeValue/index.tsx
+++ b/client/src/components/atoms/CellTimeValue/index.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from 'react'
+import Tippy from '@tippyjs/react'
+
+type Props = {
+  initialMinutes: number
+}
+
+const CellTimeValue: FC<Props> = ({ initialMinutes }): JSX.Element => {
+  const [hours, minutes] = [Math.floor(initialMinutes / 60), Math.floor(initialMinutes % 60)]
+
+  const hoursTooltip = hours > 0 ? `${hours} ${hours > 1 ? 'hours' : 'hour'}` : ''
+  const minuteTooltip = minutes > 0 ? `${minutes} ${minutes > 1 ? 'minutes' : 'minute'}` : ''
+  const tooltipContent =
+    hours > 0 && minutes > 0
+      ? `${hoursTooltip}, ${minuteTooltip}`
+      : `${hoursTooltip}${minuteTooltip}`
+
+  return initialMinutes > 0 ? (
+    <Tippy placement="left" content={tooltipContent} className="!text-xs">
+      <span>{initialMinutes}</span>
+    </Tippy>
+  ) : (
+    <span>{initialMinutes !== undefined ? initialMinutes ?? 0 : 0}</span>
+  )
+}
+
+export default CellTimeValue

--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -13,6 +13,7 @@ import CellHeader from '~/components/atoms/CellHeader'
 import handleImageError from '~/utils/handleImageError'
 import EditTimeEntriesModal from '../EditTimeEntryModal'
 import { ITimeEntry } from '~/utils/types/timeEntryTypes'
+import CellTimeValue from '~/components/atoms/CellTimeValue'
 import WorkStatusChip from '~/components/atoms/WorkStatusChip'
 import { getSpecificTimeEntry } from '~/hooks/useTimesheetQuery'
 import MenuTransition from '~/components/templates/MenuTransition'
@@ -157,20 +158,21 @@ export const columns = [
   }),
   columnHelper.accessor('late', {
     header: () => <CellHeader label="Late(min)" />,
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: (props) => <CellTimeValue initialMinutes={props.row.original.late} />
   }),
   columnHelper.accessor('undertime', {
     header: () => <CellHeader label="Undertime(min)" />,
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: (props) => <CellTimeValue initialMinutes={props.row.original.undertime} />
   }),
   columnHelper.display({
     id: 'approvedMinutes',
     header: () => <CellHeader label="Overtime(min)" />,
-    cell: (props) => {
-      const { original: timeEntry } = props.row
-      return <span>{timeEntry.overtime != null ? timeEntry.overtime.approvedMinutes ?? 0 : 0}</span>
-    },
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: (props) => (
+      <CellTimeValue initialMinutes={props.row.original.overtime?.approvedMinutes as number} />
+    )
   }),
   columnHelper.display({
     id: 'id',

--- a/client/src/components/molecules/DTRSummaryTable/columns.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/columns.tsx
@@ -4,6 +4,7 @@ import { createColumnHelper } from '@tanstack/react-table'
 import SortIcon from '~/utils/icons/SortIcon'
 import Avatar from '~/components/atoms/Avatar'
 import handleImageError from '~/utils/handleImageError'
+import CellTimeValue from '~/components/atoms/CellTimeValue'
 import { ITimesheetSummary } from '~/utils/types/timeEntryTypes'
 
 const columnHelper = createColumnHelper<ITimesheetSummary>()
@@ -57,14 +58,17 @@ export const columns = [
   }),
   columnHelper.accessor('late', {
     header: () => <CellHeader label="Late" />,
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: (props) => <CellTimeValue initialMinutes={props.row.original.late} />
   }),
   columnHelper.accessor('undertime', {
     header: () => <CellHeader label="Undertime(min)" />,
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: (props) => <CellTimeValue initialMinutes={props.row.original.undertime} />
   }),
   columnHelper.accessor('overtime', {
     header: () => <CellHeader label="Overtime(min)" />,
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: (props) => <CellTimeValue initialMinutes={props.row.original.overtime} />
   })
 ]

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -14,6 +14,7 @@ import FiledOffsetModal from './../FiledOffsetModal'
 import Button from '~/components/atoms/Buttons/Button'
 import CellHeader from '~/components/atoms/CellHeader'
 import AddNewOvertimeModal from '../AddNewOvertimeModal'
+import CellTimeValue from '~/components/atoms/CellTimeValue'
 import WorkStatusChip from '~/components/atoms/WorkStatusChip'
 import { NO_OVERTIME } from '~/utils/constants/overtimeStatus'
 import ChangeShiftRequestModal from './ChangeShiftRequestModal'
@@ -144,11 +145,13 @@ export const columns = [
   }),
   columnHelper.accessor('late', {
     header: () => <CellHeader label="Late(min)" />,
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: (props) => <CellTimeValue initialMinutes={props.row.original.late} />
   }),
   columnHelper.accessor('undertime', {
     header: () => <CellHeader label="Undertime(min)" />,
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: (props) => <CellTimeValue initialMinutes={props.row.original.undertime} />
   }),
   columnHelper.accessor('overtime', {
     header: () => <CellHeader label="Overtime(min)" />,


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-270

## Definition of Done

- [x] Users can now hover on the late, undertime, and overtime values to see the equivalent hours

## Notes
- Improvement task on
   - My Daily Time Record
   - DTR Management & Summary

## Pre-condition
- In the root directory, run ``` docker compose up db api client -d  ```

## Expected Output
- Show a tooltip showing the equivalent value, in hours, of late, undertime, and overtime values

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/109492180/7d8ebf65-036b-4003-83c5-752cef0572e7


