### PR TITLE
HRIS-275 [BE/FE] Add a confirmation modal when a user attempts to clock in during rest day.

### DIFF
--- a/client/src/components/molecules/UserTimeZone/index.tsx
+++ b/client/src/components/molecules/UserTimeZone/index.tsx
@@ -38,7 +38,8 @@ const UserTimeZone: FC<Props> = ({ user }): JSX.Element => {
           {moment(new Date()).format('dddd, MMMM Do YYYY')}
         </p>
         <p className="text-[11px] leading-tight text-slate-500">
-          Schedule: {user?.employeeSchedule.name}
+          Schedule:{' '}
+          {user?.employeeSchedule.name === 'NoDay' ? 'Rest Day' : user?.employeeSchedule.name}
         </p>
       </div>
     </div>

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -333,8 +333,8 @@ const Header: FC<Props> = (props): JSX.Element => {
             >
               <Button
                 disabled={
-                  data?.userById.timeEntry?.timeIn !== null ||
-                  data.userById.employeeSchedule.workingDayTimes.length < 1
+                  data?.userById.timeEntry?.timeIn !== null
+                  // TODO: || data.userById.employeeSchedule.workingDayTimes.length < 1
                 }
                 onClick={handleToggleTimeInDrawer}
               >

--- a/client/src/components/organisms/TimeInDrawer/index.tsx
+++ b/client/src/components/organisms/TimeInDrawer/index.tsx
@@ -76,25 +76,14 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
     confirmAlert({
       customUI: ({ onClose }) => {
         return (
-          <Card className="w-full max-w-[350px] px-8 py-6" shadow-size="xl" rounded="lg">
-            <h1 className="text-center text-xl font-bold text-rose-500">Confirmation</h1>
+          <Card className="w-full max-w-[350px] px-8 py-6 shadow-none" rounded="lg">
+            <h1 className="text-center text-xl font-bold text-amber-500">Warning!</h1>
             <p className="mt-4 text-sm font-normal text-slate-600">
-              Today is your rest day. Proceed time in?
+              Important: Time-in is not allowed on the designated rest day.
             </p>
             <div className="mt-6 flex items-center justify-center space-x-2 text-white">
-              <ButtonAction
-                onClick={() => handleSaveTimeIn()}
-                variant="danger"
-                className="w-full py-1 px-4"
-              >
-                Yes
-              </ButtonAction>
-              <ButtonAction
-                onClick={onClose}
-                variant="secondary"
-                className="w-full py-1 px-4 text-slate-500"
-              >
-                No
+              <ButtonAction onClick={onClose} variant="warning" className="w-full py-1 px-4">
+                Close
               </ButtonAction>
             </div>
           </Card>

--- a/client/src/components/organisms/TimeInDrawer/index.tsx
+++ b/client/src/components/organisms/TimeInDrawer/index.tsx
@@ -4,15 +4,18 @@ import classNames from 'classnames'
 import { toast } from 'react-hot-toast'
 import { parse } from 'iso8601-duration'
 import { serialize } from 'tinyduration'
+import { confirmAlert } from 'react-confirm-alert'
 import React, { FC, useEffect, useState } from 'react'
 import TextareaAutosize from 'react-textarea-autosize'
 
+import Card from '~/components/atoms/Card'
 import Alert from '~/components/atoms/Alert'
 import useUserQuery from '~/hooks/useUserQuery'
 import SpinnerIcon from '~/utils/icons/SpinnerIcon'
 import useTimeInMutation from '~/hooks/useTimeInMutation'
 import UserTimeZone from '~/components/molecules/UserTimeZone'
 import DrawerTemplate from '~/components/templates/DrawerTemplate'
+import ButtonAction from '~/components/atoms/Buttons/ButtonAction'
 
 type Props = {
   isOpenTimeInDrawer: boolean
@@ -54,6 +57,51 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
       setAfterStartTime(status)
     }
   }, [data])
+
+  const handleRestdayTimeInChecker = (): void => {
+    const day = moment().format('dddd')
+    const schedule = data?.userById?.employeeSchedule.workingDayTimes.find(
+      (item) => item.day === day
+    )
+    if (schedule !== null && schedule !== undefined) {
+      handleSaveTimeIn()
+    } else {
+      /* This is for when user times in when he/she rest day. */
+      handleRestdayTimeInConfirmation()
+    }
+  }
+
+  // FOR CONFIRMATION ONLY
+  const handleRestdayTimeInConfirmation = (): void => {
+    confirmAlert({
+      customUI: ({ onClose }) => {
+        return (
+          <Card className="w-full max-w-[350px] px-8 py-6" shadow-size="xl" rounded="lg">
+            <h1 className="text-center text-xl font-bold text-rose-500">Confirmation</h1>
+            <p className="mt-4 text-sm font-normal text-slate-600">
+              Today is your rest day. Proceed time in?
+            </p>
+            <div className="mt-6 flex items-center justify-center space-x-2 text-white">
+              <ButtonAction
+                onClick={() => handleSaveTimeIn()}
+                variant="danger"
+                className="w-full py-1 px-4"
+              >
+                Yes
+              </ButtonAction>
+              <ButtonAction
+                onClick={onClose}
+                variant="secondary"
+                className="w-full py-1 px-4 text-slate-500"
+              >
+                No
+              </ButtonAction>
+            </div>
+          </Card>
+        )
+      }
+    })
+  }
 
   const handleSaveTimeIn = (): void => {
     const time = moment(new Date())
@@ -165,7 +213,7 @@ const TimeInDrawer: FC<Props> = (props): JSX.Element => {
           <button
             type="button"
             disabled={timeInMutation.isLoading}
-            onClick={handleSaveTimeIn}
+            onClick={handleRestdayTimeInChecker}
             className={classNames(
               'flex items-center justify-center rounded-md border active:scale-95',
               `w-24 border-dark-primary ${

--- a/client/src/components/organisms/TimeOutDrawer/index.tsx
+++ b/client/src/components/organisms/TimeOutDrawer/index.tsx
@@ -63,9 +63,9 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
     confirmAlert({
       customUI: ({ onClose }) => {
         return (
-          <Card className="w-full max-w-xs px-8 py-6" shadow-size="xl" rounded="lg">
-            <h1 className="text-center text-xl font-bold">Confirmation</h1>
-            <p className="mt-2 text-sm font-medium">
+          <Card className="w-full max-w-[350px] px-8 py-6" shadow-size="xl" rounded="lg">
+            <h1 className="text-center text-xl font-bold text-rose-500">Confirmation</h1>
+            <p className="mt-4 text-sm font-normal text-slate-600">
               You won&apos;t be able to time in again for today if you time out. Proceed?
             </p>
             <div className="mt-6 flex items-center justify-center space-x-2 text-white">

--- a/client/src/components/organisms/TimeOutDrawer/index.tsx
+++ b/client/src/components/organisms/TimeOutDrawer/index.tsx
@@ -63,17 +63,22 @@ const TimeOutDrawer: FC<Props> = (props): JSX.Element => {
     confirmAlert({
       customUI: ({ onClose }) => {
         return (
-          <Card className="w-full max-w-[350px] px-8 py-6" shadow-size="xl" rounded="lg">
+          <Card className="w-full max-w-[350px] px-8 py-6 shadow-none" rounded="lg">
             <h1 className="text-center text-xl font-bold text-rose-500">Confirmation</h1>
             <p className="mt-4 text-sm font-normal text-slate-600">
               You won&apos;t be able to time in again for today if you time out. Proceed?
             </p>
             <div className="mt-6 flex items-center justify-center space-x-2 text-white">
               <ButtonAction
-                onClick={() => handleSaveTimeOut()}
+                disabled={timeOutMutation.isLoading}
+                onClick={() => {
+                  handleSaveTimeOut()
+                  return onClose()
+                }}
                 variant="danger"
                 className="w-full py-1 px-4"
               >
+                {timeOutMutation.isLoading && <SpinnerIcon className=" mr-2 fill-gray-500" />}
                 Yes
               </ButtonAction>
               <ButtonAction

--- a/client/src/utils/constants/sidebarMenu.ts
+++ b/client/src/utils/constants/sidebarMenu.ts
@@ -172,15 +172,15 @@ export const Menus: IMenu[] = [
 
 export const productionMenu: IMenu[] = [
   {
-    name: 'My Leaves',
-    Icon: FileStaff,
-    href: '/my-leaves',
-    role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER]
-  },
-  {
     name: 'My Daily Time Record',
     Icon: Timer,
     href: '/my-daily-time-record',
+    role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER]
+  },
+  {
+    name: 'My Leaves',
+    Icon: FileStaff,
+    href: '/my-leaves',
     role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER]
   },
   {

--- a/client/src/utils/constants/sidebarMenu.ts
+++ b/client/src/utils/constants/sidebarMenu.ts
@@ -49,15 +49,15 @@ export const Menus: IMenu[] = [
     role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER]
   },
   {
-    name: 'My Leaves',
-    Icon: FileStaff,
-    href: '/my-leaves',
-    role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER]
-  },
-  {
     name: 'My Daily Time Record',
     Icon: Timer,
     href: '/my-daily-time-record',
+    role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER]
+  },
+  {
+    name: 'My Leaves',
+    Icon: FileStaff,
+    href: '/my-leaves',
     role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER]
   },
   {

--- a/client/src/utils/styles/globals.css
+++ b/client/src/utils/styles/globals.css
@@ -7,3 +7,8 @@
   top: 0px !important;
   right: 2px !important;
 }
+
+.react-confirm-alert-overlay {
+  background: rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(5px);
+}


### PR DESCRIPTION
## Issue Link

[Backlog Link
](https://framgiaph.backlog.com/board/HRIS?selectedIssueKey=HRIS-275)

## Definition of Done

- [ ] Add a confirmation modal when a user attempts to clock in during rest day.
- [ ] Move My DTR on top of the sidebar in development and production.

## Pre-condition

Do `npm run build` and then `npm start` to enter production mode. Check sidebar.
Try to time in during restday on your schedule.

## Expected Output

1. When a user tries to login during his/her restday on schedule, the user will receive a confirmation modal if the user wants to proceed to time in during a rest day.
- Login with a user that has an assigned `EmployeeSchedules` and make sure `EmployeeSchedules` has no corresponding `WorkingDayTimes`  which indicates that the user is currently  in restday

2. The user will not receive a confirmation modal if it is not his restday.
- Login with a user that has an assigned `EmployeeSchedules` and make sure `EmployeeSchedules` has a corresponding `WorkingDayTimes`  which indicates that the user is currently not in restday

3. As an added task, the MyDTR section has been moved on top of MyLeaves in the sidebar for both development and production.
- Do `npm run build` and then `npm start` to enter production mode. Check sidebar.
## Screenshots/Recordings

Proof:
![image](https://github.com/framgia/sph-hris/assets/109579325/3675e6ac-f576-4f80-a8e5-712ae0bdbf35)
![image](https://github.com/framgia/sph-hris/assets/109579325/a0ffe4e8-4342-4ba4-b604-f2dfda159227)

