### PR TITLE
HRIS-277 [BE/FE] Display the user's name who have approved or disapproved the filed requests

### DIFF
--- a/api/Enums/PositionEnum.cs
+++ b/api/Enums/PositionEnum.cs
@@ -9,5 +9,9 @@ namespace api.Enums
         public const int ESL_TEACHER = 5;
         public const int WEB_DEVELOPER_TRAINER = 6;
         public const int WEB_DEVELOPER_TEAM_LEADER = 7;
+        public List<int> LEADERS = new List<int> { ADMIN, WEB_DEVELOPER_TEAM_LEADER, WEB_DEVELOPER_TRAINER };
+
+        // static property
+        public static List<int> ALL_LEADERS => new PositionEnum().LEADERS;
     }
 }

--- a/api/Schema/Mutations/ChangeShiftMutation.cs
+++ b/api/Schema/Mutations/ChangeShiftMutation.cs
@@ -14,21 +14,25 @@ namespace api.Schema.Mutations
         [NonESLUser]
         public async Task<ChangeShiftRequest> CreateChangeShift(CreateChangeShiftRequest request, [Service] ChangeShiftService _changeShiftService, [Service] NotificationService _notificationService, [Service] ITopicEventSender eventSender, [Service] IDbContextFactory<HrisContext> contextFactory)
         {
-            using (HrisContext context = contextFactory.CreateDbContext())
+            using HrisContext context = contextFactory.CreateDbContext();
+            try
             {
-                try
-                {
-                    using var transaction = context.Database.BeginTransaction();
-                    var changeShift = await _changeShiftService.Create(request);
-                    await _notificationService.createChangeShiftRequestNotification(changeShift);
+                using var transaction = context.Database.BeginTransaction();
+                var changeShift = await _changeShiftService.Create(request, context);
+                await _notificationService.createChangeShiftRequestNotification(context, changeShift, changeShift.UserId);
 
-                    transaction.Commit();
-                    return changeShift;
-                }
-                catch (GraphQLException e)
-                {
-                    throw e;
-                }
+                transaction.Commit();
+                return changeShift;
+            }
+            catch (GraphQLException e)
+            {
+                throw e;
+            }
+            catch (Exception e)
+            {
+                throw new GraphQLException(ErrorBuilder.New()
+                .SetMessage(e.Message)
+                .Build());
             }
         }
     }

