### PR TITLE
HRIS-282 [FE] Modify Schedule Management Page

### DIFF
--- a/client/src/components/atoms/Buttons/ClearButton.tsx
+++ b/client/src/components/atoms/Buttons/ClearButton.tsx
@@ -4,7 +4,7 @@ import Tippy from '@tippyjs/react'
 import { UseFormSetValue } from 'react-hook-form'
 
 import Button from './Button'
-import { RequestNewScheduleFormData } from '~/utils/types/formValues'
+import { RequestNewScheduleFormData, ScheduleFormData } from '~/utils/types/formValues'
 
 type Week =
   | 'mondayClear'
@@ -15,9 +15,11 @@ type Week =
   | 'saturdayClear'
   | 'sundayClear'
 
+type NewSetValueType = UseFormSetValue<RequestNewScheduleFormData | ScheduleFormData>
+
 type Props = {
   day: Week
-  setValue: UseFormSetValue<RequestNewScheduleFormData>
+  setValue: NewSetValueType
 }
 
 const ClearButton: FC<Props> = ({ day, setValue }): JSX.Element => {
@@ -59,7 +61,11 @@ const ClearButton: FC<Props> = ({ day, setValue }): JSX.Element => {
   return (
     <div>
       <Tippy placement="right" content="Clear" className="!text-xs">
-        <Button type="button" onClick={() => handleClear(day)} className="mt-3.5">
+        <Button
+          type="button"
+          onClick={() => handleClear(day)}
+          className="mt-3.5 text-slate-500 hover:text-slate-700"
+        >
           <X className="h-4 w-4" />
         </Button>
       </Tippy>

--- a/client/src/components/organisms/ViewDetailsDrawer/UploadFiles.tsx
+++ b/client/src/components/organisms/ViewDetailsDrawer/UploadFiles.tsx
@@ -1,0 +1,75 @@
+import React, { FC } from 'react'
+import toast from 'react-hot-toast'
+import classNames from 'classnames'
+import { Download } from 'react-feather'
+import { DefaultExtensionType, FileIcon, defaultStyles } from 'react-file-icon'
+
+import { IMedia } from '~/utils/types/timeEntryTypes'
+
+type Props = {
+  file: IMedia
+  index: number
+}
+
+const UploadedFiles: FC<Props> = ({ file, index }): JSX.Element => {
+  const fileExtension = file.fileName.split('.').pop()
+  const styles = defaultStyles[fileExtension as DefaultExtensionType]
+
+  const LinkChecker = (link: string): void => {
+    void fetch(link).then(async (resp) => {
+      if (resp.ok) {
+        return window.open(link)
+      } else {
+        toast.error('Sorry, cannot open file')
+      }
+    })
+  }
+
+  const handleDownloadFile = (link: string, fileName: string): void => {
+    void fetch(link)
+      .then(async (resp) => {
+        if (!resp.ok) {
+          throw Error(resp.statusText)
+        }
+        return await resp.blob()
+      })
+      .then((blobobject) => {
+        const blob = window.URL.createObjectURL(blobobject)
+        const anchor = document.createElement('a')
+        anchor.style.display = 'none'
+        anchor.href = blob
+        anchor.download = fileName
+        document.body.appendChild(anchor)
+        anchor.click()
+        window.URL.revokeObjectURL(blob)
+      })
+      .catch(() => toast.error('File does not exist'))
+  }
+
+  return (
+    <div
+      key={index}
+      className={classNames(
+        'group flex w-full justify-between rounded px-2 py-2 text-xs font-medium',
+        'text-slate-700 transition duration-150 ease-in-out focus:outline-none',
+        'focus:ring-0 hover:bg-slate-700 hover:bg-opacity-5'
+      )}
+    >
+      <div className="mr-1">
+        <div className="h-4 w-4">
+          <FileIcon extension={fileExtension} {...styles} />
+        </div>
+      </div>
+      <div className="flex w-full truncate" onClick={() => LinkChecker(file.link)}>
+        <div>{file.fileName}</div>
+      </div>
+      <button
+        className="rounded bg-white p-0.5 opacity-0 focus:outline-slate-400 group-hover:opacity-100"
+        onClick={() => handleDownloadFile(file.link, file.fileName)}
+      >
+        <Download className="h-4 w-4 text-slate-500" />
+      </button>
+    </div>
+  )
+}
+export default UploadedFiles

--- a/client/src/components/organisms/ViewDetailsDrawer/index.tsx
+++ b/client/src/components/organisms/ViewDetailsDrawer/index.tsx
@@ -10,7 +10,6 @@ import UploadedFiles from './UploadFiles'
 import Avatar from '~/components/atoms/Avatar'
 import { IMedia } from '~/utils/types/timeEntryTypes'
 import handleImageError from '~/utils/handleImageError'
-import ReactTextareaAutosize from 'react-textarea-autosize'
 import DrawerTemplate from '~/components/templates/DrawerTemplate'
 import {
   getUserProfileLink,
@@ -41,6 +40,59 @@ const ViewDetailsDrawer: FC<Props> = (props): JSX.Element => {
 
   const handleToggleDrawer = (): void => {
     void router.replace(router.pathname, undefined, { shallow: false })
+  }
+
+  const renderTextWithLinks = (text: string): React.ReactNode[] => {
+    const words = text.split(' ')
+
+    return words.map((word, index) => {
+      let linkComponent = null
+
+      switch (true) {
+        case isValidUrl(word):
+          linkComponent = (
+            <a
+              key={index}
+              href={word}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 underline hover:text-blue-700"
+            >
+              {word}
+            </a>
+          )
+          break
+        case isValidEmail(word):
+          linkComponent = (
+            <a
+              key={index}
+              href={`mailto:${word}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 underline hover:text-blue-700"
+            >
+              {word}
+            </a>
+          )
+          break
+        default:
+          linkComponent = <span key={index}>{word} </span>
+          break
+      }
+
+      return linkComponent
+    })
+  }
+
+  const isValidUrl = (url: string): boolean => {
+    const urlRegex =
+      /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/
+    return urlRegex.test(url)
+  }
+
+  const isValidEmail = (email: string): boolean => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    return emailRegex.test(email)
   }
 
   return (
@@ -139,21 +191,16 @@ const ViewDetailsDrawer: FC<Props> = (props): JSX.Element => {
               </div>
             </label>
           </div>
+
           {/* Remarks */}
           <div>
             <label htmlFor="remarks" className="space-y-0.5">
               <span className="text-xs text-slate-500">Remarks</span>
-              <ReactTextareaAutosize
-                id="remarks"
-                disabled={true}
-                placeholder="Your Remarks"
-                className={classNames(
-                  'm-0 block min-h-[20vh] w-full rounded border border-slate-300 text-[13px]',
-                  'disable:border-slate-300 bg-white bg-clip-padding',
-                  'resize-none px-3 py-1.5 text-sm font-normal text-amber-700'
-                )}
-                value={res.data?.timeById?.remarks}
-              />
+              <div className="default-scrollbar min-h-[20vh] rounded border border-slate-300 bg-white text-[13px]">
+                <h3 className="break-words px-3 py-1.5 font-normal text-amber-700">
+                  {renderTextWithLinks(res.data?.timeById?.remarks ?? '')}
+                </h3>
+              </div>
             </label>
           </div>
           {/* Downloaded Files */}

--- a/client/src/components/organisms/ViewDetailsDrawer/index.tsx
+++ b/client/src/components/organisms/ViewDetailsDrawer/index.tsx
@@ -1,91 +1,28 @@
 import moment from 'moment'
 import React, { FC } from 'react'
-import toast from 'react-hot-toast'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
 import { parse } from 'iso8601-duration'
-import { Calendar, Clock, Download, X } from 'react-feather'
-import { DefaultExtensionType, FileIcon, defaultStyles } from 'react-file-icon'
+import { Calendar, Clock, X } from 'react-feather'
 
 import Text from '~/components/atoms/Text'
+import UploadedFiles from './UploadFiles'
 import Avatar from '~/components/atoms/Avatar'
-import {
-  getSpecificTimeEntry,
-  getSpecificTimeEntryById,
-  getUserProfileLink
-} from '~/hooks/useTimesheetQuery'
 import { IMedia } from '~/utils/types/timeEntryTypes'
 import handleImageError from '~/utils/handleImageError'
+import ReactTextareaAutosize from 'react-textarea-autosize'
 import DrawerTemplate from '~/components/templates/DrawerTemplate'
+import {
+  getUserProfileLink,
+  getSpecificTimeEntry,
+  getSpecificTimeEntryById
+} from '~/hooks/useTimesheetQuery'
 
 type Props = {
   isOpenViewDetailsDrawer: boolean
   actions: {
     handleToggleViewDetailsDrawer: () => void
   }
-}
-
-type UploadFileProps = {
-  file: IMedia
-  index: number
-}
-
-const UploadedFiles = ({ file, index }: UploadFileProps): JSX.Element => {
-  const fileExtension = file.fileName.split('.').pop()
-  const styles = defaultStyles[fileExtension as DefaultExtensionType]
-
-  const LinkChecker = (link: string): void => {
-    void fetch(link).then(async (resp) => {
-      if (resp.ok) {
-        return window.open(link)
-      } else {
-        toast.error('Sorry, cannot open file')
-      }
-    })
-  }
-
-  const handleDownloadFile = (link: string, fileName: string): void => {
-    void fetch(link)
-      .then(async (resp) => {
-        if (!resp.ok) {
-          throw Error(resp.statusText)
-        }
-        return await resp.blob()
-      })
-      .then((blobobject) => {
-        const blob = window.URL.createObjectURL(blobobject)
-        const anchor = document.createElement('a')
-        anchor.style.display = 'none'
-        anchor.href = blob
-        anchor.download = fileName
-        document.body.appendChild(anchor)
-        anchor.click()
-        window.URL.revokeObjectURL(blob)
-      })
-      .catch(() => toast.error('File does not exist'))
-  }
-
-  return (
-    <div
-      key={index}
-      className="group flex w-full justify-between rounded px-2 py-2 text-xs font-medium text-slate-700 transition duration-150 ease-in-out focus:outline-none focus:ring-0 hover:bg-slate-700 hover:bg-opacity-5"
-    >
-      <div className="mr-1">
-        <div className="h-4 w-4">
-          <FileIcon extension={fileExtension} {...styles} />
-        </div>
-      </div>
-      <div className="flex w-full truncate" onClick={() => LinkChecker(file.link)}>
-        <div>{file.fileName}</div>
-      </div>
-      <button
-        className="rounded bg-white p-0.5 opacity-0 focus:outline-slate-400 group-hover:opacity-100"
-        onClick={() => handleDownloadFile(file.link, file.fileName)}
-      >
-        <Download className="h-4 w-4 text-slate-500" />
-      </button>
-    </div>
-  )
 }
 
 const ViewDetailsDrawer: FC<Props> = (props): JSX.Element => {
@@ -163,8 +100,8 @@ const ViewDetailsDrawer: FC<Props> = (props): JSX.Element => {
                 id="remarks"
                 className={classNames(
                   'm-0 block w-full items-center rounded placeholder:text-slate-400',
-                  'border border-solid border-slate-300 bg-slate-100 bg-clip-padding',
-                  'resize-none text-sm font-normal text-slate-700 transition'
+                  'border border-solid border-slate-300 bg-clip-padding',
+                  'resize-none text-sm font-normal text-amber-700 transition'
                 )}
               >
                 <div className="flex items-center">
@@ -188,8 +125,8 @@ const ViewDetailsDrawer: FC<Props> = (props): JSX.Element => {
                 id="remarks"
                 className={classNames(
                   'm-0 block w-full items-center rounded placeholder:text-slate-400',
-                  'border border-solid border-slate-300 bg-slate-100 bg-clip-padding',
-                  'resize-none text-sm font-normal text-slate-700 transition'
+                  'border border-solid border-slate-300 bg-clip-padding',
+                  'resize-none text-sm font-normal text-amber-700 transition'
                 )}
               >
                 <div className="flex items-center">
@@ -206,36 +143,43 @@ const ViewDetailsDrawer: FC<Props> = (props): JSX.Element => {
           <div>
             <label htmlFor="remarks" className="space-y-0.5">
               <span className="text-xs text-slate-500">Remarks</span>
-              <div
+              <ReactTextareaAutosize
                 id="remarks"
+                disabled={true}
+                placeholder="Your Remarks"
                 className={classNames(
-                  'm-0 block min-h-[20vh] w-full rounded placeholder:text-slate-400',
-                  'border border-solid border-slate-300 bg-white bg-clip-padding',
-                  'resize-none px-3 py-1.5 text-sm font-normal text-slate-700 transition'
+                  'm-0 block min-h-[20vh] w-full rounded border border-slate-300 text-[13px]',
+                  'disable:border-slate-300 bg-white bg-clip-padding',
+                  'resize-none px-3 py-1.5 text-sm font-normal text-amber-700'
                 )}
-              >
-                <p>{res.data?.timeById?.remarks}</p>
-              </div>
+                value={res.data?.timeById?.remarks}
+              />
             </label>
           </div>
           {/* Downloaded Files */}
           {!(router.query.time_out !== undefined) && (
-            <div>
-              <label htmlFor="remarks" className="space-y-0.5">
-                <span className="text-xs text-slate-500">Proofs Provided</span>
-                <div
-                  className={classNames(
-                    'm-0 block h-[200px] w-full rounded placeholder:text-slate-400',
-                    'border border-solid border-slate-300 bg-white bg-clip-padding',
-                    'default-scrollbar '
-                  )}
-                >
-                  {res.data?.timeById?.media?.map((file: IMedia, index: number) => {
-                    return <UploadedFiles file={file} index={index} key={index} />
-                  })}
+            <>
+              {res.data?.timeById?.media.length !== 0 ? (
+                <div>
+                  <label htmlFor="remarks" className="space-y-0.5">
+                    <span className="text-xs text-slate-500">Proofs Provided</span>
+                    <div
+                      className={classNames(
+                        'm-0 block h-[200px] w-full rounded placeholder:text-slate-400',
+                        'border border-solid border-slate-300 bg-white bg-clip-padding',
+                        'default-scrollbar '
+                      )}
+                    >
+                      {res.data?.timeById?.media?.map((file: IMedia, index: number) => {
+                        return <UploadedFiles file={file} index={index} key={index} />
+                      })}
+                    </div>
+                  </label>
                 </div>
-              </label>
-            </div>
+              ) : (
+                <div className="pt-4 text-xs italic text-slate-500">No Proofs Provided</div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/client/src/components/templates/ScheduleManagementLayout/ScheduleList/ScheduleItem.tsx
+++ b/client/src/components/templates/ScheduleManagementLayout/ScheduleList/ScheduleItem.tsx
@@ -39,16 +39,18 @@ const ScheduleItem: FC<Props> = (props): JSX.Element => {
     confirmAlert({
       customUI: ({ onClose }) => {
         return (
-          <Card className="w-full max-w-xs px-8 py-6" shadow-size="xl" rounded="lg">
-            <h1 className="text-center text-xl font-bold">Confirmation</h1>
-            <p className="mt-2 text-sm font-medium">
-              Are you sure you want to delete{' '}
-              <b className="text-amber-500 underline">{item.scheduleName}</b> schedule?
+          <Card className="w-full max-w-[350px] px-8 py-6 shadow-none" rounded="lg">
+            <h1 className="text-center text-xl font-bold text-rose-500">Confirmation</h1>
+            <p className="mt-4 text-sm font-normal text-slate-600">
+              Are you sure you want to delete <b className="font-semibold">{item.scheduleName}?</b>
             </p>
             <div className="mt-6 flex items-center justify-center space-x-2 text-white">
               <ButtonAction
+                onClick={() => {
+                  handleDeleteSchedule(onClose, item.id)
+                  return onClose()
+                }}
                 variant="danger"
-                onClick={() => handleDeleteSchedule(onClose, item.id)}
                 className="w-full py-1 px-4"
               >
                 Yes

--- a/client/src/utils/types/employeeScheduleTypes.ts
+++ b/client/src/utils/types/employeeScheduleTypes.ts
@@ -10,6 +10,8 @@ export interface IGetEmployeeSchedule {
     workingDay: string
     timeIn: string
     timeOut: string
+    breakFrom: string
+    breakTo: string
   }>
   scheduleName: string
   memberCount: number

--- a/client/src/utils/types/formValues.ts
+++ b/client/src/utils/types/formValues.ts
@@ -124,13 +124,13 @@ export type ScheduleFormData = {
   fridaySelected: boolean
   saturdaySelected: boolean
   sundaySelected: boolean
-  monday: TimeEntry
-  tuesday: TimeEntry
-  wednesday: TimeEntry
-  thursday: TimeEntry
-  friday: TimeEntry
-  saturday: TimeEntry
-  sunday: TimeEntry
+  monday: TimeEntryWithBreak
+  tuesday: TimeEntryWithBreak
+  wednesday: TimeEntryWithBreak
+  thursday: TimeEntryWithBreak
+  friday: TimeEntryWithBreak
+  saturday: TimeEntryWithBreak
+  sunday: TimeEntryWithBreak
 }
 
 export type ATMApplicationFormValues = {

--- a/client/src/utils/validation/index.ts
+++ b/client/src/utils/validation/index.ts
@@ -186,77 +186,105 @@ export const ScheduleSchema = yup.object().shape({
     is: true,
     then: yup.object().shape({
       timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required')
+      timeOut: yup.string().required('Time Out is required'),
+      breakFrom: yup.string().required('Break From is required'),
+      breakTo: yup.string().required('Break To is required')
     }),
     otherwise: yup.object().shape({
       timeIn: yup.string(),
-      timeOut: yup.string()
+      timeOut: yup.string(),
+      breakFrom: yup.string(),
+      breakTo: yup.string()
     })
   }),
   tuesday: yup.object().when('tuesdaySelected', {
     is: true,
     then: yup.object().shape({
       timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required')
+      timeOut: yup.string().required('Time Out is required'),
+      breakFrom: yup.string().required('Break From is required'),
+      breakTo: yup.string().required('Break To is required')
     }),
     otherwise: yup.object().shape({
       timeIn: yup.string(),
-      timeOut: yup.string()
+      timeOut: yup.string(),
+      breakFrom: yup.string(),
+      breakTo: yup.string()
     })
   }),
   wednesday: yup.object().when('wednesdaySelected', {
     is: true,
     then: yup.object().shape({
       timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required')
+      timeOut: yup.string().required('Time Out is required'),
+      breakFrom: yup.string().required('Break From is required'),
+      breakTo: yup.string().required('Break To is required')
     }),
     otherwise: yup.object().shape({
       timeIn: yup.string(),
-      timeOut: yup.string()
+      timeOut: yup.string(),
+      breakFrom: yup.string(),
+      breakTo: yup.string()
     })
   }),
   thursday: yup.object().when('thursdaySelected', {
     is: true,
     then: yup.object().shape({
       timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required')
+      timeOut: yup.string().required('Time Out is required'),
+      breakFrom: yup.string().required('Break From is required'),
+      breakTo: yup.string().required('Break To is required')
     }),
     otherwise: yup.object().shape({
       timeIn: yup.string(),
-      timeOut: yup.string()
+      timeOut: yup.string(),
+      breakFrom: yup.string(),
+      breakTo: yup.string()
     })
   }),
   friday: yup.object().when('fridaySelected', {
     is: true,
     then: yup.object().shape({
       timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required')
+      timeOut: yup.string().required('Time Out is required'),
+      breakFrom: yup.string().required('Break From is required'),
+      breakTo: yup.string().required('Break To is required')
     }),
     otherwise: yup.object().shape({
       timeIn: yup.string(),
-      timeOut: yup.string()
+      timeOut: yup.string(),
+      breakFrom: yup.string(),
+      breakTo: yup.string()
     })
   }),
   saturday: yup.object().when('saturdaySelected', {
     is: true,
     then: yup.object().shape({
       timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required')
+      timeOut: yup.string().required('Time Out is required'),
+      breakFrom: yup.string().required('Break From is required'),
+      breakTo: yup.string().required('Break To is required')
     }),
     otherwise: yup.object().shape({
       timeIn: yup.string(),
-      timeOut: yup.string()
+      timeOut: yup.string(),
+      breakFrom: yup.string(),
+      breakTo: yup.string()
     })
   }),
   sunday: yup.object().when('sundaySelected', {
     is: true,
     then: yup.object().shape({
       timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required')
+      timeOut: yup.string().required('Time Out is required'),
+      breakFrom: yup.string().required('Break From is required'),
+      breakTo: yup.string().required('Break To is required')
     }),
     otherwise: yup.object().shape({
       timeIn: yup.string(),
-      timeOut: yup.string()
+      timeOut: yup.string(),
+      breakFrom: yup.string(),
+      breakTo: yup.string()
     })
   })
 })
@@ -369,113 +397,7 @@ export const ReassignScheduleSchema = yup.object().shape({
   schedule: SelectSchema.label('Schedule')
 })
 
-export const RequestNewScheduleSchema = yup.object().shape({
-  monday: yup.object().when('mondaySelected', {
-    is: true,
-    then: yup.object().shape({
-      timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required'),
-      breakFrom: yup.string().required('Break From is required'),
-      breakTo: yup.string().required('Break To is required')
-    }),
-    otherwise: yup.object().shape({
-      timeIn: yup.string(),
-      timeOut: yup.string(),
-      breakFrom: yup.string(),
-      breakTo: yup.string()
-    })
-  }),
-  tuesday: yup.object().when('tuesdaySelected', {
-    is: true,
-    then: yup.object().shape({
-      timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required'),
-      breakFrom: yup.string().required('Break From is required'),
-      breakTo: yup.string().required('Break To is required')
-    }),
-    otherwise: yup.object().shape({
-      timeIn: yup.string(),
-      timeOut: yup.string(),
-      breakFrom: yup.string(),
-      breakTo: yup.string()
-    })
-  }),
-  wednesday: yup.object().when('wednesdaySelected', {
-    is: true,
-    then: yup.object().shape({
-      timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required'),
-      breakFrom: yup.string().required('Break From is required'),
-      breakTo: yup.string().required('Break To is required')
-    }),
-    otherwise: yup.object().shape({
-      timeIn: yup.string(),
-      timeOut: yup.string(),
-      breakFrom: yup.string(),
-      breakTo: yup.string()
-    })
-  }),
-  thursday: yup.object().when('thursdaySelected', {
-    is: true,
-    then: yup.object().shape({
-      timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required'),
-      breakFrom: yup.string().required('Break From is required'),
-      breakTo: yup.string().required('Break To is required')
-    }),
-    otherwise: yup.object().shape({
-      timeIn: yup.string(),
-      timeOut: yup.string(),
-      breakFrom: yup.string(),
-      breakTo: yup.string()
-    })
-  }),
-  friday: yup.object().when('fridaySelected', {
-    is: true,
-    then: yup.object().shape({
-      timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required'),
-      breakFrom: yup.string().required('Break From is required'),
-      breakTo: yup.string().required('Break To is required')
-    }),
-    otherwise: yup.object().shape({
-      timeIn: yup.string(),
-      timeOut: yup.string(),
-      breakFrom: yup.string(),
-      breakTo: yup.string()
-    })
-  }),
-  saturday: yup.object().when('saturdaySelected', {
-    is: true,
-    then: yup.object().shape({
-      timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required'),
-      breakFrom: yup.string().required('Break From is required'),
-      breakTo: yup.string().required('Break To is required')
-    }),
-    otherwise: yup.object().shape({
-      timeIn: yup.string(),
-      timeOut: yup.string(),
-      breakFrom: yup.string(),
-      breakTo: yup.string()
-    })
-  }),
-  sunday: yup.object().when('sundaySelected', {
-    is: true,
-    then: yup.object().shape({
-      timeIn: yup.string().required('Time In is required'),
-      timeOut: yup.string().required('Time Out is required'),
-      breakFrom: yup.string().required('Break From is required'),
-      breakTo: yup.string().required('Break To is required')
-    }),
-    otherwise: yup.object().shape({
-      timeIn: yup.string(),
-      timeOut: yup.string(),
-      breakFrom: yup.string(),
-      breakTo: yup.string()
-    })
-  })
-})
+export const RequestNewScheduleSchema = ScheduleSchema.omit(['scheduleName'])
 
 export const ApplyToAllSchema = yup.object().shape({
   timeIn: yup.string().required('Time In is required'),


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-282

## Definition of Done

- [x] Reused `ApplyToAllModal` with validation hooks
- [x] Fixed `ViewDetailsDrawer` overlap fields
- [x] Modified Schedule Management Fields in reference to Request New Schedule Tab page
- [x] Fixed `Time In Drawer` to render the remarks with link and can be clickable 

## Notes

- Only UI changed the previous integration is almost the same 

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet run watch`
- Go to the Schedule Management Page

## Expected Output

- HR Role will now have an updated UI with validation to Apply To All Fields Functionality
- Previous functionality is still integrated 
- It also have Schedule Shift Dropdown functionality for predefined `Morning Shift` and `Afternoon Shift`

## Screenshots/Recordings

[schedule-management 2.webm](https://github.com/framgia/sph-hris/assets/108642414/54f8a1b0-fb46-43b0-a641-2b1aba9011d7)

