### PR TITLE
HRIS-270-01 [BE/FE] Fix: Added a tooltip on MyOvertime & OvertimeManagement page, and removed tooltip for TimeIn and TimeOut columns

### DIFF
--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -1,6 +1,4 @@
-import moment from 'moment'
 import Link from 'next/link'
-import Tippy from '@tippyjs/react'
 import classNames from 'classnames'
 import React, { useState } from 'react'
 import { Menu } from '@headlessui/react'
@@ -64,33 +62,27 @@ export const columns = [
           {(timeEntry.timeIn?.remarks !== undefined && timeEntry.timeIn?.remarks !== '') ||
           getSpecificTimeEntry(Number(timeEntry.timeIn?.id)).data?.timeById?.media[0]?.fileName !==
             undefined ? (
-            <Tippy
-              content={moment(timeEntry.date).format('MMM D, YYYY')}
-              placement="left"
-              className="!text-xs"
+            <Link
+              href={`dtr-management/?time_in=${timeEntry.timeIn?.id}`}
+              className="relative flex cursor-pointer active:scale-95"
             >
-              <Link
-                href={`dtr-management/?time_in=${timeEntry.timeIn?.id}`}
-                className="relative flex cursor-pointer active:scale-95"
-              >
-                {/* Actual Time In Data */}
-                <span>{timeEntry.timeIn?.timeHour ?? EMPTY}</span>
-                {/* Status */}
-                {timeEntry.startTime > timeEntry.timeIn?.timeHour ? (
-                  <span
-                    className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
-                  />
-                ) : (
-                  <>
-                    {!Number.isNaN(timeEntry.timeIn?.id) && (
-                      <span
-                        className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')}
-                      />
-                    )}
-                  </>
-                )}
-              </Link>
-            </Tippy>
+              {/* Actual Time In Data */}
+              <span>{timeEntry.timeIn?.timeHour ?? EMPTY}</span>
+              {/* Status */}
+              {timeEntry.startTime > timeEntry.timeIn?.timeHour ? (
+                <span
+                  className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
+                />
+              ) : (
+                <>
+                  {!Number.isNaN(timeEntry.timeIn?.id) && (
+                    <span
+                      className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')}
+                    />
+                  )}
+                </>
+              )}
+            </Link>
           ) : (
             <div className="relative flex">
               {/* Actual Time In Data */}
@@ -118,25 +110,19 @@ export const columns = [
       return (
         <>
           {timeEntry.timeOut?.remarks !== undefined && timeEntry.timeOut?.remarks !== '' ? (
-            <Tippy
-              content={moment(timeEntry.date).format('MMM D, YYYY')}
-              placement="left"
-              className="!text-xs"
+            <Link
+              href={`dtr-management/?time_out=${timeEntry.timeOut?.id}`}
+              className="relative flex cursor-pointer active:scale-95"
             >
-              <Link
-                href={`dtr-management/?time_out=${timeEntry.timeOut?.id}`}
-                className="relative flex cursor-pointer active:scale-95"
-              >
-                {/* Actual Time In Data */}
-                <span>{timeEntry.timeOut?.timeHour ?? EMPTY}</span>
-                {/* Status */}
-                {!Number.isNaN(timeEntry.timeOut?.id) && (
-                  <span
-                    className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
-                  />
-                )}
-              </Link>
-            </Tippy>
+              {/* Actual Time In Data */}
+              <span>{timeEntry.timeOut?.timeHour ?? EMPTY}</span>
+              {/* Status */}
+              {!Number.isNaN(timeEntry.timeOut?.id) && (
+                <span
+                  className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
+                />
+              )}
+            </Link>
           ) : (
             <span>{timeEntry.timeOut?.timeHour ?? EMPTY}</span>
           )}

--- a/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/columns.tsx
@@ -51,33 +51,27 @@ export const columns = [
           {(timeEntry.timeIn?.remarks !== undefined && timeEntry.timeIn?.remarks !== '') ||
           getSpecificTimeEntry(Number(timeEntry.timeIn?.id)).data?.timeById?.media[0]?.fileName !==
             undefined ? (
-            <Tippy
-              content={moment(timeEntry.date).format('MMM D, YYYY')}
-              placement="left"
-              className="!text-xs"
+            <Link
+              href={`my-daily-time-record/?time_in=${timeEntry.timeIn?.id}`}
+              className="relative flex cursor-pointer active:scale-95"
             >
-              <Link
-                href={`my-daily-time-record/?time_in=${timeEntry.timeIn?.id}`}
-                className="relative flex cursor-pointer active:scale-95"
-              >
-                {/* Actual Time In Data */}
-                <span>{timeEntry.timeIn?.timeHour ?? EMPTY}</span>
-                {/* Status */}
-                {timeEntry.startTime > timeEntry.timeIn?.timeHour ? (
-                  <span
-                    className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
-                  />
-                ) : (
-                  <>
-                    {!Number.isNaN(timeEntry.timeIn?.id) && (
-                      <span
-                        className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')}
-                      />
-                    )}
-                  </>
-                )}
-              </Link>
-            </Tippy>
+              {/* Actual Time In Data */}
+              <span>{timeEntry.timeIn?.timeHour ?? EMPTY}</span>
+              {/* Status */}
+              {timeEntry.startTime > timeEntry.timeIn?.timeHour ? (
+                <span
+                  className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
+                />
+              ) : (
+                <>
+                  {!Number.isNaN(timeEntry.timeIn?.id) && (
+                    <span
+                      className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500')}
+                    />
+                  )}
+                </>
+              )}
+            </Link>
           ) : (
             <div className="relative flex">
               {/* Actual Time In Data */}
@@ -105,25 +99,19 @@ export const columns = [
       return (
         <>
           {timeEntry.timeOut?.remarks !== undefined && timeEntry.timeOut?.remarks !== '' ? (
-            <Tippy
-              content={moment(timeEntry.date).format('MMM D, YYYY')}
-              placement="left"
-              className="!text-xs"
+            <Link
+              href={`my-daily-time-record/?time_out=${timeEntry.timeOut?.id}`}
+              className="relative flex cursor-pointer active:scale-95"
             >
-              <Link
-                href={`my-daily-time-record/?time_out=${timeEntry.timeOut?.id}`}
-                className="relative flex cursor-pointer active:scale-95"
-              >
-                {/* Actual Time In Data */}
-                <span>{timeEntry.timeOut?.timeHour ?? EMPTY}</span>
-                {/* Status */}
-                {!Number.isNaN(timeEntry.timeOut?.id) && (
-                  <span
-                    className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
-                  />
-                )}
-              </Link>
-            </Tippy>
+              {/* Actual Time In Data */}
+              <span>{timeEntry.timeOut?.timeHour ?? EMPTY}</span>
+              {/* Status */}
+              {!Number.isNaN(timeEntry.timeOut?.id) && (
+                <span
+                  className={classNames('ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-purple-500')}
+                />
+              )}
+            </Link>
           ) : (
             <span>{timeEntry.timeOut?.timeHour ?? EMPTY}</span>
           )}

--- a/client/src/components/molecules/MyOvertimeTable/columns.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/columns.tsx
@@ -10,6 +10,7 @@ import ShowRemarksModal from './ShowRemarksModal'
 import { IMyOvertimeTable } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/Button'
 import CellHeader from '~/components/atoms/CellHeader'
+import CellTimeValue from '~/components/atoms/CellTimeValue'
 import { decimalFormatter } from '~/utils/myOvertimeHelpers'
 import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 import { STATUS_OPTIONS } from '~/utils/constants/notificationFilter'
@@ -110,14 +111,18 @@ export const columns = [
     footer: (info) => info.column.id,
     cell: ({ row: { original } }) => {
       const { DISAPPROVED } = STATUS_OPTIONS
+      const requestStatus = original.status
+      const approvedMinutes = original.approvedMinutes
 
       return (
         <div>
-          {original.status === DISAPPROVED.toLowerCase()
-            ? 0
-            : original.approvedMinutes ?? (
-                <span className="italic text-slate-400">(pending approval)</span>
-              )}
+          {requestStatus === DISAPPROVED.toLowerCase() ? (
+            0
+          ) : approvedMinutes !== null ? (
+            <CellTimeValue initialMinutes={approvedMinutes} />
+          ) : (
+            <span className="italic text-slate-400">(pending approval)</span>
+          )}
         </div>
       )
     }

--- a/client/src/components/molecules/OvertimeManagementTable/columns.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/columns.tsx
@@ -23,6 +23,7 @@ import ApproveConfirmationModal from './ApproveConfirmationModal'
 import ButtonAction from '~/components/atoms/Buttons/ButtonAction'
 import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 import { IOvertimeManagement, IOvertimeManagementManager } from '~/utils/interfaces'
+import CellTimeValue from '~/components/atoms/CellTimeValue'
 
 const columnHelper = createColumnHelper<IOvertimeManagement | IOvertimeManagementManager>()
 
@@ -135,7 +136,8 @@ export const hrColumns = [
   }),
   columnHelper.accessor('approvedMinutes', {
     header: () => <CellHeader label="Approved Minutes" />,
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: (props) => <CellTimeValue initialMinutes={props.row.original.approvedMinutes} />
   }),
   columnHelper.display({
     id: 'empty2',


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-270

## Definition of Done

- [x] Added a tooltip on My Overtime page for column approved minutes
- [x] Added a tooltip on Overtime management page for column approved minutes
- [x] Removed tooltip for timeIn and timeOut

## Notes
- PR fix

## Pre-condition
- In the root directory, run ``` docker compose up db api client -d ```

## Expected Output
- Column Approved Minutes on my overtime and overtime management page should now show a tooltip
- Removed tooltip for timeIn and timeOut columns

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/109492180/35e046ff-aeaf-4901-aa4c-af8f54695c2c


