### PR TITLE
HRIS-272-01 [BE/FE] Fix: aligned the icons for Edit and Cancel

### DIFF
--- a/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
@@ -208,25 +208,25 @@ export const columns = [
               <MenuTransition>
                 <Menu.Items
                   className={classNames(
-                    'absolute top-7 right-0 z-50 flex w-44 flex-col divide-y divide-slate-200 overflow-hidden rounded-md',
+                    'absolute top-7 right-0 z-50 flex w-fit flex-col divide-y divide-slate-200 overflow-hidden rounded-md',
                     'bg-white py-0.5 shadow-xl shadow-slate-200 ring-1 ring-black ring-opacity-5 focus:outline-none'
                   )}
                 >
                   <Menu.Item>
                     <button
-                      className={`${menuItemButton} space-x-2.5 pl-4`}
+                      className={`${menuItemButton} space-x-1 pl-2`}
                       onClick={() => handleEdit()}
                     >
-                      <Edit className="jw-3.5 mr-0.5 h-3.5" />
+                      <Edit className="jw-3.5 h-3.5 w-3.5" />
                       <span>Edit</span>
                     </button>
                   </Menu.Item>
                   <Menu.Item>
                     <button
-                      className={`${menuItemButton} space-x-2.5 pl-4`}
+                      className={`${menuItemButton} space-x-1 pl-2`}
                       onClick={() => handleConfirmCancelLeave(userId, leaveId)}
                     >
-                      <X className="mr-1 h-4 w-4" />
+                      <X className=" h-3.5 w-3.5" />
                       <span>Cancel</span>
                     </button>
                   </Menu.Item>


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-272

## Definition of Done

- [x] Aligned icons for Actions in my-leaves page

## Notes
- None

## Pre-condition
- In the ```api``` directory, run ```dotnet run```
- In the ```client``` directory, run ```npm run build``` and then ```npm start```

## Expected Output
- Aligned icons for Edit and Cancel

## Screenshots/Recordings
![image](https://github.com/framgia/sph-hris/assets/109492180/1aec13ba-c7fa-4c3d-916a-a436f7c94e8d)

