### PR TITLE
HRIS-296 [FE] Convert Project column values from all application tables into tags instead of using dropdown menus

### DIFF
--- a/client/src/components/atoms/ProjectChip/index.tsx
+++ b/client/src/components/atoms/ProjectChip/index.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react'
+import classNames from 'classnames'
+
+import { ReactSelectOption } from '~/utils/types/formValues'
+
+type Props = {
+  projects: Array<{
+    project_name: ReactSelectOption
+    project_leader: ReactSelectOption
+  }>
+}
+
+const ProjectChip: FC<Props> = ({ projects }): JSX.Element => {
+  return (
+    <div className="-ml-2 flex w-full min-w-[100px] flex-wrap">
+      {projects.map((option, index) => {
+        const projectName = option.project_name.label
+        const otherProjects =
+          option.project_name.label !== 'Others' && option.project_name.label?.split(',')
+
+        return (
+          <div key={index}>
+            {typeof otherProjects === 'object' && projectName !== '' ? (
+              <div key={index}>
+                {otherProjects.map((val, index) => (
+                  <span
+                    key={index}
+                    className={classNames(
+                      'inline-flex items-center rounded-md border border-amber-300',
+                      'ml-2 select-none bg-amber-50 px-1.5 py-0.5 text-xs text-amber-600'
+                    )}
+                  >
+                    {val}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default ProjectChip

--- a/client/src/components/molecules/ListOfLeaveTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/ListOfLeaveTable/MobileDisclose.tsx
@@ -12,6 +12,7 @@ import ShowReasonModal from './ShowReasonModal'
 import { IListOfLeave } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/Button'
 import handleImageError from '~/utils/handleImageError'
+import ProjectChip from '~/components/atoms/ProjectChip'
 import { variants } from '~/utils/constants/animationVariants'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import DisclosureTransition from '~/components/templates/DisclosureTransition'
@@ -50,18 +51,18 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
               <>
                 {table.getRowModel().rows.map((row) => {
                   const {
-                    avatar,
+                    id,
                     name,
-                    project,
-                    leaveDate,
                     type,
-                    isWithPay,
+                    avatar,
                     manager,
-                    projectLeader,
-                    totalUndertime,
-                    totalLeaves,
+                    projects,
                     dateFiled,
-                    id
+                    leaveDate,
+                    isWithPay,
+                    totalLeaves,
+                    projectLeader,
+                    totalUndertime
                   } = row.original
                   return (
                     <Disclosure key={row.id}>
@@ -109,8 +110,9 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                               )}
                             >
                               <ul className="flex flex-col divide-y divide-slate-200">
-                                <li className="px-4 py-2">
-                                  Project: <span className="font-semibold">{project}</span>
+                                <li className="flex flex-col space-y-2 px-4 py-2.5">
+                                  <span>Projects:</span>
+                                  <ProjectChip {...{ projects }} />
                                 </li>
                                 <li className="px-4 py-2">
                                   Leave Date: <span className="font-semibold">{leaveDate}</span>

--- a/client/src/components/molecules/ListOfLeaveTable/columns.tsx
+++ b/client/src/components/molecules/ListOfLeaveTable/columns.tsx
@@ -10,6 +10,7 @@ import { IListOfLeave } from '~/utils/interfaces'
 import CellHeader from '~/components/atoms/CellHeader'
 import Button from '~/components/atoms/Buttons/Button'
 import handleImageError from '~/utils/handleImageError'
+import ProjectChip from '~/components/atoms/ProjectChip'
 
 const columnHelper = createColumnHelper<IListOfLeave>()
 
@@ -38,10 +39,11 @@ export const columns = [
       )
     }
   }),
-  columnHelper.accessor('project', {
+  columnHelper.accessor('projects', {
     id: 'Project',
     header: () => <CellHeader label="Project" />,
-    footer: (info) => info.column.id
+    footer: (info) => info.column.id,
+    cell: ({ row: { original } }) => <ProjectChip projects={original.projects} />
   }),
   columnHelper.accessor('leaveDate', {
     header: () => <CellHeader label="Leave Date(s)" />,

--- a/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/MobileDisclose.tsx
@@ -11,6 +11,7 @@ import { Calendar, ChevronRight } from 'react-feather'
 import ShowRemarksModal from './ShowRemarksModal'
 import { IMyOvertimeTable } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/Button'
+import ProjectChip from '~/components/atoms/ProjectChip'
 import { decimalFormatter } from '~/utils/myOvertimeHelpers'
 import { variants } from '~/utils/constants/animationVariants'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
@@ -86,34 +87,7 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                             <ul className="flex flex-col divide-y divide-slate-200">
                               <li className="flex flex-col space-y-2 px-4 py-2.5">
                                 <span>Projects:</span>
-                                <div className="flex flex-wrap items-center space-x-2">
-                                  {row?.original?.projects.map((option, index) => {
-                                    const projectName = option.project_name.label
-                                    const otherProjects =
-                                      option.project_name.label !== 'Others' &&
-                                      option.project_name.label?.split(',')
-
-                                    return (
-                                      <div key={index}>
-                                        <>
-                                          {typeof otherProjects === 'object' &&
-                                          projectName !== '' ? (
-                                            <>
-                                              {otherProjects.map((val, index) => (
-                                                <span
-                                                  key={index}
-                                                  className="rounded border border-slate-300 bg-slate-50 px-1.5 font-medium"
-                                                >
-                                                  {val}
-                                                </span>
-                                              ))}
-                                            </>
-                                          ) : null}
-                                        </>
-                                      </div>
-                                    )
-                                  })}
-                                </div>
+                                <ProjectChip projects={row.original.projects} />
                               </li>
                               <li className="px-4 py-2.5">
                                 Date:{' '}

--- a/client/src/components/molecules/MyOvertimeTable/columns.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/columns.tsx
@@ -1,15 +1,13 @@
 import Tippy from '@tippyjs/react'
-import classNames from 'classnames'
+import React, { useState } from 'react'
 import { BsFileEarmarkText } from 'react-icons/bs'
-import React, { Fragment, useState } from 'react'
-import { AiOutlineCaretDown } from 'react-icons/ai'
-import { Listbox, Transition } from '@headlessui/react'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import ShowRemarksModal from './ShowRemarksModal'
 import { IMyOvertimeTable } from '~/utils/interfaces'
 import Button from '~/components/atoms/Buttons/Button'
 import CellHeader from '~/components/atoms/CellHeader'
+import ProjectChip from '~/components/atoms/ProjectChip'
 import CellTimeValue from '~/components/atoms/CellTimeValue'
 import { decimalFormatter } from '~/utils/myOvertimeHelpers'
 import RequestStatusChip from '~/components/atoms/RequestStatusChip'
@@ -21,77 +19,7 @@ export const columns = [
   columnHelper.accessor('projects', {
     header: () => <CellHeader label="Projects" />,
     footer: (info) => info.column.id,
-    cell: ({ row: { original } }) => (
-      <Listbox>
-        <div className="relative mt-1">
-          <Listbox.Button
-            className={classNames(
-              'flex items-center space-x-2',
-              'text-xs outline-none focus:scale-95'
-            )}
-          >
-            <span className="block truncate">{original.projects[0].project_name?.label}</span>
-            <AiOutlineCaretDown className="h-3 w-3 text-gray-400" aria-hidden="true" />
-          </Listbox.Button>
-          <Transition
-            as={Fragment}
-            leave="transition ease-in duration-100"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <Listbox.Options
-              className={classNames(
-                'absolute z-50 mt-1 max-h-40 w-full overflow-auto rounded-md bg-white',
-                'py-1 text-xs shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none'
-              )}
-            >
-              {original.projects.map((option, index) => {
-                const projectName = option.project_name.label
-                const otherProjects =
-                  option.project_name.label !== 'Others' && option.project_name.label?.split(',')
-
-                return (
-                  <div key={index}>
-                    {typeof otherProjects === 'object' && projectName !== '' ? (
-                      <>
-                        {otherProjects.map((val, index) => (
-                          <Listbox.Option
-                            key={index}
-                            className={({ active }) =>
-                              classNames(
-                                'relative cursor-default select-none py-2 pl-5 pr-4',
-                                active ? 'bg-amber-100 text-amber-900' : 'text-slate-800'
-                              )
-                            }
-                            value={option.project_name.value}
-                          >
-                            {({ selected }) => (
-                              <span
-                                className={classNames(
-                                  'block',
-                                  selected ? 'font-medium' : 'font-normal'
-                                )}
-                              >
-                                {val}
-                              </span>
-                            )}
-                          </Listbox.Option>
-                        ))}
-                      </>
-                    ) : null}
-                  </div>
-                )
-              })}
-            </Listbox.Options>
-          </Transition>
-        </div>
-      </Listbox>
-    )
-  }),
-  columnHelper.display({
-    id: 'empty1',
-    header: () => '',
-    footer: (info) => info.column.id
+    cell: ({ row: { original } }) => <ProjectChip projects={original.projects} />
   }),
   columnHelper.accessor('date', {
     header: () => <CellHeader label="Date" />,

--- a/client/src/components/molecules/OvertimeManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/MobileDisclose.tsx
@@ -16,6 +16,7 @@ import Button from '~/components/atoms/Buttons/Button'
 import UpdateOvertimeModal from './UpdateOvertimeModal'
 import handleImageError from '~/utils/handleImageError'
 import { IOvertimeManagement } from '~/utils/interfaces'
+import ProjectChip from '~/components/atoms/ProjectChip'
 import { variants } from '~/utils/constants/animationVariants'
 import ApproveConfirmationModal from './ApproveConfirmationModal'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
@@ -123,18 +124,9 @@ const MobileDisclose: FC<Props> = ({ table, isLoading, error }): JSX.Element => 
                               )}
                             >
                               <ul className="flex flex-col divide-y divide-slate-200">
-                                <li className="flex items-center px-4 py-2.5">
-                                  Projects:{' '}
-                                  <div className="ml-2 flex flex-wrap items-center space-x-2">
-                                    {overtimeManagement.projects.map((project, index) => (
-                                      <span
-                                        key={index}
-                                        className="rounded border border-slate-300 bg-slate-50 px-1.5 font-medium"
-                                      >
-                                        {project.project_name.label}
-                                      </span>
-                                    ))}
-                                  </div>
+                                <li className="flex flex-col space-y-2 px-4 py-2.5">
+                                  <span>Projects:</span>
+                                  <ProjectChip projects={row.original.projects} />
                                 </li>
                                 <li className="px-4 py-2.5">
                                   Date:{' '}

--- a/client/src/components/molecules/OvertimeManagementTable/columns.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/columns.tsx
@@ -1,11 +1,8 @@
 import moment from 'moment'
 import Tippy from '@tippyjs/react'
-import classNames from 'classnames'
-import React, { Fragment, useState } from 'react'
+import React, { useState } from 'react'
 import { BsFileEarmarkText } from 'react-icons/bs'
-import { AiOutlineCaretDown } from 'react-icons/ai'
 import { ThumbsDown, ThumbsUp } from 'react-feather'
-import { Listbox, Transition } from '@headlessui/react'
 import { createColumnHelper } from '@tanstack/react-table'
 
 import Avatar from '~/components/atoms/Avatar'
@@ -16,6 +13,7 @@ import Button from '~/components/atoms/Buttons/Button'
 import CellHeader from '~/components/atoms/CellHeader'
 import handleImageError from '~/utils/handleImageError'
 import UpdateOvertimeModal from './UpdateOvertimeModal'
+import ProjectChip from '~/components/atoms/ProjectChip'
 import CellTimeValue from '~/components/atoms/CellTimeValue'
 import ApproveConfirmationModal from './ApproveConfirmationModal'
 import RequestStatusChip from '~/components/atoms/RequestStatusChip'
@@ -49,80 +47,10 @@ export const hrColumns = [
       )
     }
   }),
-  columnHelper.display({
-    id: 'empty1',
-    header: () => '',
-    footer: (info) => info.column.id
-  }),
   columnHelper.accessor('projects', {
     header: () => <CellHeader label="Project" />,
     footer: (info) => info.column.id,
-    cell: (props) => {
-      const { original: overtimeManagement } = props.row
-      return (
-        <Listbox value={overtimeManagement.projects[0]}>
-          <div className="relative mt-1">
-            <>
-              <Listbox.Button
-                className={classNames(
-                  'flex items-center space-x-2',
-                  'text-xs outline-none focus:scale-95'
-                )}
-              >
-                <span className="block truncate">
-                  {overtimeManagement.projects[0].project_name.label}
-                </span>
-                <AiOutlineCaretDown className="h-3 w-3 text-gray-400" aria-hidden="true" />
-              </Listbox.Button>
-              <Transition
-                as={Fragment}
-                leave="transition ease-in duration-100"
-                leaveFrom="opacity-100"
-                leaveTo="opacity-0"
-              >
-                <Listbox.Options
-                  className={classNames(
-                    'absolute z-50 mt-1 max-h-40 w-full overflow-auto rounded-md bg-white',
-                    'py-1 text-xs shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none'
-                  )}
-                >
-                  {overtimeManagement.projects.map((project, index) => (
-                    <Listbox.Option key={index} value={project.project_name.value}>
-                      {({ selected }) => (
-                        <>
-                          <span
-                            className={classNames(
-                              'block',
-                              selected ? 'font-medium' : 'font-normal'
-                            )}
-                          >
-                            {project.project_name.label?.split(',').map((here, index) => {
-                              if (here !== 'Others' && here !== '') {
-                                return (
-                                  <p
-                                    key={index}
-                                    className={classNames(
-                                      'relative cursor-default select-none py-2 pl-5 pr-4 hover:bg-amber-100 hover:text-amber-900'
-                                    )}
-                                  >
-                                    {here}
-                                  </p>
-                                )
-                              }
-                              return null
-                            })}
-                          </span>
-                        </>
-                      )}
-                    </Listbox.Option>
-                  ))}
-                </Listbox.Options>
-              </Transition>
-            </>
-          </div>
-        </Listbox>
-      )
-    }
+    cell: ({ row: { original } }) => <ProjectChip projects={original.projects} />
   }),
   columnHelper.accessor('date', {
     header: () => <CellHeader label="Date" />,
@@ -248,72 +176,7 @@ export const managerColumns = [
   columnHelper.accessor('projects', {
     header: () => <CellHeader label="Project" />,
     footer: (info) => info.column.id,
-    cell: (props) => {
-      const { original: overtimeManagement } = props.row
-      return (
-        <Listbox value={overtimeManagement.projects[0]}>
-          <div className="relative mt-1">
-            <>
-              <Listbox.Button
-                className={classNames(
-                  'flex items-center space-x-2',
-                  'text-xs outline-none focus:scale-95'
-                )}
-              >
-                <span className="block truncate">
-                  {overtimeManagement.projects[0].project_name.label}
-                </span>
-                <AiOutlineCaretDown className="h-3 w-3 text-gray-400" aria-hidden="true" />
-              </Listbox.Button>
-              <Transition
-                as={Fragment}
-                leave="transition ease-in duration-100"
-                leaveFrom="opacity-100"
-                leaveTo="opacity-0"
-              >
-                <Listbox.Options
-                  className={classNames(
-                    'absolute z-50 mt-1 max-h-40 w-full overflow-auto rounded-md bg-white',
-                    'py-1 text-xs shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none'
-                  )}
-                >
-                  {overtimeManagement.projects.map((project, index) => (
-                    <Listbox.Option key={index} value={project.project_name.value}>
-                      {({ selected }) => (
-                        <>
-                          <span
-                            className={classNames(
-                              'block',
-                              selected ? 'font-medium' : 'font-normal'
-                            )}
-                          >
-                            {project.project_name.label.split(',').map((here, index) => {
-                              if (here !== 'Others' && here !== '') {
-                                return (
-                                  <p
-                                    key={index}
-                                    className={classNames(
-                                      'relative cursor-default select-none py-2 pl-5 pr-4 hover:bg-amber-100 hover:text-amber-900'
-                                    )}
-                                  >
-                                    {here}
-                                  </p>
-                                )
-                              }
-                              return null
-                            })}
-                          </span>
-                        </>
-                      )}
-                    </Listbox.Option>
-                  ))}
-                </Listbox.Options>
-              </Transition>
-            </>
-          </div>
-        </Listbox>
-      )
-    }
+    cell: ({ row: { original } }) => <ProjectChip projects={original.projects} />
   }),
   columnHelper.display({
     id: 'empty1',

--- a/client/src/pages/leave-management/list-of-leave.tsx
+++ b/client/src/pages/leave-management/list-of-leave.tsx
@@ -30,7 +30,16 @@ const ListOfLeave: NextPage = (): JSX.Element => {
         id: i?.id,
         name: i?.userName,
         userId: i?.userId,
-        project: i?.leaveProjects[0]?.project?.name,
+        projects: i?.leaveProjects.map((item) => ({
+          project_name: {
+            label: item.project.name,
+            value: item.project.name
+          },
+          project_leader: {
+            label: item.projectLeader.name,
+            value: item.projectLeader.name
+          }
+        })),
         leaveDate: moment(i?.leaveDate).format('MM/DD/YYYY'),
         type: i?.leaveType,
         isWithPay: i?.isWithPay,
@@ -66,6 +75,7 @@ const ListOfLeave: NextPage = (): JSX.Element => {
             placeholder="Search"
           />
         </header>
+
         {mappedLeave !== undefined && data !== undefined ? (
           <ListOfLeaveTable
             {...{

--- a/client/src/utils/createLeaveHelpers.ts
+++ b/client/src/utils/createLeaveHelpers.ts
@@ -11,7 +11,9 @@ export type SelectOptionType = {
 }
 
 export const generateProjectsMultiSelect = (projects: ProjectDetails[]): SelectOptionType[] =>
-  projects?.map((project) => ({ label: project.name, value: project.id.toString() }))
+  projects
+    ?.filter((item) => item.name !== 'Others')
+    .map((project) => ({ label: project.name, value: project.id.toString() }))
 
 export const generateUserSelect = (users: User[]): SelectOptionType[] =>
   users?.map((user) => ({ label: user?.name, value: user?.id.toString() }))

--- a/client/src/utils/interfaces/index.tsx
+++ b/client/src/utils/interfaces/index.tsx
@@ -1,7 +1,7 @@
 import * as Icons from 'react-feather'
 
 import { IESLOffset } from './eslOffsetInterface'
-import { TimeEntryWithBreak } from '../types/formValues'
+import { ReactSelectOption, TimeEntryWithBreak } from './../types/formValues'
 
 export type IconName = keyof typeof Icons
 
@@ -28,7 +28,10 @@ export interface IListOfLeave {
   id: number
   userId: number
   name: string
-  project: string
+  projects: Array<{
+    project_name: ReactSelectOption
+    project_leader: ReactSelectOption
+  }>
   leaveDate: string
   type: string
   isWithPay: boolean


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-296

## Definition of Done

- [x] Created `ProjectChip` Components
- [x] Reused `ProjectChip` to All Project Columns Table
    - [x] Applied in `My Overtime Page`
    - [x] Applied in `Leave Management -> List of Leave Tab Page`
    - [x] Applied in `Overtime Management Page`  

## Notes

- This is a client request for improvements

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet run watch`
- goto to all tables that has project columns to view the cheap

## Expected Output

- Each table that has project columns are now refactored into a Project Cheap with amber color design

## Screenshots/Recordings

[test-tse.webm](https://github.com/framgia/sph-hris/assets/108642414/adeafbb3-0ca7-42d2-83ea-f6440b4d6c00)


