### PR TITLE
HRIS-276 [BE/FE] Add functionality to enable users to edit their filed leave

### DIFF
--- a/api/DTOs/LeaveDTO.cs
+++ b/api/DTOs/LeaveDTO.cs
@@ -11,7 +11,9 @@ namespace api.DTOs
             UserName = leave.User.Name;
             UserRole = leave.User.Role.Name;
             LeaveProjects = leave.LeaveProjects;
+            LeaveTypeId = leave.LeaveTypeId;
             LeaveType = leave.LeaveType.Name;
+            ManagerId = leave.Manager.Id;
             Manager = leave.Manager.Name;
             OtherProject = leave.OtherProject;
             Reason = leave.Reason;

--- a/api/DTOs/LeavesDTO.cs
+++ b/api/DTOs/LeavesDTO.cs
@@ -13,7 +13,7 @@ namespace api.DTOs
         {
             Heatmap = heatmapLeaves;
             User = user;
-            Table = table.OrderByDescending(table => table.Date).ToList();
+            Table = table.OrderByDescending(table => table.CreatedAt).ToList();
             Breakdown = new LeaveBreakdownDTO(table);
         }
     }

--- a/api/DTOs/LeavesTableDTO.cs
+++ b/api/DTOs/LeavesTableDTO.cs
@@ -6,20 +6,24 @@ namespace api.DTOs
     public class LeavesTableDTO
     {
         public DateTime? Date { get; set; }
+        public DateTime? CreatedAt { get; set; }
+        public int LeaveTypeId { get; set; }
         public bool IsWithPay { get; set; }
         public string? Reason { get; set; }
         public string? Status { get; set; }
-        public int LeaveTypeId { get; set; }
         public float NumLeaves { get; set; }
         public string? UserName { get; set; }
         public string? LeaveName { get; set; }
         public bool? IsLeaderApproved { get; set; }
         public bool? IsManagerApproved { get; set; }
+        public int LeaveId { get; set; }
 
         public LeavesTableDTO(Leave data)
         {
-            Reason = data.Reason;
             Date = data.LeaveDate;
+            CreatedAt = data.CreatedAt;
+            LeaveId = data.Id;
+            Reason = data.Reason;
             NumLeaves = data.Days;
             UserName = data.User.Name;
             IsWithPay = data.IsWithPay;

--- a/api/Entities/LeaveNotification.cs
+++ b/api/Entities/LeaveNotification.cs
@@ -2,6 +2,7 @@ namespace api.Entities
 {
     public class LeaveNotification : Notification
     {
+
         public int LeaveId { get; set; }
         public Leave Leave { get; set; } = default!;
     }

--- a/api/Enums/SuccessMessageEnum.cs
+++ b/api/Enums/SuccessMessageEnum.cs
@@ -7,5 +7,6 @@ namespace api.Enums
         public const string SCHEDULE_UPDATED = "Successfully updated a schedule!";
         public const string EMPLOYEE_ADDED = "Employee(s) sccessfully added to the schedule!";
         public const string EMPLOYEE_SCHEDULE_UPDATED = "Employee schedule sccessfully updated!";
+        public const string LEAVE_UPDATED = "Leave successfully updated!";
     }
 }

--- a/api/Requests/UpdateLeaveRequest.cs
+++ b/api/Requests/UpdateLeaveRequest.cs
@@ -1,0 +1,14 @@
+namespace api.Requests
+{
+    public class UpdateLeaveRequest
+    {
+        public int UserId { get; set; }
+        public int LeaveTypeId { get; set; }
+        public int LeaveId { get; set; }
+        public int ManagerId { get; set; }
+        public string? OtherProject { get; set; }
+        public string? Reason { get; set; }
+        public List<MultiProjectRequest> LeaveProjects { get; set; } = default!;
+        public List<LeaveDateRequest> LeaveDates { get; set; } = default!;
+    }
+}

--- a/api/Schema/Mutations/LeaveMutation.cs
+++ b/api/Schema/Mutations/LeaveMutation.cs
@@ -41,5 +41,25 @@ namespace api.Schema.Mutations
                 }
             }
         }
+
+        public async Task<string?> UpdateLeave(UpdateLeaveRequest leave, [Service] LeaveService _leaveService, [Service] NotificationService _notificationService, [Service] IDbContextFactory<HrisContext> contextFactory)
+        {
+            using (HrisContext context = contextFactory.CreateDbContext())
+            {
+                try
+                {
+                    List<LeaveNotification> updatedNotifications = await _leaveService.UpdateLeave(leave);
+
+                    // Send Notifications
+                    updatedNotifications.ForEach(notif => _notificationService.sendLeaveNotificationEvent(notif));
+
+                    return SuccessMessageEnum.LEAVE_UPDATED;
+                }
+                catch (GraphQLException)
+                {
+                    throw;
+                }
+            }
+        }
     }
 }

--- a/api/Schema/Queries/LeaveQuery.cs
+++ b/api/Schema/Queries/LeaveQuery.cs
@@ -38,5 +38,10 @@ namespace api.Schema.Queries
         {
             return await _leaveService.GetPaidLeaves(id);
         }
+
+        public async Task<List<LeaveDTO>> GetUserLeave(int leaveId)
+        {
+            return await _leaveService.GetUserLeave(leaveId);
+        }
     }
 }

--- a/api/Services/LeaveService.cs
+++ b/api/Services/LeaveService.cs
@@ -2,10 +2,12 @@ using api.Context;
 using api.DTOs;
 using api.Entities;
 using api.Enums;
