### PR TITLE
HRIS-283 [FE] Fix File Offset Functionality

### DIFF
--- a/api/DTOs/TimeEntryDTO.cs
+++ b/api/DTOs/TimeEntryDTO.cs
@@ -105,7 +105,7 @@ namespace api.DTOs
                 }
             }
 
-            if (leave != null)
+            if (leave != null && leave.IsLeaderApproved == true && leave.IsManagerApproved == true)
             {
                 Status = (leave.LeaveType.Name!).ToLower();
             }

--- a/client/src/components/molecules/MyDailyTimeRecordTable/AddNewOffsetModal.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/AddNewOffsetModal.tsx
@@ -46,9 +46,8 @@ const AddNewOffsetModal: FC<Props> = ({ isOpen, closeModal, row }): JSX.Element 
   const { data: eslUsers, isSuccess: isESLUsersSuccess } = getESLUserQuery()
 
   // UNUSED ESL OFFSETS HOOKS
-  const { getAllUnusedESLOffsetQuery } = useUnusedESLOffset()
-  const { data: unusedESLOffsetData, isLoading: isLoadingUnusedESLOffset } =
-    getAllUnusedESLOffsetQuery(row.id, true)
+  const { getAllESLOffsetQuery } = useUnusedESLOffset()
+  const { data: unusedESLOffsetData, isLoading: isLoadingUnusedESLOffset } = getAllESLOffsetQuery()
 
   const {
     reset,
@@ -256,7 +255,7 @@ const AddNewOffsetModal: FC<Props> = ({ isOpen, closeModal, row }): JSX.Element 
                     backspaceRemovesValue={true}
                     isLoading={isLoadingUnusedESLOffset}
                     options={generateUnusedESLDateSelect(
-                      unusedESLOffsetData?.eslOffsetsByTimeEntry as IUnusedESLOffset[]
+                      unusedESLOffsetData?.allESLOffsets as IUnusedESLOffset[]
                     )}
                   />
                 )}

--- a/client/src/graphql/queries/unusedESLOffsets.ts
+++ b/client/src/graphql/queries/unusedESLOffsets.ts
@@ -12,3 +12,16 @@ export const GET_ALL_UNUSED_ESL_OFFSETS_BY_TIME_ENTRY = gql`
     }
   }
 `
+
+export const GET_ALL_UNUSED_ESL_OFFSETS = gql`
+  query () {
+    allESLOffsets(isUsed: false) {
+      id
+      title
+      timeIn
+      timeOut
+      createdAt
+      isUsed
+    }
+  }
+`

--- a/client/src/hooks/useUnusedESLOffset.ts
+++ b/client/src/hooks/useUnusedESLOffset.ts
@@ -2,22 +2,27 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query'
 
 import { client } from '~/utils/shared/client'
 import { IUnusedESLOffset } from '~/utils/interfaces/unusedELSOffsetInterface'
-import { GET_ALL_UNUSED_ESL_OFFSETS_BY_TIME_ENTRY } from '~/graphql/queries/unusedESLOffsets'
+import {
+  GET_ALL_UNUSED_ESL_OFFSETS_BY_TIME_ENTRY,
+  GET_ALL_UNUSED_ESL_OFFSETS
+} from '~/graphql/queries/unusedESLOffsets'
 
 type UnusedOffsetFuncReturnType = UseQueryResult<
   { eslOffsetsByTimeEntry: IUnusedESLOffset[] },
   unknown
 >
+type AllOffsetFuncReturnType = UseQueryResult<{ allESLOffsets: IUnusedESLOffset[] }, unknown>
 
 type HookReturnType = {
-  getAllUnusedESLOffsetQuery: (
+  getAllUnusedESLOffsetQueryByTimeEntry: (
     timeEntryId: number,
     onlyUnused: boolean
   ) => UnusedOffsetFuncReturnType
+  getAllESLOffsetQuery: () => AllOffsetFuncReturnType
 }
 
 const useUnusedESLOffset = (): HookReturnType => {
-  const getAllUnusedESLOffsetQuery = (
+  const getAllUnusedESLOffsetQueryByTimeEntry = (
     timeEntryId: number,
     onlyUnused: boolean
   ): UnusedOffsetFuncReturnType =>
@@ -28,8 +33,16 @@ const useUnusedESLOffset = (): HookReturnType => {
       select: (data: { eslOffsetsByTimeEntry: IUnusedESLOffset[] }) => data
     })
 
+  const getAllESLOffsetQuery = (): AllOffsetFuncReturnType =>
+    useQuery({
+      queryKey: ['GET_ALL_UNUSED_ESL_OFFSETS'],
+      queryFn: async () => await client.request(GET_ALL_UNUSED_ESL_OFFSETS),
+      select: (data: { allESLOffsets: IUnusedESLOffset[] }) => data
+    })
+
   return {
-    getAllUnusedESLOffsetQuery
+    getAllUnusedESLOffsetQueryByTimeEntry,
+    getAllESLOffsetQuery
   }
 }
 


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-283

## Definition of Done
- [x] Used different query when fetching all unused approved ESLOffsets
- [x] Also fixed DTR status when there is unapproved leave

## Pre-condition
- (docker) run `docker compose up api db client --build -d`

## Expected Output
- As ESL user, when filing Change Shift, all unused and approved ESLoffsets should be displayed as option in the dropdown
- In any DTR page, only approved leave will be displayed as status

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/111718037/dd0f4b45-4761-4378-98b3-016a2982eec2

