### PR TITLE
HRIS-293 [BE/FE] Overtime Management page should support multiple managers

### DIFF
--- a/api/Services/ApprovalService.cs
+++ b/api/Services/ApprovalService.cs
@@ -43,12 +43,12 @@ namespace api.Services
                     if (errors.Count > 0) throw new GraphQLException(errors);
 
                     // approve/disapprove operation
-                    var headManager = await context.Users.Where(x => x.PositionId == PositionEnum.MANAGER).FirstOrDefaultAsync();
+                    var headManager = await context.Users.Where(x => x.PositionId == PositionEnum.MANAGER || (x.PositionId == PositionEnum.ASSISTANT_MANAGER && x.Id == overtimeRequest.UserId)).ToListAsync();
                     var notification = await context.OvertimeNotifications.Where(x => x.OvertimeId == overtimeRequest.OvertimeId && x.RecipientId == overtimeRequest.UserId && x.Type == NotificationTypeEnum.OVERTIME).FirstOrDefaultAsync();
                     var overtime = await context.Overtimes.FindAsync(overtimeRequest.OvertimeId);
                     var notificationData = notification != null ? JsonConvert.DeserializeObject<dynamic>(notification.Data) : null;
 
-                    if ((overtime != null && notificationData != null) || headManager?.Id == overtimeRequest.UserId)
+                    if ((overtime != null && notificationData != null) || headManager.Count > 0)
                     {
                         overtime!.IsManagerApproved = overtimeRequest.IsApproved;
 


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-293

## Definition of Done

- [x] Overtime Management page should support multiple managers

## Notes
- Bug task only on approval/disapproval service for multiple managers

## Pre-condition
- There must be at least two ```manager``` position in the ```Users``` table to try and test 
- Backend
   - In the ```api``` directory run ``` dotnet run ```
- To check the functionality, go to ``` http://localhost:3000/overtime-management ``` where user role should be ``` manager ``` and user position is ``` manager ``` or ``` assistant manager ```

## Expected Output
- It should alter the ```isManagerApproved``` column in the ```Overtimes``` table

## Screenshots/Recordings

#### App with two managers

https://github.com/framgia/sph-hris/assets/109492180/3e7e9545-4f47-442c-a343-03a2724ffe7a


