### PR TITLE
HRIS-295 [FE] Hide Employee Management and My Schedule Page in Production Mode

### DIFF
--- a/client/src/utils/constants/sidebarMenu.ts
+++ b/client/src/utils/constants/sidebarMenu.ts
@@ -187,45 +187,48 @@ export const productionMenu: IMenu[] = [
     name: 'My Overtime',
     href: '/my-overtime',
     Icon: Sleep,
-    role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER]
-  },
-  {
-    name: 'My Schedule',
-    Icon: Schedule,
-    href: '/my-schedule',
     role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER],
-    spacing: true,
-    submenu: true,
-    submenuItems: [
-      {
-        name: 'Current Schedule',
-        Icon: CalendarThirtyTwo,
-        href: '/my-schedule/current-schedule'
-      },
-      {
-        name: 'Request New Schedule',
-        Icon: SendToBack,
-        href: '/my-schedule/request-new-schedule'
-      },
-      {
-        name: 'Filed Schedules',
-        Icon: ViewList,
-        href: '/my-schedule/filed-schedules'
-      }
-    ]
+    spacing: true
   },
+  // Temporarily hidden
+  // {
+  //   name: 'My Schedule',
+  //   Icon: Schedule,
+  //   href: '/my-schedule',
+  //   role: [Roles.EMPLOYEE, Roles.HR_ADMIN, Roles.MANAGER],
+  //   spacing: true,
+  //   submenu: true,
+  //   submenuItems: [
+  //     {
+  //       name: 'Current Schedule',
+  //       Icon: CalendarThirtyTwo,
+  //       href: '/my-schedule/current-schedule'
+  //     },
+  //     {
+  //       name: 'Request New Schedule',
+  //       Icon: SendToBack,
+  //       href: '/my-schedule/request-new-schedule'
+  //     },
+  //     {
+  //       name: 'Filed Schedules',
+  //       Icon: ViewList,
+  //       href: '/my-schedule/filed-schedules'
+  //     }
+  //   ]
+  // },
   {
     name: 'Schedule Management',
     Icon: Calendar,
     href: '/schedule-management',
     role: [Roles.HR_ADMIN]
   },
-  {
-    name: 'Employee Management',
-    Icon: EveryUser,
-    href: '/employee-management',
-    role: [Roles.HR_ADMIN]
-  },
+  // Temporarily hidden
+  // {
+  //   name: 'Employee Management',
+  //   Icon: EveryUser,
+  //   href: '/employee-management',
+  //   role: [Roles.HR_ADMIN]
+  // },
   {
     name: 'Leave Management',
     Icon: FileEditingOne,


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-295

## Definition of Done

- [x] Users cannot see the Employee Management and My Schedule Page in production mode

## Notes
- None

## Pre-condition
- In the ```api``` directory, run ```dotnet run```
- In the ```client``` directory, run ```npm run build``` and then ```npm start```

## Expected Output
- Employee management and My schedule page should be hidden on production mode

## Screenshots/Recordings
### Development
![image](https://github.com/framgia/sph-hris/assets/109492180/c9e4f6f1-23ae-452f-86c5-f5c42a34410a)

### Production
![image](https://github.com/framgia/sph-hris/assets/109492180/9d26ac97-abd1-46fb-bd94-9f8a3e7e80cf)


