### PR TITLE
HRIS-281 [BE] Resolve the issue preventing users from clocking in or out in the Clock-in and Clock-out functionality

### DIFF
--- a/api/Schema/Mutations/TimeOutMutation.cs
+++ b/api/Schema/Mutations/TimeOutMutation.cs
@@ -13,7 +13,16 @@ namespace api.Schema.Mutations
         }
         public async Task<string> UpdateTimeOut(TimeOutRequest timeOut)
         {
-            return await _timeOutService.Update(timeOut);
+            try
+            {
+                return await _timeOutService.Update(timeOut);
+            }
+            catch (Exception e)
+            {
+                throw new GraphQLException(ErrorBuilder.New()
+                .SetMessage(e.Message)
+                .Build());
+            }
         }
     }
 }

--- a/api/Services/TimeInService.cs
+++ b/api/Services/TimeInService.cs
@@ -89,7 +89,7 @@ namespace api.Services
                     var files = _fileUpload.UploadBlob(timeIn.files, this.GetType().Name.ToLower());
                     var time = context.Times.Add(new Time
                     {
-                        TimeHour = timeIn.TimeHour,
+                        TimeHour = TimeSpan.FromSeconds(Math.Round(DateTime.Now.TimeOfDay.TotalSeconds)),
                         Remarks = timeIn.Remarks,
                         Media = files
                     });

--- a/api/Services/TimeOutService.cs
+++ b/api/Services/TimeOutService.cs
@@ -22,7 +22,7 @@ namespace api.Services
                 {
                     var time = context.Times.Add(new Time
                     {
-                        TimeHour = timeout.TimeHour,
+                        TimeHour = TimeSpan.FromSeconds(Math.Round(DateTime.Now.TimeOfDay.TotalSeconds)),
                         Remarks = timeout.Remarks
                     });
 
@@ -47,9 +47,9 @@ namespace api.Services
                     transaction.Commit();
                     return "Successful Time Out!";
                 }
-                catch (Exception e)
+                catch
                 {
-                    return e.InnerException?.Message ?? "Something went wrong...";
+                    throw new Exception("Something went wrong...");
                 }
             }
         }
@@ -60,8 +60,12 @@ namespace api.Services
             TimeEntryDTO timeEntryDTO = new TimeEntryDTO(timeEntry, null, "", null, null);
             TimeSpan UndertimeTimeSpan = TimeSpan.FromMinutes(timeEntryDTO.Undertime);
             TimeSpan LateTimeSpan = TimeSpan.FromMinutes(timeEntryDTO.Late);
+            TimeSpan ScheduledHours = timeEntry.EndTime - timeEntry.StartTime;
 
-            return timeEntry.EndTime - timeEntry.StartTime - UndertimeTimeSpan - LateTimeSpan;
+            // check if logged in after work schedule
+            if ((ScheduledHours - LateTimeSpan).TotalMinutes < 0) LateTimeSpan = ScheduledHours - UndertimeTimeSpan;
+
+            return ScheduledHours - UndertimeTimeSpan - LateTimeSpan;
         }
     }
 }

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -16,6 +16,7 @@ import { INotification } from '~/utils/interfaces'
 import ClockInIcon from '~/utils/icons/ClockInIcon'
 import ClockOutIcon from '~/utils/icons/ClockOutIcon'
 import { Menus } from '~/utils/constants/sidebarMenu'
+import { serverTime } from '~/utils/shared/serverTime'
 import Button from '~/components/atoms/Buttons/Button'
 import handleImageError from '~/utils/handleImageError'
 import { getDuration } from '~/utils/notificationHelpers'
@@ -147,7 +148,7 @@ const Header: FC<Props> = (props): JSX.Element => {
 
   const setTimer = (data: any): void => {
     setRunning(true)
-    const now = moment(new Date()).format('YYYY-MM-DD HH:mm:ss')
+    const now = moment(serverTime()).format('YYYY-MM-DD HH:mm:ss')
     setSeconds(0)
     if (data.userById.timeEntry.timeIn !== null) {
       const timeObj = parse(data?.userById.timeEntry.timeIn?.timeHour)

--- a/client/src/utils/shared/serverTime.ts
+++ b/client/src/utils/shared/serverTime.ts
@@ -1,0 +1,3 @@
+export const serverTime: any = () => {
+  return new Date().toLocaleString('en-US', { timeZone: 'Asia/Manila' })
+}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-281

## Definition of Done
- [x] Fixed the issue where user cannot clock out when clocked in beyond schedule time
- [x] Clock in time is now based on server time and not on the user's machine time
- [x] Added error handling in TimeOut

## Notes
- The bug occurs when user is clocked in past the their scheduled work time and then clocked out
- To test timezone difference with the server it is important to run BE in docker

## Pre-condition
- (docker) run `docker compose up db api client --build -d`
- Clock In / Clock Out

## Expected Output
- User should be able to clock out normally regardless of when the last clock in
- When clocking in or clocking out, the time registered should be the server time and not the user's machine time
- The timer in FE shoud be consistent with the server time

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/111718037/5688f7b7-16e3-426f-a47d-ecb2cd24f5ee


https://github.com/framgia/sph-hris/assets/111718037/d46e6225-407e-48c6-a000-df992cafb735



