### PR TITLE
HRIS-287 [FE/BE] Add user's name column in the Yearly Leave Summary Page

### DIFF
--- a/api/DTOs/LeavesTableDTO.cs
+++ b/api/DTOs/LeavesTableDTO.cs
@@ -6,26 +6,28 @@ namespace api.DTOs
     public class LeavesTableDTO
     {
         public DateTime? Date { get; set; }
-        public int LeaveTypeId { get; set; }
         public bool IsWithPay { get; set; }
         public string? Reason { get; set; }
-        public float NumLeaves { get; set; }
         public string? Status { get; set; }
+        public int LeaveTypeId { get; set; }
+        public float NumLeaves { get; set; }
+        public string? UserName { get; set; }
+        public string? LeaveName { get; set; }
         public bool? IsLeaderApproved { get; set; }
         public bool? IsManagerApproved { get; set; }
-        public string? LeaveName { get; set; }
 
         public LeavesTableDTO(Leave data)
         {
-            Date = data.LeaveDate;
-            LeaveTypeId = data.LeaveTypeId;
-            IsWithPay = data.IsWithPay;
-            NumLeaves = data.Days;
             Reason = data.Reason;
+            Date = data.LeaveDate;
+            NumLeaves = data.Days;
+            UserName = data.User.Name;
+            IsWithPay = data.IsWithPay;
+            LeaveTypeId = data.LeaveTypeId;
+            LeaveName = data.LeaveType.Name;
             IsLeaderApproved = data.IsLeaderApproved;
             IsManagerApproved = data.IsManagerApproved;
             Status = RStatus(data.IsLeaderApproved, data.IsManagerApproved);
-            LeaveName = data.LeaveType.Name;
         }
 
         public static string? RStatus(bool? isLeaderApproved, bool? isManagerApproved)

--- a/api/Services/LeaveService.cs
+++ b/api/Services/LeaveService.cs
@@ -35,6 +35,7 @@ namespace api.Services
             {
                 var leaves = await context.Leaves
                             .Include(i => i.LeaveType)
+                            .Include(i => i.User)
                             .Where(u => u.UserId == userId && u.LeaveDate.Year == year)
                             .OrderBy(o => o.LeaveDate.Day)
                             .Select(s => new LeavesTableDTO(s))
@@ -44,7 +45,7 @@ namespace api.Services
                             .Where(u => u.Id == userId)
                             .FirstAsync();
 
-                LeaveHeatMapDTO heatmap = new LeaveHeatMapDTO(leaves);
+                LeaveHeatMapDTO heatmap = new(leaves);
                 return new LeavesDTO(new LeaveHeatMapDTO(leaves), leaves, user);
             }
         }
