### PR TITLE
HRIS-297 [FE] Add Error Image handier on the Approve and Disspprove modal

### DIFF
--- a/client/src/components/molecules/OvertimeManagementTable/ApproveConfirmationModal.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/ApproveConfirmationModal.tsx
@@ -10,6 +10,7 @@ import Input from '~/components/atoms/Input'
 import useOvertime from '~/hooks/useOvertime'
 import useUserQuery from '~/hooks/useUserQuery'
 import Button from '~/components/atoms/Buttons/Button'
+import handleImageError from '~/utils/handleImageError'
 import ReactTextareaAutosize from 'react-textarea-autosize'
 import { ApproveConfirmationSchema } from '~/utils/validation'
 import { IOvertimeManagementManager } from '~/utils/interfaces'
@@ -93,7 +94,12 @@ const ApproveConfirmationModal: FC<Props> = ({ isOpen, closeModal, row }): JSX.E
         <main className="py-6 px-7 text-xs">
           <section className="flex items-start justify-between">
             <div className="inline-flex flex-col space-y-1">
-              <img src={row.user.link} className="h-14 w-14 rounded-full" alt="" />
+              <img
+                onError={(e) => handleImageError(e, '/images/default.png')}
+                src={row.user.link}
+                className="h-14 w-14 rounded-full"
+                alt=""
+              />
               <h1 className="text-lg font-semibold text-slate-700">{row.user.name}</h1>
             </div>
             <Button

--- a/client/src/components/molecules/OvertimeManagementTable/DisapproveConfirmationModal.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/DisapproveConfirmationModal.tsx
@@ -10,6 +10,7 @@ import TextField from './../TextField'
 import useOvertime from '~/hooks/useOvertime'
 import useUserQuery from '~/hooks/useUserQuery'
 import Button from '~/components/atoms/Buttons/Button'
+import handleImageError from '~/utils/handleImageError'
 import { IOvertimeManagementManager } from '~/utils/interfaces'
 import ModalTemplate from '~/components/templates/ModalTemplate'
 import { DisapproveConfirmationSchema } from '~/utils/validation'
@@ -90,7 +91,12 @@ const DisapproveConfirmationModal: FC<Props> = ({ isOpen, closeModal, row }): JS
         <main className="py-6 px-7 text-xs">
           <section className="flex items-start justify-between">
             <div className="inline-flex flex-col space-y-1">
-              <img src={row.user.link} className="h-14 w-14 rounded-full" alt="" />
+              <img
+                onError={(e) => handleImageError(e, '/images/default.png')}
+                src={row.user.link}
+                className="h-14 w-14 rounded-full"
+                alt=""
+              />
               <h1 className="text-lg font-semibold text-slate-700">{row.user.name}</h1>
             </div>
             <Button


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-297

## Definition of Done

- [x] Default image will replace the broken display picture

## Notes
- None

## Pre-condition
- In the ```api``` directory, run ```dotnet run```
- In the ```client``` directory, run ```npm run build``` and then ```npm start```

## Expected Output
- If there's a broken image link, the default image will take over on approve/disapprove modal

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/109492180/89d79984-9060-458d-b455-7587bf516fcf