--- a/api/Schema/Mutations/ESLChangeShiftMutation.cs
+++ b/api/Schema/Mutations/ESLChangeShiftMutation.cs
@@ -19,8 +19,8 @@ namespace api.Schema.Mutations
                 try
                 {
                     using var transaction = context.Database.BeginTransaction();
-                    var changeShift = await _eslChangeShiftService.Create(request);
-                    await _notificationService.createESLChangeShiftRequestNotification(changeShift);
+                    var changeShift = await _eslChangeShiftService.Create(request, context);
+                    await _notificationService.createESLChangeShiftRequestNotification(context, changeShift);
 
                     transaction.Commit();
                     return changeShift;
@@ -39,7 +39,7 @@ namespace api.Schema.Mutations
                 try
                 {
                     using var transaction = context.Database.BeginTransaction();
-                    var eSLChangeShift = await _eslChangeShiftStatusService.ApproveDisapproveESLChangeShiftStatus(request);
+                    var eSLChangeShift = await _eslChangeShiftStatusService.ApproveDisapproveESLChangeShiftStatus(request, context);
 
                     transaction.Commit();
                     return eSLChangeShift;

--- a/api/Schema/Mutations/ESLOffsetMutation.cs
+++ b/api/Schema/Mutations/ESLOffsetMutation.cs
@@ -19,8 +19,8 @@ namespace api.Schema.Mutations
                 try
                 {
                     using var transaction = context.Database.BeginTransaction();
-                    var offset = await _eslOffsetService.Create(request);
-                    await _notificationService.createESLOffsetRequestNotification(offset);
+                    var offset = await _eslOffsetService.Create(request, context);
+                    await _notificationService.createESLOffsetRequestNotification(offset, context);
 
                     transaction.Commit();
                     return offset;
@@ -39,7 +39,7 @@ namespace api.Schema.Mutations
                 try
                 {
                     using var transaction = context.Database.BeginTransaction();
-                    var changeShift = await _changeESLOffsetStatusService.ApproveDisapproveChangeOffsetStatus(request);
+                    var changeShift = await _changeESLOffsetStatusService.ApproveDisapproveChangeOffsetStatus(request, context);
 
                     transaction.Commit();
                     return changeShift;

--- a/api/Services/ApprovalService.cs
+++ b/api/Services/ApprovalService.cs
@@ -14,7 +14,7 @@ namespace api.Services
     {
         private readonly IDbContextFactory<HrisContext> _contextFactory = default!;
         private readonly ITopicEventSender _eventSender;
-        private readonly CustomInputValidation _customInputValidation;
+        private readonly ApprovalServiceInputValidation _customInputValidation;
         private readonly NotificationService _notificationService;
         private readonly bool APPROVED = true;
         private readonly bool DISAPPROVED = false;
@@ -23,7 +23,7 @@ namespace api.Services
         {
             _contextFactory = contextFactory;
             _eventSender = eventSender;
-            _customInputValidation = new CustomInputValidation(_contextFactory);
+            _customInputValidation = new ApprovalServiceInputValidation(_contextFactory);
             _notificationService = notificationService;
         }
 

--- a/api/Services/ESLOffsetService.cs
+++ b/api/Services/ESLOffsetService.cs
@@ -53,6 +53,7 @@ namespace api.Services
                 var eslOffsets = await context.ESLOffsets
                     .Include(x => x.TeamLeader)
                     .Where(x => x.TimeEntryId == timeEntryId && (onlyUnused ? x.IsUsed == false && x.IsLeaderApproved == true : true))
+                    .OrderByDescending(x => x.CreatedAt)
                     .Select(x => new ESLOffsetDTO(x))
                     .ToListAsync();
 

--- a/api/Services/ESLOffsetService.cs
+++ b/api/Services/ESLOffsetService.cs
@@ -22,31 +22,28 @@ namespace api.Services
             _customInputValidation = new CustomInputValidation(_contextFactory);
         }
 
-        public async Task<ESLOffset> Create(CreateESLOffsetRequest request)
+        public async Task<ESLOffset> Create(CreateESLOffsetRequest request, HrisContext context)
         {
-            using (HrisContext context = _contextFactory.CreateDbContext())
+            // validate inputs
+            var errors = _customInputValidation.checkESLOffsetRequestInput(request);
+
+            if (errors.Count > 0) throw new GraphQLException(errors);
+
+            //  Create ESLChangeShiftRequest
+            var eslOffset = new ESLOffset
             {
-                // validate inputs
-                var errors = _customInputValidation.checkESLOffsetRequestInput(request);
+                UserId = request.UserId,
+                TeamLeaderId = request.TeamLeaderId,
+                TimeEntryId = request.TimeEntryId,
+                TimeIn = TimeSpan.ParseExact(request.TimeIn, "hh':'mm", null),
+                TimeOut = TimeSpan.ParseExact(request.TimeOut, "hh':'mm", null),
+                Description = request.Description,
+                Title = request.Title
+            };
 
-                if (errors.Count > 0) throw new GraphQLException(errors);
-
-                //  Create ESLChangeShiftRequest
-                var eslOffset = new ESLOffset
-                {
-                    UserId = request.UserId,
-                    TeamLeaderId = request.TeamLeaderId,
-                    TimeEntryId = request.TimeEntryId,
-                    TimeIn = TimeSpan.ParseExact(request.TimeIn, "hh':'mm", null),
-                    TimeOut = TimeSpan.ParseExact(request.TimeOut, "hh':'mm", null),
-                    Description = request.Description,
-                    Title = request.Title
-                };
-
-                context.ESLOffsets.Add(eslOffset);
-                await context.SaveChangesAsync();
-                return eslOffset;
-            }
+            context.ESLOffsets.Add(eslOffset);
+            await context.SaveChangesAsync();
+            return eslOffset;
         }
 
         public async Task<List<ESLOffsetDTO>> GetTimeEntryOffsets(int timeEntryId, bool onlyUnused)

--- a/api/Services/InterruptionService.cs
+++ b/api/Services/InterruptionService.cs
@@ -43,6 +43,7 @@ namespace api.Services
                 return await context.WorkInterruptions
                             .Include(i => i.WorkInterruptionType)
                             .Where(i => i.TimeEntryId == interruption.TimeEntryId)
+                            .OrderByDescending(x => x.CreatedAt)
                             .Select(x => ToWorkInterruptionDTO(x))
                             .ToListAsync();
             }

--- a/api/Services/OvertimeService.cs
+++ b/api/Services/OvertimeService.cs
@@ -83,6 +83,7 @@ namespace api.Services
                     .Include(x => x.Manager)
                         .ThenInclude(x => x.Role)
                     .Where(w => w.UserId == UserId)
+                    .OrderByDescending(x => x.CreatedAt)
                     .Select(x => new MyOvertimeDTO(x))
                     .ToListAsync();
             }
@@ -107,6 +108,7 @@ namespace api.Services
                     .ThenInclude(x => x.TimeIn)
                 .Include(x => x.TimeEntry)
                     .ThenInclude(x => x.TimeOut)
+                .OrderByDescending(x => x.CreatedAt)
                 .Select(x => new OvertimeDTO(x, domain))
                 .ToListAsync();
             }