@@ -53,14 +54,14 @@ namespace api.Services
         {
             using (HrisContext context = _contextFactory.CreateDbContext())
             {
-
                 var leaves = await context.Leaves
                             .Include(i => i.LeaveType)
+                            .Include(i => i.User)
                             .Where(u => u.LeaveDate.Year == year)
                             .OrderBy(o => o.LeaveDate.Day)
                             .Select(s => new LeavesTableDTO(s))
                             .ToListAsync();
-                LeaveHeatMapDTO heatmap = new LeaveHeatMapDTO(leaves);
+                LeaveHeatMapDTO heatmap = new(leaves);
                 heatmap.summarizeMonth();
                 return new LeavesDTO(heatmap, leaves);
             }

--- a/client/src/components/atoms/WorkStatusChip/index.tsx
+++ b/client/src/components/atoms/WorkStatusChip/index.tsx
@@ -11,39 +11,41 @@ type Props = {
 const WorkStatusChip: FC<Props> = ({ label }): JSX.Element => {
   const styles = classNames(
     'border rounded-full px-1 font-normal select-none capitalize',
-    label === WorkStatus.ON_DUTY.toLowerCase()
+    label.toLowerCase() === WorkStatus.ON_DUTY.toLowerCase()
       ? 'border-green-300 bg-green-50 text-green-600'
       : null,
-    label === WorkStatus.VACATION_LEAVE.toLowerCase()
+    label.toLowerCase() === WorkStatus.VACATION_LEAVE.toLowerCase()
       ? 'border-yellow-300 bg-yellow-50 text-yellow-600'
       : null,
-    label === WorkStatus.SICK_LEAVE.toLowerCase()
+    label.toLowerCase() === WorkStatus.SICK_LEAVE.toLowerCase()
       ? 'border-rose-300 bg-rose-50 text-rose-600'
       : null,
-    label === WorkStatus.ABSENT.toLowerCase()
+    label.toLowerCase() === WorkStatus.ABSENT.toLowerCase()
       ? 'border-fuchsia-300 bg-fuchsia-50 text-fuchsia-600'
       : null,
-    label === WorkStatus.BEREAVEMENT_LEAVE.toLowerCase()
+    label.toLowerCase() === WorkStatus.BEREAVEMENT_LEAVE.toLowerCase()
       ? 'border-gray-300 bg-gray-100 text-gray-600'
       : null,
-    label === WorkStatus.EMERGENCY_LEAVE.toLowerCase()
+    label.toLowerCase() === WorkStatus.EMERGENCY_LEAVE.toLowerCase()
       ? 'border-red-300 bg-red-50 text-red-600'
       : null,
-    label === WorkStatus.MATERNITY_PATERNITY_LEAVE.toLowerCase()
+    label.toLowerCase() === WorkStatus.MATERNITY_PATERNITY_LEAVE.toLowerCase()
       ? 'border-violet-300 bg-violet-50 text-violet-600'
       : null,
-    label === WorkStatus.UNDERTIME.toLowerCase()
+    label.toLowerCase() === WorkStatus.UNDERTIME.toLowerCase()
       ? 'border-amber-300 bg-amber-50 text-amber-600'
       : null,
-    label === WorkStatus.REST.toLowerCase() ? 'border-sky-300 bg-sky-50 text-sky-600' : null,
-    label === WorkStatus.AWAITING.toLowerCase() ? 'invisible' : null,
-    label === LeaveStatus.PENDING.toLowerCase()
+    label.toLowerCase() === WorkStatus.REST.toLowerCase()
+      ? 'border-sky-300 bg-sky-50 text-sky-600'
+      : null,
+    label.toLowerCase() === WorkStatus.AWAITING.toLowerCase() ? 'invisible' : null,
+    label.toLowerCase() === LeaveStatus.PENDING.toLowerCase()
       ? 'border-amber-300 bg-amber-50 text-amber-600'
       : null,
-    label === LeaveStatus.APPROVED.toLowerCase()
+    label.toLowerCase() === LeaveStatus.APPROVED.toLowerCase()
       ? 'border-green-300 bg-green-50 text-green-600'
       : null,
-    label === LeaveStatus.DISAPPROVED.toLowerCase()
+    label.toLowerCase() === LeaveStatus.DISAPPROVED.toLowerCase()
       ? 'border-rose-300 bg-rose-50 text-rose-600'
       : null
   )

--- a/client/src/components/molecules/LeaveManagementResultTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/MobileDisclose.tsx
@@ -2,13 +2,16 @@ import moment from 'moment'
 import React, { FC } from 'react'
 import classNames from 'classnames'
 import { motion } from 'framer-motion'
+import { useRouter } from 'next/router'
 import { Table } from '@tanstack/react-table'
 import { Disclosure } from '@headlessui/react'
 import { Calendar, ChevronRight } from 'react-feather'
 
 import { getLeaveType } from '~/utils/getLeaveType'
 import { LeaveTable } from '~/utils/types/leaveTypes'
+import { Pathname } from '~/utils/constants/pathnames'
 import { variants } from '~/utils/constants/animationVariants'
+import WorkStatusChip from '~/components/atoms/WorkStatusChip'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import DisclosureTransition from '~/components/templates/DisclosureTransition'
 
@@ -21,6 +24,10 @@ type Props = {
 }
 
 const MobileDisclose: FC<Props> = ({ table, query: { isLoading, isError } }): JSX.Element => {
+  const router = useRouter()
+  const { pathname } = router
+  const isYearlyPage = pathname === Pathname.YearlySummaryLeavesPath
+
   return (
     <>
       {isError === null || !isError ? (
@@ -79,6 +86,17 @@ const MobileDisclose: FC<Props> = ({ table, query: { isLoading, isError } }): JS
                                 'transition duration-150 ease-in-out'
                               )}
                             >
+                              <li className="px-4 py-2 font-normal hover:bg-slate-50">
+                                Status:{' '}
+                                <span className="font-medium">
+                                  {<WorkStatusChip label={row.original.status} />}
+                                </span>
+                              </li>
+                              {isYearlyPage && (
+                                <li className="px-4 py-2 font-normal hover:bg-slate-50">
+                                  Name: <span className="font-medium">{row.original.userName}</span>
+                                </li>
+                              )}
                               <li className="px-4 py-2 font-normal hover:bg-slate-50">
                                 Type of leave:{' '}
                                 <span className="font-medium">

--- a/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import moment from 'moment'
+import { useRouter } from 'next/router'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import { getLeaveType } from '~/utils/getLeaveType'
 import { LeaveTable } from '~/utils/types/leaveTypes'
+import { Pathname } from '~/utils/constants/pathnames'
 import CellHeader from '~/components/atoms/CellHeader'
 import WorkStatusChip from '~/components/atoms/WorkStatusChip'
 
@@ -18,6 +20,31 @@ export const columns = [
   columnHelper.accessor('status', {
     header: () => <CellHeader label="Status" className="text-xs text-slate-500" />,
     cell: (props) => <WorkStatusChip label={props.getValue()?.toLowerCase()} />,
+    footer: (info) => info.column.id
+  }),
+  columnHelper.accessor('userName', {
+    header: () => {
+      const router = useRouter()
+      const { pathname } = router
+      const isYearlyPage = pathname === Pathname.YearlySummaryLeavesPath
+
+      if (isYearlyPage) {
+        return <CellHeader label="Name" className="text-xs text-slate-500" />
+      }
+
+      return null
+    },
+    cell: (props) => {
+      const router = useRouter()
+      const { pathname } = router
+      const isYearlyPage = pathname === Pathname.YearlySummaryLeavesPath
+
+      if (isYearlyPage) {
+        return props.getValue()
+      }
+
+      return null
+    },
     footer: (info) => info.column.id
   }),
   columnHelper.accessor('leaveTypeId', {

--- a/client/src/graphql/queries/leaveQuery.ts
+++ b/client/src/graphql/queries/leaveQuery.ts
@@ -83,6 +83,7 @@ export const GET_MY_LEAVES_QUERY = gql`
         reason
         numLeaves
         status
+        userName
       }
       breakdown {
         sickLeave
@@ -171,6 +172,7 @@ export const GET_YEARLY_ALL_LEAVES_QUERY = gql`
         reason
         numLeaves
         status
+        userName
       }
       breakdown {
         sickLeave

--- a/client/src/utils/constants/pathnames.ts
+++ b/client/src/utils/constants/pathnames.ts
@@ -1,0 +1,3 @@
+export const Pathname = {
+  YearlySummaryLeavesPath: '/leave-management/yearly-summary'
+}

--- a/client/src/utils/types/leaveTypes.ts
+++ b/client/src/utils/types/leaveTypes.ts
@@ -48,6 +48,7 @@ export type LeaveTable = {
   reason: string
   numLeaves: number
   status: string
+  userName: string
 }
 export type Breakdown = {
   sickLeave: number


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-287

## Definition of Done

- [x] Added Name column for yearly summary page on desktop view
- [x] Added Name column for yearly summary page on mobile view

## Notes
- Improvement task for addition of columns

## Pre-condition
- In the api directory, run ``` dotnet run ```
- In the client directory, run ``` npm run build ``` and then ``` npm start ```
-  Go to ``` http://localhost:3000/leave-management/yearly-summary ```

## Expected Output
- The name column should only reflect on the Yearly summary page

## Screenshots/Recordings

### Desktop view

https://github.com/framgia/sph-hris/assets/109492180/48c6be3f-cb81-4c3b-8139-813c2b6801ef

### Mobile view

https://github.com/framgia/sph-hris/assets/109492180/63713215-b3c2-42b8-9cf4-5e0263bd72ee



