### PR TITLE
HRIS-289 [FE] Handling Fetching Error on DTR Management Page

### DIFF
--- a/client/src/pages/dtr-management.tsx
+++ b/client/src/pages/dtr-management.tsx
@@ -314,9 +314,15 @@ const DTRManagement: NextPage = (): JSX.Element => {
               )
             )}
           </>
-        ) : (
+        ) : allEmployee.error == null ? (
           <div className="flex min-h-[50vh] items-center justify-center">
             <PulseLoader color="#ffb40b" size={10} />
+          </div>
+        ) : (
+          <div className="bg-rose-50">
+            <p className="w-full py-2 text-center font-medium  text-rose-500">
+              Something went wrong
+            </p>
           </div>
         )}
       </section>

--- a/client/src/pages/dtr-management.tsx
+++ b/client/src/pages/dtr-management.tsx
@@ -314,7 +314,7 @@ const DTRManagement: NextPage = (): JSX.Element => {
               )
             )}
           </>
-        ) : allEmployee.error == null ? (
+        ) : allEmployee.error === null ? (
           <div className="flex min-h-[50vh] items-center justify-center">
             <PulseLoader color="#ffb40b" size={10} />
           </div>


### PR DESCRIPTION
## Issue Link

[Backlog Link](https://framgiaph.backlog.com/board/HRIS?selectedIssueKey=HRIS-289)

## Definition of Done

- [x] Users will be notified that there is something wrong when the backend is down.

## Pre-condition

Run front end `npm run dev`  and go to dtr management page

For this task make sure your backend is down or not running to test the error catcher.

## Expected Output

It should notify the users in DTR Management that there is something wrong trying to fetch the data from the backend.

## Screenshots/Recordings
 
 Proof

[screen-capture (2).webm](https://github.com/framgia/sph-hris/assets/109579325/5b002708-1bcc-4ac3-8da0-8f873f587b5f)