--- a/api/Services/ProjectService.cs
+++ b/api/Services/ProjectService.cs
@@ -28,7 +28,7 @@ namespace api.Services
         {
             using (HrisContext context = _contextFactory.CreateDbContext())
             {
-                var ids = new List<int> { PositionEnum.ADMIN, PositionEnum.WEB_DEVELOPER_TEAM_LEADER, PositionEnum.WEB_DEVELOPER_TRAINER };
+                var ids = PositionEnum.ALL_LEADERS;
 
                 if (projectId == ProjectId.OJT)
                 {

--- a/api/Services/TimeSheetService.cs
+++ b/api/Services/TimeSheetService.cs
@@ -62,6 +62,7 @@ namespace api.Services
                     .Include(entry => entry.User)
                         .ThenInclude(x => x.ProfileImage)
                     .Include(entry => entry.Overtime)
+                    .Include(x => x.WorkInterruptions)
                     .Where(c => c.UserId == id)
                     .OrderByDescending(entry => entry.Date)
                     .Select(x => ToTimeEntryDTO(x, leaves, domain, changeShift, eslChangeShift))
@@ -81,6 +82,7 @@ namespace api.Services
 
                 return await context.TimeEntries
                     .Include(entity => entity.TimeIn)
+                    .Include(x => x.WorkInterruptions)
                     .Select(x => ToTimeEntryDTO(x, leaves, domain, null, null))
                     .FirstOrDefaultAsync(c => c.UserId == id);
             }

--- a/api/Utils/Validation.cs
+++ b/api/Utils/Validation.cs
@@ -58,9 +58,9 @@ namespace api.Utils
         {
             using (HrisContext context = _contextFactory.CreateDbContext())
             {
-                var user = await context.Projects.Where(x => x.ProjectLeaderId == id).FirstOrDefaultAsync();
+                var user = await context.Users.FindAsync(id);
 
-                return user != null;
+                return user != null && PositionEnum.ALL_LEADERS.Contains(user.PositionId);
             }
         }
 

--- a/api/Utils/Validation.cs
+++ b/api/Utils/Validation.cs
@@ -12,7 +12,7 @@ namespace api.Utils
     public class CustomInputValidation
     {
         public string VARIABLE_STRING = "variable";
-        private readonly IDbContextFactory<HrisContext> _contextFactory = default!;
+        protected readonly IDbContextFactory<HrisContext> _contextFactory = default!;
         public CustomInputValidation(IDbContextFactory<HrisContext> contextFactory)
         {
             _contextFactory = contextFactory;
@@ -70,18 +70,6 @@ namespace api.Utils
             {
                 var user = context.Users.Find(id);
                 return user != null && user.PositionId != PositionEnum.ESL_TEACHER;
-            }
-        }
-
-        public async Task<bool> checkApprovingProjectLeader(int projectLeaderId, int id, string type)
-        {
-            using (HrisContext context = _contextFactory.CreateDbContext())
-            {
-                MultiProject? multiProject = null;
-                if (type == MultiProjectTypeEnum.LEAVE) multiProject = await context.MultiProjects.Where(x => x.Type == type && x.LeaveId == id && x.ProjectLeaderId == projectLeaderId).FirstOrDefaultAsync();
-                if (type == MultiProjectTypeEnum.OVERTIME) multiProject = await context.MultiProjects.Where(x => x.Type == type && x.OvertimeId == id && x.ProjectLeaderId == projectLeaderId).FirstOrDefaultAsync();
-                if (type == MultiProjectTypeEnum.CHANGE_SHIFT) multiProject = await context.MultiProjects.Where(x => x.Type == type && x.ChangeShiftRequestId == id && x.ProjectLeaderId == projectLeaderId).FirstOrDefaultAsync();
-                return multiProject != null;
             }
         }
 
@@ -305,37 +293,6 @@ namespace api.Utils
             return errors;
         }
 
-        public List<IError> checkApproveLeaveRequestInput(ApproveLeaveUndertimeRequest request)
-        {
-            var errors = new List<IError>();
-
-            if (!checkUserExist(request.UserId))
-                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
-
-            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
-
-            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.LEAVE).Result)
-                errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
-
-            return errors;
-        }
-
-        public List<IError> checkApproveUndertimeRequestInput(ApproveLeaveUndertimeRequest request)
-        {
-            var errors = new List<IError>();
-
-            if (!checkUserExist(request.UserId))
-                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
-
-
-            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
-
-            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.UNDERTIME).Result)
-                errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
-
-            return errors;
-        }
-
         public List<IError> checkApproveOvertimeRequestInput(ApproveOvertimeRequest request)
         {
             var errors = new List<IError>();
@@ -344,54 +301,6 @@ namespace api.Utils
                 errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
 
             if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
-
-            return errors;
-        }
-
-        public List<IError> checkLeaderApproveOvertimeRequestInput(ApproveOvertimeRequest request)
-        {
-            var errors = new List<IError>();
-
-            if (!checkUserExist(request.UserId))
-                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
-
-            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
-
-            if (request.NotificationId == null || !checkNotificationExist((int)request.NotificationId, NotificationTypeEnum.OVERTIME).Result)
-                errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
-
-            return errors;
-        }
-
-        public List<IError> checkManagerApproveOvertimeRequestInput(ApproveOvertimeRequest request)
-        {
-            var errors = new List<IError>();
-
-            if (!checkUserExist(request.UserId))
-                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
-
-
-            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
-
-            if (request.OvertimeId == null || !checkOvertimeExist((int)request.OvertimeId).Result)
-                errors.Add(buildError(nameof(request.OvertimeId), InputValidationMessageEnum.INVALID_OVERTIME));
-
-            if (request.IsApproved && request.ApprovedMinutes == null)
-                errors.Add(buildError(nameof(request.ApprovedMinutes), InputValidationMessageEnum.MISSING_APPROVED_MINUTES));
-
-            return errors;
-        }
-
-        public List<IError> checkApproveChangeShiftRequestInput(ApproveChangeShiftRequest request)
-        {
-            var errors = new List<IError>();
-
-            if (!checkUserExist(request.UserId))
-                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
-
-            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
-
-            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.CHANGE_SHIFT).Result) errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
 
             return errors;
         }
