### PR TITLE
HRIS-273 [Bugfix]  Fix the Project Leader Dropdown in the File Overtime Request Modal and Non-ESL Change Shift Request Modal

### DIFF
--- a/client/src/components/molecules/AddNewOvertimeModal/index.tsx
+++ b/client/src/components/molecules/AddNewOvertimeModal/index.tsx
@@ -27,7 +27,7 @@ import useUserQuery from '~/hooks/useUserQuery'
 import SpinnerIcon from '~/utils/icons/SpinnerIcon'
 import { MyOvertimeSchema } from '~/utils/validation'
 import { User as UserType } from '~/utils/types/userTypes'
-import { ProjectDetails } from '~/utils/types/projectTypes'
+import { LeaderDetails, ProjectDetails } from '~/utils/types/projectTypes'
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import { customStyles } from '~/utils/customReactSelectStyles'
 import ModalTemplate from '~/components/templates/ModalTemplate'
@@ -53,33 +53,23 @@ const AddNewOvertimeModal: FC<Props> = ({
   timeEntry,
   initialMinutes
 }): JSX.Element => {
-  const [leaders, setLeaders] = useState<UserType[]>([])
+  const [leaders, setLeaders] = useState<LeaderDetails[]>([])
   const [managers, setManagers] = useState<UserType[]>([])
 
-  const { handleProjectQuery } = useProject()
-  const { data: projects, isSuccess: isProjectsSuccess } = handleProjectQuery()
+  const { handleProjectQuery, getLeadersQuery } = useProject()
+  const { data: projects } = handleProjectQuery()
 
   const { handleAllUsersQuery, handleUserQuery } = useUserQuery()
   const { data: user } = handleUserQuery()
   const { data: users, isSuccess: isUsersSuccess } = handleAllUsersQuery()
+  const { data: leadersList } = getLeadersQuery(undefined)
 
   const { handleOvertimeMutation } = useOvertime()
   const overtimeMutation = handleOvertimeMutation()
 
   useEffect(() => {
-    if (isProjectsSuccess && projects.projects.length > 0) {
-      const tempLeaders = [...leaders]
-      projects?.projects.forEach((project) => {
-        if (project?.projectLeader != null || project?.projectSubLeader != null) {
-          if (!tempLeaders.some((leader) => leader.id === project.projectLeader.id))
-            tempLeaders.push(project?.projectLeader)
-          if (!tempLeaders.some((leader) => leader.id === project.projectSubLeader.id))
-            tempLeaders.push(project?.projectSubLeader)
-        }
-      })
-      setLeaders(tempLeaders)
-    }
-  }, [isProjectsSuccess, projects?.projects])
+    if (leadersList !== undefined) setLeaders(leadersList.allLeaders)
+  }, [leadersList])
 
   useEffect(() => {
     if (isUsersSuccess) {
@@ -295,7 +285,7 @@ const AddNewOvertimeModal: FC<Props> = ({
                                 : 'border-slate-300'
                           }}
                           backspaceRemovesValue={true}
-                          options={generateUserSelect(leaders)}
+                          options={generateUserSelect(leaders as UserType[])}
                           components={animatedComponents}
                           className="w-full"
                         />

--- a/client/src/components/molecules/MyDailyTimeRecordTable/ChangeShiftRequestModal.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/ChangeShiftRequestModal.tsx
@@ -20,7 +20,7 @@ import useChangeShift from '~/hooks/useChangeShift'
 import SpinnerIcon from '~/utils/icons/SpinnerIcon'
 import { User as UserType } from '~/utils/types/userTypes'
 import { PROJECT_NAMES } from '~/utils/constants/projects'
-import { ProjectDetails } from '~/utils/types/projectTypes'
+import { ProjectDetails, LeaderDetails } from '~/utils/types/projectTypes'
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import { changeShiftRequestSchema } from '~/utils/validation'
 import { customStyles } from '~/utils/customReactSelectStyles'
@@ -40,33 +40,23 @@ type Props = {
 const animatedComponents = makeAnimated()
 
 const ChangeShiftRequestModal: FC<Props> = ({ isOpen, timeEntry, closeModal }): JSX.Element => {
-  const [leaders, setLeaders] = useState<UserType[]>([])
+  const [leaders, setLeaders] = useState<LeaderDetails[]>([])
   const [managers, setManagers] = useState<UserType[]>([])
 
-  const { handleProjectQuery } = useProject()
-  const { data: projects, isSuccess: isProjectsSuccess } = handleProjectQuery()
+  const { handleProjectQuery, getLeadersQuery } = useProject()
+  const { data: projects } = handleProjectQuery()
 
   const { handleAllUsersQuery, handleUserQuery } = useUserQuery()
   const { data: user } = handleUserQuery()
   const { data: users, isSuccess: isUsersSuccess } = handleAllUsersQuery()
+  const { data: leadersList } = getLeadersQuery(undefined)
 
   const { handleChangeShiftRequestMutation } = useChangeShift()
   const changeShiftRequestMutation = handleChangeShiftRequestMutation()
 
   useEffect(() => {
-    if (isProjectsSuccess && projects.projects.length > 0) {
-      const tempLeaders = [...leaders]
-      projects?.projects.forEach((project) => {
-        if (project?.projectLeader != null || project?.projectSubLeader != null) {
-          if (!tempLeaders.some((leader) => leader.id === project.projectLeader.id))
-            tempLeaders.push(project?.projectLeader)
-          if (!tempLeaders.some((leader) => leader.id === project.projectSubLeader.id))
-            tempLeaders.push(project?.projectSubLeader)
-        }
-      })
-      setLeaders(tempLeaders)
-    }
-  }, [isProjectsSuccess, projects?.projects])
+    if (leadersList !== undefined) setLeaders(leadersList.allLeaders)
+  }, [leadersList])
 
   useEffect(() => {
     if (isUsersSuccess) {
@@ -331,7 +321,7 @@ const ChangeShiftRequestModal: FC<Props> = ({ isOpen, timeEntry, closeModal }): 
                                 : 'border-slate-300'
                           }}
                           backspaceRemovesValue={true}
-                          options={generateUserSelect(leaders)}
+                          options={generateUserSelect(leaders as UserType[])}
                           components={animatedComponents}
                           className="w-full"
                         />

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -155,22 +155,20 @@ export const columns = [
     footer: (info) => info.column.id,
     cell: (props) => {
       const { original: timeEntry } = props.row
-      const { overtime } = timeEntry
+      const { overtime, endTime } = timeEntry
+      const threshold = moment(endTime, 'HH:mm:ss').add(1, 'hour').format('HH:mm:ss')
 
       const [isOpen, setIsOpen] = useState<boolean>(false)
 
       const handleToggle = (): void => setIsOpen(!isOpen)
 
       const minuteDifference =
-        timeEntry.timeOut !== null
+        endTime !== '00:00' && timeEntry.timeOut !== null
           ? Math.floor(
               moment
                 .duration(
                   moment(timeEntry.timeOut?.createdAt).diff(
-                    `${moment(timeEntry.date).format('YYYY-MM-DD')} ${moment(
-                      '19:30',
-                      'HH:mm:ss'
-                    ).format('HH:mm:ss')}`
+                    `${moment(timeEntry.date).format('YYYY-MM-DD')} ${threshold}`
                   )
                 )
                 .asMinutes()


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-273

## Definition of Done
- [x] Changed query for leaders in Add New Overtime Modal and Change Shift Request Modal

## Notes
- Also fixed computation of Overtime in MyDTR table

## Pre-condition
- (docker) run `docker compose up db api client --build -d`
- go to `My Daily Time Record` page

## Expected Output
- The leaders in the dropdown of Add New Overtime Modal and Change Shift Request Modal should be users with positions `Admin`, `Web Developer - Trainer`, `Web Developer - Team Leader`
- The page should also not break when opening these two modals

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/111718037/f00640ef-242f-42c3-977e-0e9302683762


