### PR TITLE
HRIS-281-1 [BE] Fix deprecated warning in timer

### DIFF
--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -148,7 +148,7 @@ const Header: FC<Props> = (props): JSX.Element => {
 
   const setTimer = (data: any): void => {
     setRunning(true)
-    const now = moment(serverTime()).format('YYYY-MM-DD HH:mm:ss')
+    const now = serverTime()
     setSeconds(0)
     if (data.userById.timeEntry.timeIn !== null) {
       const timeObj = parse(data?.userById.timeEntry.timeIn?.timeHour)

--- a/client/src/utils/shared/serverTime.ts
+++ b/client/src/utils/shared/serverTime.ts
@@ -1,3 +1,5 @@
-export const serverTime: any = () => {
-  return new Date().toLocaleString('en-US', { timeZone: 'Asia/Manila' })
+import moment from 'moment'
+
+export const serverTime = (): string => {
+  return moment().utcOffset(480).format('YYYY-MM-DD HH:mm:ss')
 }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-281

## Definition of Done
- [x] Fixed the deprecation warning occuring in the timer

## Notes
- Revision PR from #234 

## Pre-condition
- (docker) run `docker compose up db api client --build -d`
- open console in FE

## Expected Output
- There should be no more warning in the console pf FE

## Screenshots/Recordings
![image](https://github.com/framgia/sph-hris/assets/111718037/e282336e-6ab9-4a24-b354-76d029ee1ce8)