@@ -476,36 +385,6 @@ namespace api.Utils
 
             if (checkNonESLUser(request.TeamLeaderId))
                 errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_TEAM_LEADER));
-
-            return errors;
-        }
-
-        public List<IError> ESLChangeShiftStatusRequestInput(ApproveESLChangeShiftRequest request)
-        {
-            var errors = new List<IError>();
-
-            if (!checkUserExist(request.TeamLeaderId))
-                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_USER));
-
-            if (checkNonESLUser(request.TeamLeaderId))
-                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_TEAM_LEADER));
-
-            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.ESL_OFFSET_SCHEDULE).Result) errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
-
-            return errors;
-        }
-
-        public List<IError> ChangeESLOffsetStatusRequestInput(ApproveESLChangeShiftRequest request)
-        {
-            var errors = new List<IError>();
-
-            if (!checkUserExist(request.TeamLeaderId))
-                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_USER));
-
-            if (checkNonESLUser(request.TeamLeaderId))
-                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_TEAM_LEADER));
-
-            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.ESL_OFFSET).Result) errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
 
             return errors;
         }

--- a/api/Utils/Validation/ApprovalServiceInputValidation.cs
+++ b/api/Utils/Validation/ApprovalServiceInputValidation.cs
@@ -1,0 +1,138 @@
+using api.Context;
+using api.Entities;
+using api.Enums;
+using api.Requests;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Utils
+{
+    public class ApprovalServiceInputValidation : CustomInputValidation
+    {
+        // constructor
+        public ApprovalServiceInputValidation(IDbContextFactory<HrisContext> contextFactory) : base(contextFactory)
+        {
+
+        }
+
+        public async Task<bool> checkApprovingProjectLeader(int projectLeaderId, int id, string type)
+        {
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                MultiProject? multiProject = null;
+                if (type == MultiProjectTypeEnum.LEAVE) multiProject = await context.MultiProjects.Where(x => x.Type == type && x.LeaveId == id && x.ProjectLeaderId == projectLeaderId).FirstOrDefaultAsync();
+                if (type == MultiProjectTypeEnum.OVERTIME) multiProject = await context.MultiProjects.Where(x => x.Type == type && x.OvertimeId == id && x.ProjectLeaderId == projectLeaderId).FirstOrDefaultAsync();
+                if (type == MultiProjectTypeEnum.CHANGE_SHIFT) multiProject = await context.MultiProjects.Where(x => x.Type == type && x.ChangeShiftRequestId == id && x.ProjectLeaderId == projectLeaderId).FirstOrDefaultAsync();
+                return multiProject != null;
+            }
+        }
+
+        public List<IError> checkApproveLeaveRequestInput(ApproveLeaveUndertimeRequest request)
+        {
+            var errors = new List<IError>();
+
+            if (!checkUserExist(request.UserId))
+                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
+
+            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
+
+            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.LEAVE).Result)
+                errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
+
+            return errors;
+        }
+
+        public List<IError> checkApproveUndertimeRequestInput(ApproveLeaveUndertimeRequest request)
+        {
+            var errors = new List<IError>();
+
+            if (!checkUserExist(request.UserId))
+                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
+
+
+            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
+
+            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.UNDERTIME).Result)
+                errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
+
+            return errors;
+        }
+
+        public List<IError> checkLeaderApproveOvertimeRequestInput(ApproveOvertimeRequest request)
+        {
+            var errors = new List<IError>();
+
+            if (!checkUserExist(request.UserId))
+                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
+
+            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
+
+            if (request.NotificationId == null || !checkNotificationExist((int)request.NotificationId, NotificationTypeEnum.OVERTIME).Result)
+                errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
+
+            return errors;
+        }
+
+        public List<IError> checkManagerApproveOvertimeRequestInput(ApproveOvertimeRequest request)
+        {
+            var errors = new List<IError>();
+
+            if (!checkUserExist(request.UserId))
+                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
+
+
+            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
+
+            if (request.OvertimeId == null || !checkOvertimeExist((int)request.OvertimeId).Result)
+                errors.Add(buildError(nameof(request.OvertimeId), InputValidationMessageEnum.INVALID_OVERTIME));
+
+            if (request.IsApproved && request.ApprovedMinutes == null)
+                errors.Add(buildError(nameof(request.ApprovedMinutes), InputValidationMessageEnum.MISSING_APPROVED_MINUTES));
+
+            return errors;
+        }
+
+        public List<IError> checkApproveChangeShiftRequestInput(ApproveChangeShiftRequest request)
+        {
+            var errors = new List<IError>();
+
+            if (!checkUserExist(request.UserId))
+                errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.INVALID_USER));
+
+            if (!(CheckManagerUser(request.UserId).Result || checkProjectLeaderUser(request.UserId).Result)) errors.Add(buildError(nameof(request.UserId), InputValidationMessageEnum.NOT_MANAGER_PROJECT_LEADER));
+
+            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.CHANGE_SHIFT).Result) errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
+
+            return errors;
+        }
+
+        public List<IError> ESLChangeShiftStatusRequestInput(ApproveESLChangeShiftRequest request)
+        {
+            var errors = new List<IError>();
+
+            if (!checkUserExist(request.TeamLeaderId))
+                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_USER));
+
+            if (checkNonESLUser(request.TeamLeaderId))
+                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_TEAM_LEADER));
+
+            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.ESL_OFFSET_SCHEDULE).Result) errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
+
+            return errors;
+        }
+
+        public List<IError> ChangeESLOffsetStatusRequestInput(ApproveESLChangeShiftRequest request)
+        {
+            var errors = new List<IError>();
+
+            if (!checkUserExist(request.TeamLeaderId))
+                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_USER));
+
+            if (checkNonESLUser(request.TeamLeaderId))
+                errors.Add(buildError(nameof(request.TeamLeaderId), InputValidationMessageEnum.INVALID_TEAM_LEADER));
+
+            if (!checkNotificationExist(request.NotificationId, NotificationTypeEnum.ESL_OFFSET).Result) errors.Add(buildError(nameof(request.NotificationId), InputValidationMessageEnum.INVALID_NOTIFICATION));
+
+            return errors;
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-277