+using api.NotificationDataClasses;
 using api.Requests;
 using api.Utils;
 using HotChocolate.Subscriptions;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
 
 namespace api.Services
 {
@@ -176,6 +178,188 @@ namespace api.Services
             if (leave.IsLeaderApproved == true && leave.IsManagerApproved == true) return RequestStatus.APPROVED;
             if (leave.IsLeaderApproved == false && leave.IsManagerApproved == false) return RequestStatus.DISAPPROVED;
             return RequestStatus.PENDING;
+        }
+
+        public async Task<List<LeaveDTO>> GetUserLeave(int leaveId)
+        {
+            var domain = _httpService.getDomainURL();
+            using (HrisContext context = _contextFactory.CreateDbContext())
+            {
+                return
+                await context.Leaves
+                .Include(x => x.User.Role)
+                .Include(x => x.User)
+                    .ThenInclude(x => x.ProfileImage)
+                .Include(x => x.LeaveType)
+                .Include(x => x.Manager)
+                .Include(x => x.LeaveProjects)
+                    .ThenInclude(x => x.Project)
+                .Include(x => x.LeaveProjects)
+                    .ThenInclude(x => x.ProjectLeader)
+                    .Where(x => x.Id == leaveId)
+                .Select(x => new LeaveDTO(x, domain))
+                .ToListAsync();
+            }
+        }
+
+        public async Task<List<LeaveNotification>> UpdateLeave(UpdateLeaveRequest requestLeave)
+        {
+            using HrisContext context = _contextFactory.CreateDbContext();
+            // validate inputs
+            var errors = _customInputValidation.CheckUpdateLeaveRequestInput(requestLeave);
+            if (errors.Count > 0) throw new GraphQLException(errors);
+
+            var existingLeave = context.Leaves.FirstOrDefault(x => x.Id == requestLeave.LeaveId);
+            int oldManagerId = (int)existingLeave!.ManagerId!;
+
+            List<LeaveNotification> updatedNotifications = new();
+
+            requestLeave.LeaveDates?.ForEach(date =>
+            {
+                var existingNotfication = context.LeaveNotifications.Where(x => x.LeaveId == requestLeave.LeaveId).ToList();
+
+                if (existingLeave != null)
+                {
+                    // Update LeaveProjects
+                    UpdateLeaveProjects(context, requestLeave);
+
+                    // Update the existing Leave entity
+                    UpdateExistingLeave(requestLeave, date, existingLeave);
+
+                    // Update manager notification
+                    int managerNotificationId = UpdateManagerNotification(requestLeave, existingLeave, oldManagerId, updatedNotifications).Result;
+
+                    // Update leader notification
+                    UpdateLeaderLeaveNotification(requestLeave, existingLeave, managerNotificationId, updatedNotifications);
+                }
+            });
+
+            await context.SaveChangesAsync();
+            return updatedNotifications;
+        }
+
+        public async Task<int> UpdateManagerNotification(UpdateLeaveRequest requestLeave, Leave leave, int oldManagerId, List<LeaveNotification> updatedNotifications)
+        {
+            using HrisContext context = _contextFactory.CreateDbContext();
+            var notifications = context.LeaveNotifications.Where(x => x.LeaveId == requestLeave.LeaveId).ToList();
+            var managerNotification = notifications.Find(x => x.RecipientId == oldManagerId && x.LeaveId == requestLeave.LeaveId);
+
+            List<int> projectIds = requestLeave.LeaveProjects.ConvertAll(u => u.ProjectId);
+            List<int?> recipientIdList = notifications.ConvertAll(x => x.RecipientId);
+            User? managerUser = context.Users.Include(x => x.Role).Where(x => recipientIdList.Contains(x.Id) && x.Role.Name == RoleEnum.MANAGER).FirstOrDefault();
+
+            var projects = context.Projects.Where(x => projectIds.Contains(x.Id));
+            var notificationData = JsonConvert.DeserializeObject<LeaveLeaderData>(managerNotification!.Data);
+            var leaveProjectIds = requestLeave.LeaveProjects.ConvertAll(x => x.ProjectLeaderId);
+
+            notificationData!.Projects = projects.Select(project => project.Name!).ToList();
+            notificationData!.RequestedHours = LeaveDaysToHours(leave.Days);
+            notificationData.Remarks = leave.Reason;
+            notificationData.IsWithPay = leave.IsWithPay;
+            notificationData.DateRequested = leave.LeaveDate;
+            notificationData.Status = RequestStatus.PENDING;
+            managerNotification.Data = JsonConvert.SerializeObject(notificationData);
+
+            managerNotification.RecipientId = requestLeave.ManagerId;
+            managerNotification.IsRead = false;
+            managerNotification.ReadAt = null;
+
+            await context.SaveChangesAsync();
+
+            updatedNotifications.Add(managerNotification);
+
+            return managerNotification.Id;
+        }
+
+        public async void UpdateLeaderLeaveNotification(UpdateLeaveRequest requestLeave, Leave leave, int managerNotificationId, List<LeaveNotification> updatedNotifications)
+        {
+            using HrisContext context = _contextFactory.CreateDbContext();
+            var notifications = context.LeaveNotifications.Where(x => x.LeaveId == requestLeave.LeaveId).ToList();
+
+            // All notifications recipient ID
+            var recipientId = notifications.ConvertAll(x => x.RecipientId);
+
+            // Check and get all the project leaders ID on the notifications
+            List<int> projectLeaderUsers = context.Users
+            .Include(x => x.Position)
+            .Where(x => recipientId.Contains(x.Id) && PositionEnum.ALL_LEADERS.Contains(x.PositionId))
+            .Select(x => x.Id)
+            .ToList();
+
+            var leaderNotifications = notifications.Where(x => projectLeaderUsers.Contains((int)x.RecipientId!) && x.LeaveId == requestLeave.LeaveId && x.Id != managerNotificationId).ToList();
+
+            // Old + New project leader notifications ID
+            List<int> newLeaderIds = requestLeave.LeaveProjects.ConvertAll(u => u.ProjectLeaderId);
+
+            // Old + New projects
+            List<int> projectIds = requestLeave.LeaveProjects.ConvertAll(u => u.ProjectId);
+            var projects = context.Projects.Where(x => projectIds.Contains(x.Id)).ToList();
+
+            int index = 0;
+            leaderNotifications.ForEach((leaderNotification) =>
+            {
+                var notificationData = JsonConvert.DeserializeObject<LeaveLeaderData>(leaderNotification.Data);
+                var leaveProjectId = requestLeave.LeaveProjects[index].ProjectId;
+                var project = projects.Find(x => x.Id == leaveProjectId);
+
+                notificationData!.Projects = new List<string> { project!.Name == "Others" ? leave.OtherProject! : project.Name! };
+                notificationData!.RequestedHours = LeaveDaysToHours(leave.Days);
+                notificationData.Remarks = leave.Reason;
+                notificationData.IsWithPay = leave.IsWithPay;
+                notificationData.DateRequested = leave.LeaveDate;
+                notificationData.Status = RequestStatus.PENDING;
+                leaderNotification.Data = JsonConvert.SerializeObject(notificationData);
+
+                leaderNotification.RecipientId = newLeaderIds[index];
+                leaderNotification.IsRead = false;
+                leaderNotification.ReadAt = null;
+
+                index++;
+            });
+
+            await context.SaveChangesAsync();
+            updatedNotifications.AddRange(leaderNotifications);
+        }
+
+        private static void UpdateLeaveProjects(HrisContext context, UpdateLeaveRequest leave)
+        {
+            leave.LeaveProjects?.ForEach(project =>
+                    {
+                        DeleteOutdatedProjects(leave.LeaveId, context);
+                        UpdateMultiProjects(leave.LeaveId, project, context);
+                    });
+        }
+
+        private static void UpdateMultiProjects(int leaveId, MultiProjectRequest project, HrisContext context)
+        {
+            var leaveProjectsList = new List<MultiProject>();
+            var projectLeave = new MultiProject
+            {
+                ProjectId = project.ProjectId,
+                ProjectLeaderId = project.ProjectLeaderId,
+                Type = MultiProjectTypeEnum.LEAVE,
+                LeaveId = leaveId
+            };
+            leaveProjectsList.Add(context.MultiProjects.Add(projectLeave).Entity);
+        }
+
+        private static void DeleteOutdatedProjects(int leaveId, HrisContext context)
+        {
+            var existingProjects = context.MultiProjects.Where(x => x.LeaveId == leaveId);
+            context.MultiProjects.RemoveRange(existingProjects);
+        }
+
+        private static void UpdateExistingLeave(UpdateLeaveRequest leave, LeaveDateRequest date, Leave existingLeave)
+        {
+            existingLeave.ManagerId = leave.ManagerId;
+            existingLeave.LeaveTypeId = leave.LeaveTypeId;
+            existingLeave.OtherProject = leave.OtherProject;
+            existingLeave.Reason = leave.Reason;
+            existingLeave.IsWithPay = date.IsWithPay;
+            existingLeave.Days = date.Days;
+            existingLeave.IsManagerApproved = null;
+            existingLeave.IsLeaderApproved = null;
+            existingLeave.LeaveDate = DateTime.Parse(date.LeaveDate);
         }
     }
 }

