### PR TITLE
HRIS-285 [FE] Fix 'undefined' value on to the tooltip when hovering on the heatmap data

### DIFF
--- a/client/src/graphql/queries/leaveQuery.ts
+++ b/client/src/graphql/queries/leaveQuery.ts
@@ -106,50 +106,62 @@ export const GET_YEARLY_ALL_LEAVES_QUERY = gql`
         january {
           value
           day
+          leaveName
         }
         february {
           value
           day
+          leaveName
         }
         march {
           value
           day
+          leaveName
         }
         april {
           value
           day
+          leaveName
         }
         may {
           value
           day
+          leaveName
         }
         june {
           value
           day
+          leaveName
         }
         july {
           value
           day
+          leaveName
         }
         august {
           value
           day
+          leaveName
         }
         september {
           value
           day
+          leaveName
         }
         october {
           value
           day
+          leaveName
         }
         november {
           value
           day
+          leaveName
         }
         december {
           value
           day
+          leaveName
         }
       }
       table {
@@ -158,6 +170,7 @@ export const GET_YEARLY_ALL_LEAVES_QUERY = gql`
         isWithPay
         reason
         numLeaves
+        status
       }
       breakdown {
         sickLeave


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-285

## Definition of Done

- [x] Users can see the correct values reflected on the heatmap and table 

## Notes
- Bugtask on yearly summary heatmap and table

## Pre-condition
- In the api directory, run ``` dotnet run ```
- In the client directory, run ``` npm run build  ``` and then ``` npm start ```
- Go to ``` http://localhost:3000/leave-management/yearly-summary ```

## Expected Output
- It should reflect  the correct leaveName on the heatmap, and reflect the chipped value of status column on table

## Screenshots/Recordings

![image](https://github.com/framgia/sph-hris/assets/109492180/ef4ad4e8-288b-4204-b4c6-6f1ee58e6b2a)