## Definition of Done
- [x] Fixed names generated and displayed in notifications.

## Notes
- It's ideal to have access to three accounts to check for the notifications. One normal user, one leader ( `positionId` = 3, 6 or 7) and one manager (`roleId` = 1)
- `ESL Change Shift` and `ESL Offset` are only for ESL Users (`positionId` = 5)

## Pre-condition
- (docker) run `docker compose up db api client --build -d`
- To make Leave/Undertime request, go to `My Leaves` page
- To make Overtime request, go to `My Overtime` page
- To make Change Shift request, go to `My Daily Time Record` page
- To make ESL Change Shift and Offset request, go to `My Daily Time Record` page
- Approve requests as Leader/Manager in `Notifications` page

## Expected Output
- The name of requesting/approving/disapproving user should be displayed correctly in notifications.

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/111718037/daed97dd-afa4-4e92-8bec-d1ad74384890

https://github.com/framgia/sph-hris/assets/111718037/cf4194ea-e308-4e2a-86c0-a522130e294f

https://github.com/framgia/sph-hris/assets/111718037/31ff71c8-a173-4d94-b281-60abc116e67e

https://github.com/framgia/sph-hris/assets/111718037/1cb5e176-a5c0-44cb-82c7-3b571ac5f81c

https://github.com/framgia/sph-hris/assets/111718037/0fcd3601-8ba8-4cfd-b608-8628eb7d3f7a