--- a/api/Utils/Validation.cs
+++ b/api/Utils/Validation.cs
@@ -263,6 +263,45 @@ namespace api.Utils
             return errors;
         }
 
+        public List<IError> CheckUpdateLeaveRequestInput(UpdateLeaveRequest leave)
+        {
+            var errors = new List<IError>();
+            int index = 0;
+
+            if (!checkUserExist(leave.UserId))
+                errors.Add(buildError(nameof(leave.UserId), InputValidationMessageEnum.INVALID_USER));
+
+            if (!CheckManagerUser(leave.ManagerId).Result)
+                errors.Add(buildError(nameof(leave.ManagerId), InputValidationMessageEnum.INVALID_MANAGER));
+
+
+            if (!checkLeaveType(leave.LeaveTypeId))
+                errors.Add(buildError(nameof(leave.LeaveTypeId), InputValidationMessageEnum.INVALID_LEAVE_TYPE));
+
+            index = 0;
+            leave.LeaveProjects?.ForEach(project =>
+            {
+                if (!checkProjectExist(project.ProjectId))
+                    errors.Add(buildError(nameof(project.ProjectId), InputValidationMessageEnum.INVALID_PROJECT, index));
+
+                if (!checkUserExist(project.ProjectLeaderId))
+                    errors.Add(buildError(nameof(project.ProjectLeaderId), InputValidationMessageEnum.INVALID_PROJECT_LEADER, index));
+
+                index++;
+            });
+
+            index = 0;
+            leave.LeaveDates?.ForEach(date =>
+            {
+                if (!checkDateFormat(date.LeaveDate))
+                    errors.Add(buildError(nameof(date.LeaveDate), InputValidationMessageEnum.INVALID_DATE, index));
+
+                index++;
+            });
+
+            return errors;
+        }
+
         public List<IError> checkOvertimeRequestInput(CreateOvertimeRequest overtime)
         {
             var errors = new List<IError>();

--- a/client/src/components/molecules/EditLeaveModal/EditTab.tsx
+++ b/client/src/components/molecules/EditLeaveModal/EditTab.tsx
@@ -1,0 +1,717 @@
+import moment from 'moment'
+import classNames from 'classnames'
+import toast from 'react-hot-toast'
+import ReactSelect from 'react-select'
+import { useRouter } from 'next/router'
+import { Tab } from '@headlessui/react'
+import makeAnimated from 'react-select/animated'
+import CreatableSelect from 'react-select/creatable'
+import { yupResolver } from '@hookform/resolvers/yup'
+import React, { FC, useEffect, useState } from 'react'
+import ReactTextareaAutosize from 'react-textarea-autosize'
+import { Controller, useFieldArray, useForm } from 'react-hook-form'
+import { X, Save, User, Coffee, FileText, Calendar, RefreshCcw } from 'react-feather'
+
+import TextField from './../TextField'
+import useProject from '~/hooks/useProject'
+import Input from '~/components/atoms/Input'
+import useUserQuery from '~/hooks/useUserQuery'
+import { Roles } from '~/utils/constants/roles'
+import SpinnerIcon from '~/utils/icons/SpinnerIcon'
+import { NewLeaveSchema } from '~/utils/validation'
+import { User as UserType } from '~/utils/types/userTypes'
+import Button from '~/components/atoms/Buttons/ButtonAction'
+import { customStyles } from '~/utils/customReactSelectStyles'
+import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
+import { NewLeaveFormValues, ReactSelectOption } from '~/utils/types/formValues'
+import {
+  generateUserSelect,
+  generateProjectsMultiSelect,
+  generateLeaveTypeSelect,
+  generateNumberOfDaysSelect
+} from '~/utils/createLeaveHelpers'
+import useLeave from '~/hooks/useLeave'
+import { LeaveProject, LeaveType } from '~/utils/types/leaveTypes'
+import { LeaderDetails, ProjectDetails } from '~/utils/types/projectTypes'
+import { numberOfDaysInLeaves } from '~/utils/constants/dummyAddNewLeaveFields'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+}
+
+const animatedComponents = makeAnimated()
+
+const EditTab: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
+  const router = useRouter()
+  const { leaveId } = router.query
+  const [managers, setManagers] = useState<UserType[]>([])
+  const [leaders, setLeaders] = useState<LeaderDetails[]>([])
+  const { handleProjectQuery, getLeadersQuery } = useProject()
+  const { handleAllUsersQuery, handleUserQuery } = useUserQuery()
+  const { handleLeaveTypeQuery, getSpecificLeaveQuery, handleUpdateLeaveMutation } = useLeave()
+  const { data: user } = handleUserQuery()
+  const leaveMutation = handleUpdateLeaveMutation(
+    user?.userById.id as number,
+    parseInt(router.query.year as string)
+  )
+  const { data: projects } = handleProjectQuery()
+  const { data: leaveTypes } = handleLeaveTypeQuery()
+  const { data: leadersList } = getLeadersQuery(undefined)
+  const { data: userLeave } = getSpecificLeaveQuery(Number(leaveId))
+  const { data: users, isSuccess: isUsersSuccess } = handleAllUsersQuery()
+
+  // Initial Data useStates
+  const [initialProjectNameValue, setInitialProjectNameValue] = useState<ReactSelectOption[]>([])
+
+  const [initialProjectLeaderValue, setInitialProjectLeaderValue] = useState<ReactSelectOption[]>(
+    []
+  )
+  const [initialLeaveTypeValue, setInitialLeaveTypeValue] = useState<ReactSelectOption | null>(null)
+  const [initialLeaveDateValue, setInitialLeaveDateValue] = useState<
+    Array<{ date: string; number_of_days_in_leave: ReactSelectOption; is_with_pay: boolean }>
+  >([])
+  const [initialManagerValue, setInitialManagerValue] = useState<ReactSelectOption | null>(null)
+  const [initialReasonValue, setInitialReasonValue] = useState<ReactSelectOption | null>(null)
+
+  const emptyReactSelectOption = {
+    label: '',
+    value: ''
+  }
+  const paidLeaves = user?.userById.paidLeaves
+
+  const hasRemainingPaidLeaves = paidLeaves !== undefined ? paidLeaves <= 0 : false
+
+  const [isSaveDisable, setIsSaveDisable] = useState<boolean>(true)
+
+  const handleDataChange = (): void => {
+    setIsSaveDisable(false)
+  }
+
+  // modify custom style control
+  customStyles.control = (provided: Record<string, unknown>, state: any): any => ({
+    ...provided,
+    boxShadow: 'none',
+    borderColor: 'none',
+    '&:hover': {
+      color: '#75c55e'
+    }
+  })
+
+  const {
+    reset,
+    control,
+    setValue,
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting }
+  } = useForm<NewLeaveFormValues>({
+    mode: 'onTouched',
+    resolver: yupResolver(NewLeaveSchema)
+  })
+
+  // This will handle form submit and save
+  const handleSave = async (data: NewLeaveFormValues): Promise<void> => {
+    return await new Promise((resolve) => {
+      // Other Project Name
+      const others = data.projects.map(
+        (project) => project.project_name.__isNew__ === true && project.project_name.value
+      )
+
+      leaveMutation.mutate(
+        {
+          userId: user?.userById.id as number,
+          leaveTypeId: parseInt(data.leave_type.value),
+          leaveId: Number(leaveId),
+          managerId: parseInt(data.manager.value),
+          reason: data.reason,
+          otherProject: others.filter((value) => value !== false).toString(),
+          leaveDates: data.leave_date.map((date) => {
+            return {
+              leaveDate: date.date,
+              isWithPay: date.is_with_pay,
+              days: parseFloat(date.number_of_days_in_leave.value)
+            }
+          }),
+          leaveProjects: data.projects.map((project) => {
+            const otherProjectType = projects?.projects.find(
+              (project) => project.name.toLowerCase() === 'others'
+            ) as ProjectDetails
+
+            return {
+              projectId: (project.project_name.__isNew__ as boolean)
+                ? otherProjectType.id
+                : parseInt(project.project_name.value),
+              projectLeaderId: parseInt(project.project_leader.value)
+            }
+          })
+        },
+        {
+          onSuccess: ({ updateLeave }) => {
+            // Reset state variables before making a new query
+            closeModal()
+            toast.success(updateLeave)
+          }
+        }
+      )
+
+      resolve()
+    })
+  }
+
+  const { fields: leaveDateFields } = useFieldArray({
+    control,
+    name: 'leave_date'
+  })
+
+  const { fields: projectFields, update: updateProject } = useFieldArray({
+    control,
+    name: 'projects'
+  })
+
+  const handleInitialValues = (): void => {
+    handleAddNewProject(initialProjectNameValue, initialProjectLeaderValue)
+    setValue('leave_type', initialLeaveTypeValue ?? emptyReactSelectOption)
+    setValue('leave_date', initialLeaveDateValue ?? '')
+    setValue('manager', initialManagerValue ?? emptyReactSelectOption)
+    setValue('reason', initialReasonValue?.label as string)
+  }
+
+  // Add Project
+  const handleAddNewProject = (
+    projectData: ReactSelectOption[],
+    projectLeaderData: ReactSelectOption[]
+  ): void => {
+    const newProjectFields = projectData.map((projectName, index) => ({
+      project_name: projectName,
+      project_leader: projectLeaderData[index]
+    }))
+
+    newProjectFields.forEach((field, index) => {
+      updateProject(parseInt(index.toString()), field)
+    })
+  }
+
+  const handleReset = (): void => {
+    reset({
+      projects: [
+        {
+          project_name: emptyReactSelectOption,
+          project_leader: emptyReactSelectOption
+        }
+      ],
+      leave_type: emptyReactSelectOption,
+      leave_date: [
+        {
+          date: '',
+          number_of_days_in_leave: emptyReactSelectOption,
+          is_with_pay: false
+        }
+      ],
+      manager: emptyReactSelectOption,
+      reason: ''
+    })
+  }
+
+  useEffect(() => {
+    if (
+      initialProjectNameValue.length !== 0 &&
+      initialProjectLeaderValue.length !== 0 &&
+      initialLeaveTypeValue !== null &&
+      initialLeaveDateValue.length > 0 &&
+      initialManagerValue !== null &&
+      initialReasonValue !== null
+    ) {
+      handleInitialValues()
+    }
+  }, [
+    initialProjectNameValue,
+    initialProjectLeaderValue,
+    initialLeaveTypeValue,
+    initialLeaveDateValue,
+    initialManagerValue,
+    initialReasonValue
+  ])
+
+  useEffect(() => {
+    if (userLeave?.userLeave !== undefined && userLeave.userLeave.length > 0) {
+      const {
+        leaveProjects,
+        leaveType,
+        leaveTypeId,
+        leaveDate,
+        days,
+        isWithPay,
+        managerId,
+        manager,
+        reason
+      }: {
+        leaveProjects: LeaveProject[]
+        leaveType: string
+        leaveTypeId: number
+        leaveDate: string
+        days: number
+        isWithPay: boolean
+        managerId: number
+        manager: string
+        reason: string
+      } = userLeave.userLeave[0]
+
+      setInitialProjectNameValue(
+        leaveProjects?.map((leaveProject) => ({
+          value: String(leaveProject.projectId),
+          label: leaveProject.project.name
+        })) as ReactSelectOption[]
+      )
+
+      setInitialProjectLeaderValue(
+        leaveProjects?.map((leaveProject) => ({
+          value: String(leaveProject.projectLeaderId),
+          label: leaveProject.projectLeader.name
+        })) as ReactSelectOption[]
+      )
+
+      const leaveTypeValue: ReactSelectOption = {
+        label: String(leaveType),
+        value: String(leaveTypeId)
+      }
+      setInitialLeaveTypeValue(leaveTypeValue)
+
+      const leaveDateValue = [
+        {
+          date: moment(String(leaveDate)).format('YYYY-MM-DD'),
+          number_of_days_in_leave: generateNumberOfDaysSelect(numberOfDaysInLeaves).filter(
+            (x) => parseFloat(x.value).toFixed(4) === days.toFixed(4)
+          )[0],
+          is_with_pay: isWithPay
+        }
+      ]
+      setInitialLeaveDateValue(leaveDateValue)
+
+      const managerValue: ReactSelectOption = {
+        label: String(manager),
+        value: String(managerId)
+      }
+      setInitialManagerValue(managerValue)
+
+      const reasonValue: ReactSelectOption = {
+        label: reason,
+        value: String(reason)
+      }
+      setInitialReasonValue(reasonValue)
+    }
+  }, [userLeave?.userLeave[0], leaveId])
+
+  useEffect(() => {
+    if (leadersList !== undefined) setLeaders(leadersList.allLeaders)
+  }, [leadersList])
+
+  useEffect(() => {
+    if (isUsersSuccess) {
+      const tempManager = users.allUsers.filter((user) => user.role.name === Roles.MANAGER)
+      setManagers([...tempManager])
+    }
+  }, [isUsersSuccess])
+
+  useEffect(() => {
+    if (isOpen) {
+      handleInitialValues()
+    }
+  }, [isOpen])
+
+  return (
+    <Tab.Panel className="focus:outline-none">
+      <form
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        onSubmit={handleSubmit(handleSave)}
+      >
+        <main className="grid grid-cols-2 gap-x-4 gap-y-6 py-6 px-8 text-xs text-slate-800">
+          {/* Projects */}
+          {projectFields.map((field, index) => (
+            <div
+              key={field.id}
+              className={classNames(
+                'col-span-2 flex w-full flex-wrap items-end justify-between',
+                ' space-y-4 sm:space-x-2 md:space-y-0',
+                (errors?.projects?.[index]?.project_name !== null &&
+                  errors?.projects?.[index]?.project_name !== undefined) ||
+                  (errors?.projects?.[index]?.project_leader !== null &&
+                    errors?.projects?.[index]?.project_leader !== undefined)
+                  ? 'pb-4'
+                  : ''
+              )}
+            >
+              {/* Project */}
+              <section className="w-full sm:w-[43%]">
+                <TextField title={`Project`} Icon={Coffee} isRequired>
+                  <Controller
+                    name={`projects.${index}.project_name` as any}
+                    control={control}
+                    render={({ field }) => {
+                      const handleDataChange = (selectedOption: any): void => {
+                        field.onChange(selectedOption)
+                        setIsSaveDisable(false)
+                      }
+
+                      return (
+                        <CreatableSelect
+                          {...field}
+                          isClearable
+                          placeholder=""
+                          styles={customStyles}
+                          closeMenuOnSelect={true}
+                          classNames={{
+                            control: (state) =>
+                              state.isFocused
+                                ? 'border-primary'
+                                : errors.projects?.[index]?.project_name !== null &&
+                                  errors.projects?.[index]?.project_name !== undefined
+                                ? 'border-rose-500 ring-rose-500'
+                                : 'border-slate-300'
+                          }}
+                          isDisabled={isSubmitting}
+                          onChange={handleDataChange}
+                          backspaceRemovesValue={true}
+                          components={animatedComponents}
+                          options={generateProjectsMultiSelect(
+                            projects?.projects as ProjectDetails[]
+                          )}
+                          className="w-full"
+                        />
+                      )
+                    }}
+                  />
+                </TextField>
+                {errors.projects?.[index]?.project_name !== null &&
+                  errors.projects?.[index]?.project_name !== undefined && (
+                    <span className="error absolute text-[10px]">
+                      Project {index + 1} name is required
+                    </span>
+                  )}
+              </section>
+
+              {/* Project Leader */}
+              <section className="w-full flex-1">
+                <TextField title="Project Leader" Icon={Coffee} isRequired>
+                  <Controller
+                    name={`projects.${index}.project_leader` as any}
+                    control={control}
+                    render={({ field }) => {
+                      const handleDataChange = (selectedOption: any): void => {
+                        field.onChange(selectedOption)
+                        setIsSaveDisable(false)
+                      }
+
+                      return (
+                        <ReactSelect
+                          {...field}
+                          isClearable
+                          placeholder=""
+                          styles={customStyles}
+                          closeMenuOnSelect={true}
+                          isDisabled={isSubmitting}
+                          classNames={{
+                            control: (state) =>
+                              state.isFocused
+                                ? 'border-primary'
+                                : errors.projects?.[index]?.project_leader !== null &&
+                                  errors.projects?.[index]?.project_leader !== undefined
+                                ? 'border-rose-500 ring-rose-500'
+                                : 'border-slate-300'
+                          }}
+                          backspaceRemovesValue={true}
+                          options={generateUserSelect(leaders as UserType[])}
+                          components={animatedComponents}
+                          className="w-full"
+                          onChange={handleDataChange}
+                        />
+                      )
+                    }}
+                  />
+                </TextField>
+                {errors.projects?.[index]?.project_leader !== null &&
+                  errors.projects?.[index]?.project_leader !== undefined && (
+                    <span className="error absolute text-[10px]">
+                      Project leader {index + 1} is required
+                    </span>
+                  )}
+              </section>
+            </div>
+          ))}
+
+          {/* Leave Type */}
+          <section className="col-span-2">
+            <TextField title="Leave Type" Icon={User} isRequired className="py-2.5 text-xs">
+              <Controller
+                name="leave_type"
+                control={control}
+                rules={{ required: true }}
+                render={({ field }) => {
+                  const handleDataChange = (selectedOption: any): void => {
+                    field.onChange(selectedOption)
+                    setIsSaveDisable(false)
+                  }
+
+                  return (
+                    <ReactSelect
+                      {...field}
+                      isClearable
+                      placeholder=""
+                      className="w-full"
+                      styles={customStyles}
+                      classNames={{
+                        control: (state) =>
+                          state.isFocused
+                            ? 'border-primary'
+                            : errors.leave_type !== null && errors.leave_type !== undefined
+                            ? 'border-rose-500 ring-rose-500'
+                            : 'border-slate-300'
+                      }}
+                      value={field.value}
+                      onChange={handleDataChange}
+                      isDisabled={isSubmitting}
+                      options={generateLeaveTypeSelect(leaveTypes?.leaveTypes as LeaveType[])}
+                    />
+                  )
+                }}
+              />
+            </TextField>
+            {errors.leave_type !== null && errors.leave_type !== undefined && (
+              <span className="error text-[10px]">Type of leave is required</span>
+            )}
+          </section>
+
+          {/* Leave Dynamic Field */}
+          {leaveDateFields.map((date, index) => (
+            <div
+              key={date.id}
+              className={classNames(
+                'col-span-2 flex w-full flex-wrap items-end justify-between',
+                'space-y-4 sm:space-x-2 md:space-y-0',
+                (errors?.leave_date?.[index]?.date !== null &&
+                  errors?.leave_date?.[index]?.date !== undefined) ||
+                  (errors?.leave_date?.[index]?.number_of_days_in_leave !== null &&
+                    errors?.leave_date?.[index]?.number_of_days_in_leave !== undefined)
+                  ? 'pb-4'
+                  : ''
+              )}
+            >
+              {/* Date Calendar Field */}
+              <section className="w-full sm:w-[36%]">
+                <TextField
+                  title={`Leave Date`}
+                  Icon={Calendar}
+                  isRequired
+                  isError={errors?.leave_date?.[index]?.date}
+                  className="flex-1"
+                >
+                  <Input
+                    type="date"
+                    disabled={isSubmitting}
+                    {...register(`leave_date.${index}.date` as any)}
+                    placeholder="Leave Date"
+                    iserror={
+                      errors.leave_date?.[index]?.date !== null &&
+                      errors.leave_date?.[index]?.date !== undefined
+                    }
+                    className="py-2.5 pl-11 text-xs"
+                    onChange={handleDataChange}
+                  />
+                </TextField>
+                {errors.leave_date?.[index]?.date !== null &&
+                  errors.leave_date?.[index]?.date !== undefined && (
+                    <span className="error absolute text-[10px]">Leave Date is required field</span>
+                  )}
+              </section>
+              {/* Number of days in leave */}
+              <section className="w-full flex-1">
+                <TextField
+                  title="Number of Days in Leave"
+                  Icon={User}
+                  isRequired
+                  className="py-2.5 text-xs"
+                >
+                  <Controller
+                    name={`leave_date.${index}.number_of_days_in_leave`}
+                    control={control}
+                    rules={{ required: true }}
+                    render={({ field }) => {
+                      const handleDataChange = (selectedOption: any): void => {
+                        field.onChange(selectedOption)
+                        setIsSaveDisable(false)
+                      }
+
+                      return (
+                        <ReactSelect
+                          {...field}
+                          isClearable
+                          placeholder=""
+                          className="w-full"
+                          classNames={{
+                            control: (state) =>
+                              state.isFocused
+                                ? 'border-primary'
+                                : errors.leave_date?.[index]?.number_of_days_in_leave !== null &&
+                                  errors.leave_date?.[index]?.number_of_days_in_leave !== undefined
+                                ? 'border-rose-500 ring-rose-500'
+                                : 'border-slate-300'
+                          }}
+                          styles={customStyles}
+                          value={field.value}
+                          onChange={handleDataChange}
+                          isDisabled={isSubmitting}
+                          options={generateNumberOfDaysSelect(numberOfDaysInLeaves)}
+                        />
+                      )
+                    }}
+                  />
+                </TextField>
+                {errors.leave_date?.[index]?.number_of_days_in_leave !== null &&
+                  errors.leave_date?.[index]?.number_of_days_in_leave !== undefined && (
+                    <span className="error absolute text-[10px]">
+                      Number of days in leave is required
+                    </span>
+                  )}
+              </section>
+              <div className="ml-4 flex items-center space-x-2 sm:ml-0">
+                {/* With Pay boolean */}
+                <div className="shrink-0">
+                  <label className="flex h-10 items-center">
+                    <input
+                      disabled={hasRemainingPaidLeaves}
+                      type="checkbox"
+                      className={classNames(
+                        `h-4 w-4 rounded border-slate-300 bg-slate-100 ${
+                          hasRemainingPaidLeaves ? 'opacity-30' : ''
+                        }`,
+                        'text-primary focus:ring-primary'
+                      )}
+                      {...register(`leave_date.${index}.is_with_pay` as any)}
+                      onChange={handleDataChange}
+                    />
+                    <span
+                      className={`ml-2 select-none text-xs capitalize text-slate-500 ${
+                        hasRemainingPaidLeaves ? 'opacity-30' : ''
+                      }`}
+                    >
+                      With Pay
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {/* Manager */}
+          <section className="col-span-2">
+            <TextField title="Manager" Icon={User} isRequired className="py-2.5 text-xs">
+              <Controller
+                name="manager"
+                control={control}
+                rules={{ required: true }}
+                render={({ field }) => {
+                  const handleDataChange = (selectedOption: any): void => {
+                    field.onChange(selectedOption)
+                    setIsSaveDisable(false)
+                  }
+
+                  return (
+                    <ReactSelect
+                      {...field}
+                      isClearable
+                      placeholder=""
+                      className="w-full"
+                      styles={customStyles}
+                      classNames={{
+                        control: (state) =>
+                          state.isFocused
+                            ? 'border-primary'
+                            : errors.manager !== null && errors.manager !== undefined
+                            ? 'border-rose-500 ring-rose-500'
+                            : 'border-slate-300'
+                      }}
+                      value={field.value}
+                      onChange={handleDataChange}
+                      isDisabled={isSubmitting}
+                      options={generateUserSelect(managers)}
+                    />
+                  )
+                }}
+              />
+            </TextField>
+            {errors.manager !== null && errors.manager !== undefined && (
+              <span className="error text-[10px]">Manager is required</span>
+            )}
+          </section>
+
+          {/* Reason for leave Field */}
+          <section className="col-span-2">
+            <TextField title="Reason for leave" Icon={FileText} isRequired>
+              <ReactTextareaAutosize
+                id="reason"
+                {...register('reason')}
+                className={classNames(
+                  'text-area-auto-resize pl-12',
+                  errors?.reason !== null && errors.reason !== undefined
+                    ? 'border-rose-500 ring-rose-500'
+                    : ''
+                )}
+                disabled={isSubmitting}
+                onChange={handleDataChange}
+              />
+            </TextField>
+            {errors.reason !== null && errors.reason !== undefined && (
+              <span className="error text-[10px]">{errors.reason?.message}</span>
+            )}
+          </section>
+        </main>
+
+        {/* Custom Modal Footer Style */}
+        <ModalFooter>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleReset}
+            disabled={isSubmitting}
+            className="flex items-center space-x-2 px-4 py-1 text-sm"
+          >
+            <RefreshCcw className="h-4 w-4" />
+            <span>Reset</span>
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={closeModal}
+            disabled={isSubmitting}
+            className="flex items-center space-x-2 px-4 py-1 text-sm"
+          >
+            <X className="h-4 w-4" />
+            <span>Close</span>
+          </Button>
+          <Button
+            type="submit"
+            variant="success"
+            disabled={isSubmitting || isSaveDisable}
+            className="flex items-center space-x-2 px-5 py-1 text-sm"
+          >
+            {isSubmitting ? (
+              <>
+                <SpinnerIcon className="h-3 w-3 fill-amber-600" />
+                <span>Saving..</span>
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4" />
+                <span>Save</span>
+              </>
+            )}
+          </Button>
+        </ModalFooter>
+      </form>
+    </Tab.Panel>
+  )
+}
+
+EditTab.defaultProps = {}
+
+export default EditTab

--- a/client/src/components/molecules/EditLeaveModal/index.tsx
+++ b/client/src/components/molecules/EditLeaveModal/index.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react'
+import { Tab } from '@headlessui/react'
+
+import ModalTemplate from '~/components/templates/ModalTemplate'
+import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+import EditTab from './EditTab'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+}
+
+const EditLeaveModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
+  return (
+    <ModalTemplate
+      {...{
+        isOpen,
+        closeModal
+      }}
+      className="w-full max-w-[800px]"
+    >
+      {/* Custom Modal Header */}
+      <ModalHeader
+        {...{
+          title: 'Edit Leave',
+          closeModal
+        }}
+      />
+      <Tab.Group>
+        {/* Tab header */}
+        <Tab.Panels className="overflow-y-auto">
+          {/* Edit Tab Form */}
+          <EditTab
+            {...{
+              isOpen,
+              closeModal
+            }}
+          />
+        </Tab.Panels>
+      </Tab.Group>
+    </ModalTemplate>
+  )
+}
+
+EditLeaveModal.defaultProps = {
+  isOpen: false
+}
+
+export default EditLeaveModal

