### PR TITLE
HRIS-294 [FE] Change eye icon to note icon in all of the pages

### DIFF
--- a/client/src/components/molecules/FiledOffsetModal/MobileDisclose.tsx
+++ b/client/src/components/molecules/FiledOffsetModal/MobileDisclose.tsx
@@ -2,9 +2,10 @@ import Tippy from '@tippyjs/react'
 import classNames from 'classnames'
 import { motion } from 'framer-motion'
 import React, { FC, useState } from 'react'
+import { ChevronRight } from 'react-feather'
 import { Table } from '@tanstack/react-table'
 import { Disclosure } from '@headlessui/react'
-import { ChevronRight, Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import ShowRemarksModal from './ShowRemarksModal'
 import Button from '~/components/atoms/Buttons/Button'
@@ -118,7 +119,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                       className="py-0.5 px-1 text-slate-500"
                                       onClick={handleToggle}
                                     >
-                                      <Eye className="h-4 w-4" />
+                                      <BsFileEarmarkText className="h-4 w-4" />
                                     </Button>
                                   </Tippy>
                                 </li>

--- a/client/src/components/molecules/FiledOffsetModal/ShowRemarksModal.tsx
+++ b/client/src/components/molecules/FiledOffsetModal/ShowRemarksModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import { IFiledOffsetTable } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/ButtonAction'
@@ -26,7 +26,7 @@ const ShowRemarksModal: FC<Props> = ({ isOpen, closeModal, row }): JSX.Element =
       <ModalHeader
         {...{
           title: 'View Remarks',
-          Icon: Eye,
+          Icon: BsFileEarmarkText,
           closeModal
         }}
       />

--- a/client/src/components/molecules/FiledOffsetModal/columns.tsx
+++ b/client/src/components/molecules/FiledOffsetModal/columns.tsx
@@ -1,6 +1,6 @@
 import Tippy from '@tippyjs/react'
-import { Eye } from 'react-feather'
 import React, { useState } from 'react'
+import { BsFileEarmarkText } from 'react-icons/bs'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import ShowRemarksModal from './ShowRemarksModal'
@@ -51,7 +51,7 @@ export const columns = [
         <div className="inline-flex items-center space-x-1 rounded">
           <Tippy content="View" placement="left" className="!text-xs">
             <Button rounded="none" className="py-0.5 px-1 text-slate-500" onClick={handleToggle}>
-              <Eye className="h-4 w-4" />
+              <BsFileEarmarkText className="h-4 w-4" />
 
               {/* This will show the remarks modal */}
               {isOpen ? (

--- a/client/src/components/molecules/InterruptionTimeEntriesModal/ShowRemarksModal.tsx
+++ b/client/src/components/molecules/InterruptionTimeEntriesModal/ShowRemarksModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import ModalTemplate from '~/components/templates/ModalTemplate'
@@ -25,7 +25,7 @@ const ShowRemarksModal: FC<Props> = ({ isOpen, closeModal, remarks }): JSX.Eleme
       <ModalHeader
         {...{
           title: 'View Remarks',
-          Icon: Eye,
+          Icon: BsFileEarmarkText,
           closeModal
         }}
       />

--- a/client/src/components/molecules/InterruptionTimeEntriesModal/columns.tsx
+++ b/client/src/components/molecules/InterruptionTimeEntriesModal/columns.tsx
@@ -1,9 +1,10 @@
 import moment from 'moment'
 import Tippy from '@tippyjs/react'
 import { useRouter } from 'next/router'
+import { Edit, Trash } from 'react-feather'
 import React, { useRef, useState } from 'react'
-import { Edit, Eye, Trash } from 'react-feather'
 import { confirmAlert } from 'react-confirm-alert'
+import { BsFileEarmarkText } from 'react-icons/bs'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import { Roles } from '~/utils/constants/roles'
@@ -106,7 +107,7 @@ export const columns = [
               className="py-0.5 px-1 text-slate-500"
               onClick={() => handleOpenRemark(interruptionTimeEntry.remarks)}
             >
-              <Eye className="h-4 w-4" />
+              <BsFileEarmarkText className="h-4 w-4" />
               {/* This will show the Remarks Modal */}
               {isOpenRemark ? (
                 <ShowRemarksModal

--- a/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
@@ -151,13 +151,19 @@ export const columns = [
                   )}
                 >
                   <Menu.Item>
-                    <button className={menuItemButton} onClick={() => handleEdit()}>
+                    <button
+                      className={`${menuItemButton} space-x-2.5 pl-4`}
+                      onClick={() => handleEdit()}
+                    >
                       <Edit className="mr-0.5 h-3.5 w-3.5" />
                       <span>Edit</span>
                     </button>
                   </Menu.Item>
                   <Menu.Item>
-                    <button className={menuItemButton} onClick={() => alert('Cancel')}>
+                    <button
+                      className={`${menuItemButton} space-x-2.5 pl-4`}
+                      onClick={() => alert('Cancel')}
+                    >
                       <X className="mr-1 h-4 w-4" />
                       <span>Cancel</span>
                     </button>

--- a/client/src/components/molecules/ListOfLeaveTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/ListOfLeaveTable/MobileDisclose.tsx
@@ -4,7 +4,8 @@ import { motion } from 'framer-motion'
 import React, { FC, useState } from 'react'
 import { Table } from '@tanstack/react-table'
 import { Disclosure } from '@headlessui/react'
-import { ChevronRight, Edit, Eye } from 'react-feather'
+import { ChevronRight, Edit } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import Avatar from '~/components/atoms/Avatar'
 import ShowReasonModal from './ShowReasonModal'
@@ -152,7 +153,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                         rounded="none"
                                         className="py-0.5 px-1 text-slate-500"
                                       >
-                                        <Eye className="h-4 w-4" />
+                                        <BsFileEarmarkText className="h-4 w-4" />
                                       </Button>
                                     </Tippy>
                                     <Tippy placement="left" content="Edit" className="!text-xs">

--- a/client/src/components/molecules/ListOfLeaveTable/ShowReasonModal.tsx
+++ b/client/src/components/molecules/ListOfLeaveTable/ShowReasonModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import { IListOfLeave } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/ButtonAction'
@@ -26,7 +26,7 @@ const ShowReasonModal: FC<Props> = ({ isOpen, closeModal, remarks }): JSX.Elemen
       <ModalHeader
         {...{
           title: 'View Reason',
-          Icon: Eye,
+          Icon: BsFileEarmarkText,
           closeModal
         }}
       />

--- a/client/src/components/molecules/ListOfLeaveTable/columns.tsx
+++ b/client/src/components/molecules/ListOfLeaveTable/columns.tsx
@@ -1,6 +1,7 @@
 import Tippy from '@tippyjs/react'
+import { Edit } from 'react-feather'
 import React, { useState } from 'react'
-import { Edit, Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import Avatar from '~/components/atoms/Avatar'
@@ -93,7 +94,7 @@ export const columns = [
               rounded="none"
               className="py-0.5 px-1 text-slate-500"
             >
-              <Eye className="h-4 w-4" />
+              <BsFileEarmarkText className="h-4 w-4" />
               {/* This will show the Remarks Modal */}
               {isOpenListOfLeave ? (
                 <ShowReasonModal

--- a/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/index.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/ViewFiledChangeShiftModal/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
-import { Eye, X } from 'react-feather'
+import { X } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import useUserQuery from '~/hooks/useUserQuery'
 import { Position } from '~/utils/constants/position'
@@ -60,7 +61,7 @@ const ViewFiledChangeShiftModal: FC<Props> = (props): JSX.Element => {
         {...{
           title: 'Filed Change Shift',
           closeModal,
-          Icon: Eye
+          Icon: BsFileEarmarkText
         }}
       />
       <main className="px-8 py-4 text-sm  text-slate-700">

--- a/client/src/components/molecules/MyFiledScheduleTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyFiledScheduleTable/MobileDisclose.tsx
@@ -5,7 +5,8 @@ import { motion } from 'framer-motion'
 import React, { FC, useState } from 'react'
 import { Table } from '@tanstack/react-table'
 import { Disclosure } from '@headlessui/react'
-import { Calendar, ChevronRight, Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
+import { Calendar, ChevronRight } from 'react-feather'
 
 import ViewScheduleModal from './ViewScheduleModal'
 import Button from '~/components/atoms/Buttons/Button'
@@ -104,7 +105,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                       rounded="none"
                                       className="py-0.5 px-1 text-slate-500"
                                     >
-                                      <Eye className="h-4 w-4" />
+                                      <BsFileEarmarkText className="h-4 w-4" />
                                     </Button>
                                   </Tippy>
                                 </div>

--- a/client/src/components/molecules/MyFiledScheduleTable/columns.tsx
+++ b/client/src/components/molecules/MyFiledScheduleTable/columns.tsx
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import Tippy from '@tippyjs/react'
-import { Eye } from 'react-feather'
 import React, { useState } from 'react'
+import { BsFileEarmarkText } from 'react-icons/bs'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import ViewScheduleModal from './ViewScheduleModal'
@@ -38,7 +38,7 @@ export const columns = [
         <div className="inline-flex rounded border border-slate-300">
           <Tippy placement="left" content="View Schedule Modal" className="!text-xs">
             <Button onClick={handleToggle} rounded="none" className="py-0.5 px-1 text-slate-500">
-              <Eye className="h-4 w-4" />
+              <BsFileEarmarkText className="h-4 w-4" />
             </Button>
           </Tippy>
 

--- a/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
@@ -5,7 +5,8 @@ import { motion } from 'framer-motion'
 import React, { FC, useState } from 'react'
 import { Table } from '@tanstack/react-table'
 import { Disclosure } from '@headlessui/react'
-import { Calendar, ChevronRight, Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
+import { Calendar, ChevronRight } from 'react-feather'
 
 import ShowRemarksModal from './ShowRemarksModal'
 import { IMyOvertimeTable } from '~/utils/interfaces'
@@ -159,7 +160,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                       rounded="none"
                                       className="py-0.5 px-1 text-slate-500"
                                     >
-                                      <Eye className="h-4 w-4" />
+                                      <BsFileEarmarkText className="h-4 w-4" />
 
                                       {/* This will show the remarks modal */}
                                       {isOpen ? (

--- a/client/src/components/molecules/MyOvertimeTable/ShowRemarksModal.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/ShowRemarksModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import { IMyOvertimeTable } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/ButtonAction'
@@ -26,7 +26,7 @@ const ShowRemarksModal: FC<Props> = ({ isOpen, closeModal, row }): JSX.Element =
       <ModalHeader
         {...{
           title: 'View Remarks',
-          Icon: Eye,
+          Icon: BsFileEarmarkText,
           closeModal
         }}
       />

--- a/client/src/components/molecules/MyOvertimeTable/columns.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/columns.tsx
@@ -1,6 +1,6 @@
 import Tippy from '@tippyjs/react'
 import classNames from 'classnames'
-import { Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 import React, { Fragment, useState } from 'react'
 import { AiOutlineCaretDown } from 'react-icons/ai'
 import { Listbox, Transition } from '@headlessui/react'
@@ -158,7 +158,7 @@ export const columns = [
         <div className="inline-flex rounded border border-slate-300">
           <Tippy placement="left" content="View Remarks" className="!text-xs">
             <Button onClick={handleToggle} rounded="none" className="py-0.5 px-1 text-slate-500">
-              <Eye className="h-4 w-4" />
+              <BsFileEarmarkText className="h-4 w-4" />
             </Button>
           </Tippy>
 

--- a/client/src/components/molecules/NotificationList/NotificationItem.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationItem.tsx
@@ -1,13 +1,14 @@
 import moment from 'moment'
 import Tippy from '@tippyjs/react'
 import classNames from 'classnames'
-import { Eye } from 'react-feather'
 import { motion } from 'framer-motion'
 import { useRouter } from 'next/router'
 import React, { FC, useEffect } from 'react'
 import { Table } from '@tanstack/react-table'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import Avatar from '~/components/atoms/Avatar'
+import { User } from '~/utils/types/userTypes'
 import useUserQuery from '~/hooks/useUserQuery'
 import ViewDetailsModal from './ViewDetailsModal'
 import { INotification } from '~/utils/interfaces'
@@ -15,10 +16,9 @@ import Button from '~/components/atoms/Buttons/Button'
 import handleImageError from '~/utils/handleImageError'
 import useNotification from '~/hooks/useNotificationQuery'
 import { switchMessage } from '~/utils/notificationHelpers'
-import { NOTIFICATION_TYPE } from '~/utils/constants/notificationTypes'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import useNotificationMutation from '~/hooks/useNotificationMutation'
-import { User } from '~/utils/types/userTypes'
+import { NOTIFICATION_TYPE } from '~/utils/constants/notificationTypes'
 
 type Props = {
   table: Table<INotification>
@@ -166,7 +166,7 @@ const NotificationItem: FC<Props> = ({ table, isLoading }): JSX.Element => {
                               handleViewDetails(row.original)
                             }}
                           >
-                            <Eye className="h-4 w-4" />
+                            <BsFileEarmarkText className="h-4 w-4" />
                           </Button>
                         </Tippy>
 

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/index.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/index.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import { useRouter } from 'next/router'
-import { Check, Eye, X } from 'react-feather'
+import { Check, X } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import useLeave from '~/hooks/useLeave'
 import LeaveDetails from './LeaveDetails'
@@ -278,7 +279,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
                 })
               }}
             >
-              <Eye className="h-5 w-5" />
+              <BsFileEarmarkText className="h-5 w-5" />
               <span>View In Overtime Management</span>
             </Button>
           ) : (

--- a/client/src/components/molecules/OvertimeManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/MobileDisclose.tsx
@@ -5,7 +5,8 @@ import { motion } from 'framer-motion'
 import React, { FC, useState } from 'react'
 import { Table } from '@tanstack/react-table'
 import { Disclosure } from '@headlessui/react'
-import { ChevronRight, Edit, Eye, ThumbsDown, ThumbsUp } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
+import { ChevronRight, Edit, ThumbsDown, ThumbsUp } from 'react-feather'
 
 import Avatar from '~/components/atoms/Avatar'
 import { Roles } from '~/utils/constants/roles'
@@ -207,7 +208,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                             rounded="none"
                                             className="py-0.5 px-1 text-slate-500"
                                           >
-                                            <Eye className="h-4 w-4" />
+                                            <BsFileEarmarkText className="h-4 w-4" />
 
                                             {/* This will show the remarks modal */}
                                             {isOpen ? (
@@ -282,7 +283,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                                             onClick={handleShowRemarksToggle}
                                             className="py-0.5 px-1 text-slate-500"
                                           >
-                                            <Eye className="h-4 w-4" />
+                                            <BsFileEarmarkText className="h-4 w-4" />
 
                                             {/* This will show the remarks modal */}
                                             {isOpenRemarksModal ? (

--- a/client/src/components/molecules/OvertimeManagementTable/ShowRemarksModal.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/ShowRemarksModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Eye } from 'react-feather'
+import { BsFileEarmarkText } from 'react-icons/bs'
 
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import ModalTemplate from '~/components/templates/ModalTemplate'
@@ -26,7 +26,7 @@ const ShowRemarksModal: FC<Props> = ({ isOpen, closeModal, row }): JSX.Element =
       <ModalHeader
         {...{
           title: "View Requester's Remarks",
-          Icon: Eye,
+          Icon: BsFileEarmarkText,
           closeModal
         }}
       />

--- a/client/src/components/molecules/OvertimeManagementTable/columns.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/columns.tsx
@@ -2,9 +2,10 @@ import moment from 'moment'
 import Tippy from '@tippyjs/react'
 import classNames from 'classnames'
 import React, { Fragment, useState } from 'react'
+import { BsFileEarmarkText } from 'react-icons/bs'
 import { AiOutlineCaretDown } from 'react-icons/ai'
+import { ThumbsDown, ThumbsUp } from 'react-feather'
 import { Listbox, Transition } from '@headlessui/react'
-import { Eye, ThumbsDown, ThumbsUp } from 'react-feather'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import Avatar from '~/components/atoms/Avatar'
@@ -190,7 +191,7 @@ export const hrColumns = [
               rounded="none"
               className="py-0.5 px-1 text-slate-500"
             >
-              <Eye className="h-4 w-4" />
+              <BsFileEarmarkText className="h-4 w-4" />
             </Button>
           </Tippy>
 
@@ -439,7 +440,7 @@ export const managerColumns = [
               onClick={handleShowRemarksToggle}
               className="py-0.5 px-1 text-slate-500"
             >
-              <Eye className="h-4 w-4" />
+              <BsFileEarmarkText className="h-4 w-4" />
             </Button>
           </Tippy>
 


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-294

## Definition of Done

- [x] Modified `Eye` Icon into `Notes` Icon in every pages

## Notes

- Used `react-icons` from the changes 

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet run watch`

## Expected Output

- The `Eye` icon are now replaced into a `Notes` icon from `react-icons`

## Screenshots/Recordings

[change-eye-into-notes.webm](https://github.com/framgia/sph-hris/assets/108642414/2efaa1a0-a7ff-4edf-8302-a4ff6d9cac31)

