### PR TITLE
HRIS-288 [BE/FE]  Fix the user clock-in and clock-out functionality so that it reflects immediately after the mutation.

### DIFF
--- a/client/src/components/organisms/WorkInterruptionDrawer/index.tsx
+++ b/client/src/components/organisms/WorkInterruptionDrawer/index.tsx
@@ -3,12 +3,13 @@ import classNames from 'classnames'
 import toast from 'react-hot-toast'
 import { X, Info } from 'react-feather'
 import React, { FC, useEffect } from 'react'
+import { PulseLoader } from 'react-spinners'
 import { FieldError, useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import TextareaAutosize from 'react-textarea-autosize'
 
 import useUserQuery from '~/hooks/useUserQuery'
-import SpinnerIcon from '~/utils/icons/SpinnerIcon'
+import Button from '~/components/atoms/Buttons/Button'
 import useInterruptionType from '~/hooks/useInterruptionType'
 import { ConfirmInterruptionSchema } from '~/utils/validation'
 import UserTimeZone from '~/components/molecules/UserTimeZone'
@@ -67,7 +68,7 @@ const WorkInterruptionDrawer: FC<Props> = (props): JSX.Element => {
   useEffect(() => {
     if (interruptionMutation.isSuccess) {
       handleToggleWorkInterruptionDrawer()
-      toast.success('Work interruption submitted!')
+      toast.success('Work interruption submitted! ⚡')
     }
   }, [interruptionMutation.status])
 
@@ -293,7 +294,7 @@ const WorkInterruptionDrawer: FC<Props> = (props): JSX.Element => {
         {/* Footer Options */}
         <footer className="border-t border-slate-200">
           <div className="flex justify-end py-2 px-6">
-            <button
+            <Button
               type="button"
               disabled={isSubmitting}
               onClick={handleToggleWorkInterruptionDrawer}
@@ -304,8 +305,8 @@ const WorkInterruptionDrawer: FC<Props> = (props): JSX.Element => {
               )}
             >
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               type="submit"
               disabled={isSubmitting || !watch('power_checkbox')}
               className={classNames(
@@ -314,8 +315,8 @@ const WorkInterruptionDrawer: FC<Props> = (props): JSX.Element => {
                 'w-24 border-dark-primary bg-primary text-xs text-white outline-none hover:bg-dark-primary'
               )}
             >
-              {isSubmitting ? <SpinnerIcon className="h-4 w-4 !fill-amber-500" /> : 'Save'}
-            </button>
+              {isSubmitting ? <PulseLoader color="#fff" size={6} /> : 'Save'}
+            </Button>
           </div>
         </footer>
       </form>

--- a/client/src/hooks/useTimeInMutation.ts
+++ b/client/src/hooks/useTimeInMutation.ts
@@ -1,5 +1,5 @@
 import toast from 'react-hot-toast'
-import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query'
+import { useMutation, UseMutationResult } from '@tanstack/react-query'
 
 import { UPDATE_TIME_IN_MUTATION } from '~/graphql/mutations/TimeInMutation'
 import { client } from '~/utils/shared/client'
@@ -20,19 +20,12 @@ type returnType = {
 type handleTimeInMutationReturnType = UseMutationResult<any, unknown, TimeInRequest, unknown>
 
 const useTimeInMutation = (): returnType => {
-  const queryClient = useQueryClient()
   const handleTimeInMutation = (): handleTimeInMutationReturnType =>
     useMutation({
       mutationFn: async (timeIn: TimeInRequest) => {
         return await client.request(UPDATE_TIME_IN_MUTATION, {
           timeIn
         })
-      },
-      onSuccess: async () => {
-        await Promise.all([
-          queryClient.invalidateQueries({ queryKey: ['GET_USER_QUERY'] }),
-          queryClient.invalidateQueries({ queryKey: ['GET_EMPLOYEE_TIMESHEET'] })
-        ])
       },
       onError: (error) => {
         const data = JSON.parse(JSON.stringify(error))

--- a/client/src/hooks/useTimeOutMutation.ts
+++ b/client/src/hooks/useTimeOutMutation.ts
@@ -1,8 +1,8 @@
 import toast from 'react-hot-toast'
-import { useMutation, UseMutationResult, useQueryClient } from '@tanstack/react-query'
+import { useMutation, UseMutationResult } from '@tanstack/react-query'
 
-import { UPDATE_TIME_OUT_MUTATION } from '~/graphql/mutations/TimeOutMutation'
 import { client } from '~/utils/shared/client'
+import { UPDATE_TIME_OUT_MUTATION } from '~/graphql/mutations/TimeOutMutation'
 
 type TimeOutRequest = {
   userId: number
@@ -17,19 +17,12 @@ type returnType = {
 type handleTimeOutMutationReturnType = UseMutationResult<any, unknown, TimeOutRequest, unknown>
 
 const useTimeOutMutation = (): returnType => {
-  const queryClient = useQueryClient()
   const handleTimeOutMutation = (): handleTimeOutMutationReturnType =>
     useMutation({
       mutationFn: async (timeOut: TimeOutRequest) => {
         return await client.request(UPDATE_TIME_OUT_MUTATION, {
           timeOut
         })
-      },
-      onSuccess: async () => {
-        await Promise.all([
-          queryClient.invalidateQueries({ queryKey: ['GET_USER_QUERY'] }),
-          queryClient.invalidateQueries({ queryKey: ['GET_EMPLOYEE_TIMESHEET'] })
-        ])
       },
       onError: (error) => {
         const data = JSON.parse(JSON.stringify(error))


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-288

## Definition of Done

- [x] Improve Time In with synchronous functionality  `async` and `await`
- [x] Improve Time Out with  synchronous functionality  `async` and `await`
- [x] Replace Time In/Out button with PulseLoader Animation during submission 
- [x] Added Pasted Icon every toast Message during Time In/Out/Power Interruption 

## Notes

- It insures that the clock will only run after the Time In mutate

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet run watch`

## Expected Output

- When User try to Time In/Out it will wait synchronously and shows loading in the button and after that it will perform an automatic Time Start/Stop to prevent unnecessary problem of the timer 
- Also Improve the Button loading style and the toast message with Paste Icon

## Screenshots/Recordings

[timer.webm](https://github.com/framgia/sph-hris/assets/108642414/716cca8a-aa8f-42d0-8d62-47e964ecbaa1)