--- a/client/src/components/molecules/LeaveManagementResultTable/Table.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/Table.tsx
@@ -61,23 +61,30 @@ const LeaveManagementTable: FC<Props> = (props) => {
               <TableMesagge message="No Data Available" />
             ) : (
               <>
-                {table.getRowModel().rows.map((row) => (
-                  <Tr
-                    key={row.id}
-                    className={classNames(
-                      'group hover:bg-slate-50 hover:shadow-md hover:shadow-slate-200'
-                    )}
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <td
-                        key={cell.id}
-                        className="z-20 flex-wrap px-4 py-2 text-xs capitalize text-slate-500"
-                      >
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </td>
-                    ))}
-                  </Tr>
-                ))}
+                {table
+                  .getRowModel()
+                  .rows.sort((a, b) => {
+                    const dateA = new Date(a.original.createdAt)
+                    const dateB = new Date(b.original.createdAt)
+                    return dateB.getTime() - dateA.getTime()
+                  })
+                  .map((row) => (
+                    <Tr
+                      key={row.id}
+                      className={classNames(
+                        'group hover:bg-slate-50 hover:shadow-md hover:shadow-slate-200'
+                      )}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <td
+                          key={cell.id}
+                          className="z-20 flex-wrap px-4 py-2 text-xs capitalize text-slate-500"
+                        >
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </td>
+                      ))}
+                    </Tr>
+                  ))}
               </>
             )
           ) : (

--- a/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
@@ -1,13 +1,20 @@
-import React from 'react'
 import moment from 'moment'
+import { omit } from 'lodash'
+import classNames from 'classnames'
+import React, { useState } from 'react'
 import { useRouter } from 'next/router'
+import { Menu } from '@headlessui/react'
 import { createColumnHelper } from '@tanstack/react-table'
 
+import { Edit, MoreVertical, X } from 'react-feather'
 import { getLeaveType } from '~/utils/getLeaveType'
 import { LeaveTable } from '~/utils/types/leaveTypes'
 import { Pathname } from '~/utils/constants/pathnames'
 import CellHeader from '~/components/atoms/CellHeader'
 import WorkStatusChip from '~/components/atoms/WorkStatusChip'
+import MenuTransition from '~/components/templates/MenuTransition'
+import EditLeaveModal from '~/components/molecules/EditLeaveModal'
+import { LeaveStatus } from '~/utils/constants/leaveStatus'
 
 const columnHelper = createColumnHelper<LeaveTable>()
 
@@ -64,6 +71,89 @@ export const columns = [
   columnHelper.accessor('numLeaves', {
     header: () => <CellHeader label="No. of leaves" className="text-xs text-slate-500" />,
     cell: (props) => parseFloat(props.getValue().toFixed(3)) * 1,
+    footer: (info) => info.column.id
+  }),
+  columnHelper.display({
+    id: 'id',
+    header: () => <span className="text-xs font-normal text-slate-500">Actions</span>,
+    cell: (props) => {
+      const menuItemButton = 'flex px-3 py-2 text-left text-xs hover:text-slate-700 text-slate-500'
+      const [isOpen, setIsOpen] = useState<boolean>(false)
+      const leaveId = props.row.original.leaveId
+      const router = useRouter()
+      const isPending =
+        props.row.original.status.toLowerCase() === LeaveStatus.PENDING.toLowerCase()
+
+      // Close the Edit Modal
+      const handleToggle = (): void => {
+        setIsOpen(!isOpen)
+        removeQueryParam('leaveId')
+      }
+
+      // Open the Edit Modal
+      const handleEdit = (): void => {
+        setIsOpen(!isOpen)
+        addOrUpdateQueryParam('leaveId', `${leaveId}`)
+      }
+
+      // Function to remove query parameter
+      const removeQueryParam = (key: string): void => {
+        const { pathname, query } = router
+        const updatedQuery = omit(query, key)
+        void router.push({ pathname, query: updatedQuery })
+      }
+
+      // Function to update query parameter
+      const addOrUpdateQueryParam = (key: string, value: string): void => {
+        const { pathname, query } = router
+        query[key] = value
+        void router.push({ pathname, query })
+      }
+
+      return (
+        <div
+          className={classNames(
+            'inline-flex divide-x divide-slate-300 rounded border',
+            'border-transparent group-hover:border-slate-300'
+          )}
+        >
+          <EditLeaveModal
+            {...{
+              isOpen,
+              closeModal: handleToggle
+            }}
+          />
+          <Menu as="div" className="relative w-full">
+            {isPending && (
+              <Menu.Button className="p-0.5 text-slate-500 outline-none">
+                <MoreVertical className="h-4" />
+              </Menu.Button>
+            )}
+            <MenuTransition>
+              <Menu.Items
+                className={classNames(
+                  'absolute top-7 right-0 z-50 flex w-44 flex-col divide-y divide-slate-200 overflow-hidden rounded-md',
+                  'bg-white py-0.5 shadow-xl shadow-slate-200 ring-1 ring-black ring-opacity-5 focus:outline-none'
+                )}
+              >
+                <Menu.Item>
+                  <button className={menuItemButton} onClick={() => handleEdit()}>
+                    <Edit className="mr-0.5 h-3.5 w-3.5" />
+                    <span>Edit</span>
+                  </button>
+                </Menu.Item>
+                <Menu.Item>
+                  <button className={menuItemButton} onClick={() => alert('Cancel')}>
+                    <X className="mr-1 h-4 w-4" />
+                    <span>Cancel</span>
+                  </button>
+                </Menu.Item>
+              </Menu.Items>
+            </MenuTransition>
+          </Menu>
+        </div>
+      )
+    },
     footer: (info) => info.column.id
   })
 ]

--- a/client/src/components/molecules/LeaveManagementResultTable/index.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/index.tsx
@@ -52,7 +52,7 @@ const LeaveManagementResultTable: FC<Props> = (props): JSX.Element => {
   return (
     <div className="flex flex-1 flex-col space-y-1">
       {/* Show on Desktop */}
-      <Card className="hidden overflow-hidden md:block" shadow-size="sm">
+      <Card className="hidden overflow-visible md:block" shadow-size="sm">
         <LeaveManagementTable
           {...{
             query: {

--- a/client/src/graphql/mutations/leaveMutation.ts
+++ b/client/src/graphql/mutations/leaveMutation.ts
@@ -17,3 +17,9 @@ export const APROVE_DISAPPROVE_UNDERTIME_MUTATION = gql`
     approveDisapproveUndertime(approvingData: $approval)
   }
 `
+
+export const UPDATE_LEAVE_MUTATION = gql`
+  mutation ($updateLeave: UpdateLeaveRequestInput!) {
+    updateLeave(leave: $updateLeave)
+  }
+`

--- a/client/src/graphql/queries/leaveQuery.ts
+++ b/client/src/graphql/queries/leaveQuery.ts
@@ -77,6 +77,7 @@ export const GET_MY_LEAVES_QUERY = gql`
         }
       }
       table {
+        leaveId
         date
         leaveTypeId
         isWithPay
@@ -84,6 +85,7 @@ export const GET_MY_LEAVES_QUERY = gql`
         numLeaves
         status
         userName
+        createdAt
       }
       breakdown {
         sickLeave
@@ -173,6 +175,7 @@ export const GET_YEARLY_ALL_LEAVES_QUERY = gql`
         numLeaves
         status
         userName
+        createdAt
       }
       breakdown {
         sickLeave
@@ -184,6 +187,39 @@ export const GET_YEARLY_ALL_LEAVES_QUERY = gql`
         withoutPayTotal
         withPayTotal
       }
+    }
+  }
+`
+export const GET_SPECIFIC_USER_LEAVE_QUERY = gql`
+  query ($leaveId: Int!) {
+    userLeave(leaveId: $leaveId) {
+      id
+      userId
+      userName
+      userRole
+      leaveProjects {
+        projectId
+        project {
+          name
+        }
+        projectLeaderId
+        projectLeader {
+          name
+        }
+      }
+      leaveType
+      leaveTypeId
+      managerId
+      manager
+      otherProject
+      reason
+      leaveDate
+      isWithPay
+      isLeaderApproved
+      isManagerApproved
+      days
+      createdAt
+      avatar
     }
   }
 `

--- a/client/src/utils/types/leaveTypes.ts
+++ b/client/src/utils/types/leaveTypes.ts
@@ -49,6 +49,8 @@ export type LeaveTable = {
   numLeaves: number
   status: string
   userName: string
+  leaveId: number
+  createdAt: string
 }
 export type Breakdown = {
   sickLeave: number
@@ -89,6 +91,16 @@ export type LeaveRequest = {
   leaveDates: LeaveDateRequest[]
   leaveProjects: LeaveProjectsRequest[]
 }
+export type UpdateLeaveRequest = {
+  userId: number
+  leaveTypeId: number
+  leaveId: number
+  managerId: number
+  otherProject: string
+  reason: string
+  leaveDates: LeaveDateRequest[]
+  leaveProjects: LeaveProjectsRequest[]
+}
 export type LeaveDateRequest = {
   leaveDate: string
   isWithPay: boolean
@@ -111,4 +123,38 @@ export interface IApproveLeaveUndertimeRequestInput {
   userId: number
   notificationId: number
   isApproved: boolean
+}
+
+export type LeaveProject = {
+  projectId: number
+  project: {
+    name: string
+  }
+  projectLeaderId: number
+  projectLeader: {
+    name: string
+  }
+}
+
+export type IUserLeave = {
+  userLeave: Array<{
+    id: number
+    userId: number
+    userName: string
+    userRole: string
+    leaveProjects: LeaveProject[]
+    leaveType: string
+    leaveTypeId: number
+    managerId: number
+    manager: string
+    otherProject: string
+    reason: string
+    leaveDate: string
+    isWithPay: boolean
+    isLeaderApproved: boolean
+    isManagerApproved: boolean
+    days: number
+    createdAt: string
+    avatar: string
+  }>
 }


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-276

## Definition of Done

- [x] Users can update their leave request
- [x] Added a column for Actions functionality

## Notes
- A user must have an existing leave that is on pending status

## Pre-condition
- In the api directory, run ``` dotnet run ```
- In the client directory, run ``` npm run build ``` and then ``` npm start ```
- Go to ``` http://localhost:3000/my-leaves?year=2023 ```

## Expected Output
- My leaves table should reflect a new column for actions
- Upon clicking on Edit action, it should display the correct details of the leave request
- Upon clicking save, it should close the modal and show a toast
- All of the notifications for the recipients should reflect again asking for approval

## Screenshots/Recordings

### Single Project

https://github.com/framgia/sph-hris/assets/109492180/711260dc-856f-4615-9d8e-2dee212bf3b8

### Multiple projects

https://github.com/framgia/sph-hris/assets/109492180/8174e344-258d-48bf-8fca-17c4355c1401

### Same ProjectLeader and Manager

https://github.com/framgia/sph-hris/assets/109492180/ce14f768-edd6-4f25-912f-f11086154e4c

### Notification handling Manager

https://github.com/framgia/sph-hris/assets/109492180/edbd548e-d8ad-4dc3-a660-3ff5b498bdf9

### Notification handling Project leader

https://github.com/framgia/sph-hris/assets/109492180/2547ccb3-99be-4fd4-8df9-20a696ece757





