### PR TITLE
HRIS-299 [FE] Enhance Leave Management and My Leave Sections to Present Filter Options within the Content

### DIFF
--- a/client/src/components/molecules/SummaryFilterDropdown/index.tsx
+++ b/client/src/components/molecules/SummaryFilterDropdown/index.tsx
@@ -1,21 +1,17 @@
-import React, { FC, useEffect, useState } from 'react'
-import classNames from 'classnames'
-import { useRouter } from 'next/router'
 import Select from 'react-select'
+import { useRouter } from 'next/router'
+import React, { FC, useEffect, useState } from 'react'
 
-import Text from '~/components/atoms/Text'
 import useUserQuery from '~/hooks/useUserQuery'
-import CheckBox from '~/components/atoms/CheckBox'
-import { WorkStatus } from '~/utils/constants/work-status'
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import { customStyles } from '~/utils/customReactSelectStyles'
-import FilterDropdownTemplate from '~/components/templates/FilterDropdownTemplate'
 import { optionType, usersSelectOptions, yearSelectOptions } from '~/utils/maps/filterOptions'
 
 type Props = {}
 
 const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
   const router = useRouter()
+
   const currentYear = new Date().getFullYear()
   const { handleAllUsersQuery } = useUserQuery()
 
@@ -112,94 +108,62 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
   }, [router])
 
   return (
-    <div>
-      <FilterDropdownTemplate btnText="Filters" cardClassName="overflow-visible">
-        <main className="flex flex-col space-y-3 px-5 py-4">
-          <Text theme="sm" weight="semibold" className="text-slate-500">
-            {isListOfLeaveTabPage ? 'Leave Filters' : 'Summary Filters'}
-          </Text>
-          {!isListOfLeaveTabPage && (
-            <>
-              {router.pathname === '/leave-management/leave-summary' ? (
-                <>
-                  <label htmlFor="filterName" className="flex flex-col space-y-1">
-                    <span className="text-xs text-slate-500">Name</span>
-                    <Select
-                      id="filterName"
-                      styles={customStyles}
-                      defaultValue={handleDefaultValues(NAME_FIELD)}
-                      isLoading={isLoading}
-                      name={NAME_FIELD}
-                      onChange={(e) => (e !== null ? setSelectedUser(e.value) : null)}
-                      options={nameOptions}
-                    />
-                  </label>
-                  <label htmlFor="filterYear" className="flex flex-col space-y-1">
-                    <span className="text-xs text-slate-500">Year</span>
-                    <Select
-                      id="filterYear"
-                      styles={customStyles}
-                      defaultValue={handleDefaultValues(YEAR_FIELD)}
-                      isLoading={isLoading}
-                      name={YEAR_FIELD}
-                      onChange={(e) => (e !== null ? setYear(e.value) : null)}
-                      options={yearOptions}
-                    />
-                  </label>
-                </>
-              ) : (
-                <label htmlFor="filterYear" className="flex flex-col space-y-1">
-                  <span className="text-xs text-slate-500">Year</span>
-                  <Select
-                    id="filterYear"
-                    styles={customStyles}
-                    defaultValue={handleDefaultValues('year')}
-                    name="year"
-                    onChange={(e) => (e !== null ? setYear(e.value) : null)}
-                    options={yearOptions}
-                  />
-                </label>
-              )}
-            </>
-          )}
-          {isListOfLeaveTabPage && (
-            <div className="space-y-4">
-              <label htmlFor="filterName" className="flex flex-col space-y-1">
-                <span className="text-xs text-slate-500">Filter Type</span>
-                <select
-                  className={classNames(
-                    'w-full rounded-md border border-slate-300 text-xs shadow-sm',
-                    'focus:border-primary focus:ring-1 focus:ring-primary'
-                  )}
-                  id="filterName"
-                >
-                  <option value="">All</option>
-                  <option value="">{WorkStatus.VACATION_LEAVE}</option>
-                  <option value="">{WorkStatus.ABSENT}</option>
-                  <option value="">{WorkStatus.ON_DUTY}</option>
-                  <option value="">{WorkStatus.SICK_LEAVE}</option>
-                </select>
+    <div className="flex flex-col items-center gap-y-4 space-x-2 text-xs sm:flex-row sm:items-end">
+      {!isListOfLeaveTabPage && (
+        <div className="flex w-full flex-col items-center sm:w-auto sm:flex-row sm:space-x-2">
+          {/* ===== PAGE FOR: LEAVE SUMMARY ===== */}
+          {router.pathname === '/leave-management/leave-summary' && (
+            <div className="mt-4 w-full sm:w-64">
+              <label htmlFor="leaveSummaryFilterName" className="flex flex-col space-y-1">
+                <span className="text-xs text-slate-500">Name</span>
+                <Select
+                  id="leaveSummaryFilterName"
+                  styles={customStyles}
+                  defaultValue={handleDefaultValues(NAME_FIELD)}
+                  isLoading={isLoading}
+                  name={NAME_FIELD}
+                  className="w-full"
+                  classNames={{
+                    control: (state) => (state.isFocused ? 'border-primary' : 'border-slate-300')
+                  }}
+                  onChange={(e) => (e !== null ? setSelectedUser(e.value) : null)}
+                  options={nameOptions}
+                />
               </label>
-              <hr />
-              <div className="flex items-center justify-between">
-                <CheckBox label="With Pay" />
-                <CheckBox label="Without Pay" />
-              </div>
             </div>
           )}
-        </main>
-        <footer className="bg-slate-100 px-5 py-3">
-          <Button
-            onClick={handleUpdateResult}
-            type="button"
-            variant="primary"
-            rounded="md"
-            className="w-full py-2"
-          >
-            Update Results
-          </Button>
-        </footer>
-      </FilterDropdownTemplate>
+
+          {/* ===== PAGE FOR: MY LEAVE PAGE AND YEARLY SUMMARY ===== */}
+          <div className="mt-4 w-full sm:w-64">
+            <label htmlFor="myleaveFilterYear" className="flex flex-col space-y-1">
+              <span className="text-xs text-slate-500">Filter By Year</span>
+              <Select
+                id="myleaveFilterYear"
+                styles={customStyles}
+                defaultValue={handleDefaultValues(YEAR_FIELD)}
+                name={YEAR_FIELD}
+                classNames={{
+                  control: (state) => (state.isFocused ? 'border-primary' : 'border-slate-300')
+                }}
+                className="w-full text-xs"
+                onChange={(e) => (e !== null ? setYear(e.value) : null)}
+                options={yearOptions}
+              />
+            </label>
+          </div>
+        </div>
+      )}
+
+      <div className="mb-0.5 w-full">
+        <Button
+          onClick={handleUpdateResult}
+          type="button"
+          variant="primary"
+          className="w-full py-2 px-4 sm:w-auto"
+        >
+          Filter
+        </Button>
+      </div>
     </div>
   )
 }

--- a/client/src/components/templates/LeaveManagementLayout/index.tsx
+++ b/client/src/components/templates/LeaveManagementLayout/index.tsx
@@ -4,11 +4,8 @@ import { useRouter } from 'next/router'
 import React, { FC, ReactNode } from 'react'
 
 import Layout from './../Layout'
-import useLeave from '~/hooks/useLeave'
-import useUserQuery from '~/hooks/useUserQuery'
 import TabLink from '~/components/atoms/TabLink'
 import { Menus } from '~/utils/constants/sidebarMenu'
-import SummaryFilterDropdown from '~/components/molecules/SummaryFilterDropdown'
 
 type Props = {
   children: ReactNode
@@ -17,22 +14,7 @@ type Props = {
 
 const LeaveManagementLayout: FC<Props> = ({ children, metaTitle }): JSX.Element => {
   const router = useRouter()
-  const { handleUserQuery } = useUserQuery()
-
-  const { getLeaveQuery } = useLeave()
-  const { data: user } = handleUserQuery()
-
-  const { data: remainingLeaves } = getLeaveQuery(
-    router.query.id !== undefined
-      ? parseInt(router.query.id as string)
-      : (user?.userById.id as number),
-    router.query.year !== undefined
-      ? parseInt(router.query.year as string)
-      : new Date().getFullYear()
-  )
-
   const isListOfLeaveTabPage = router.pathname === '/leave-management/list-of-leave'
-  const isLeaveSummaryTabPage = router.pathname === '/leave-management/leave-summary'
 
   return (
     <Layout
@@ -60,17 +42,6 @@ const LeaveManagementLayout: FC<Props> = ({ children, metaTitle }): JSX.Element 
                   }}
                 />
               ))}
-            </section>
-            <section className="flex space-x-2 px-4">
-              {isLeaveSummaryTabPage ? (
-                <div className="flex items-center space-x-1">
-                  <div className="hidden sm:block">
-                    <span className="text-slate-500 line-clamp-1">Remaining Paid Leaves:</span>
-                  </div>
-                  <Chip count={remainingLeaves?.leaves?.user?.paidLeaves} />
-                </div>
-              ) : null}
-              {!isListOfLeaveTabPage ? <SummaryFilterDropdown /> : null}
             </section>
           </nav>
         </header>

--- a/client/src/pages/leave-management/yearly-summary.tsx
+++ b/client/src/pages/leave-management/yearly-summary.tsx
@@ -6,12 +6,6 @@ import { useRouter } from 'next/router'
 import { PulseLoader } from 'react-spinners'
 import React, { useEffect, useState } from 'react'
 
-import {
-  Series,
-  getHeatmapData,
-  initialSeriesData,
-  initialChartOptions
-} from '~/utils/generateData'
 import NotFound from './../404'
 import useLeave from '~/hooks/useLeave'
 import Card from '~/components/atoms/Card'
@@ -22,7 +16,14 @@ import { Breakdown, LeaveTable } from '~/utils/types/leaveTypes'
 import MaxWidthContainer from '~/components/atoms/MaxWidthContainer'
 import BreakdownOfLeaveCard from '~/components/molecules/BreakdownOfLeavesCard'
 import LeaveManagementLayout from '~/components/templates/LeaveManagementLayout'
+import SummaryFilterDropdown from '~/components/molecules/SummaryFilterDropdown'
 import LeaveManagementResultTable from '~/components/molecules/LeaveManagementResultTable'
+import {
+  Series,
+  getHeatmapData,
+  initialSeriesData,
+  initialChartOptions
+} from '~/utils/generateData'
 
 const ReactApexChart = dynamic(async () => await import('react-apexcharts'), {
   ssr: false
@@ -34,10 +35,13 @@ type SeriesData = {
 }
 
 const YearlySummary: NextPage = (): JSX.Element => {
+  const router = useRouter()
+
+  // CURRENT USER QUERY HOOKS
   const { handleUserQuery } = useUserQuery()
   const { data: currentUser } = handleUserQuery()
 
-  const router = useRouter()
+  // GET YEARLY LEAVE HOOKS
   const { getYearlyAllLeaveQuery } = useLeave()
   const {
     data: leaves,
@@ -115,6 +119,9 @@ const YearlySummary: NextPage = (): JSX.Element => {
   return (
     <LeaveManagementLayout metaTitle="Yearly Summary">
       <FadeInOut className="default-scrollbar h-full overflow-y-auto px-4">
+        {/* This will trigger filter */}
+        <SummaryFilterDropdown />
+
         {!isLeavesLoading ? (
           <main className="flex flex-col space-y-4">
             <MaxWidthContainer>


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-299

## Definition of Done

- [x] Removed Dropdown Menu in the My Leave Page that show within content
- [x] Removed Dropdown in the Tab Pages in Leave Management  that show within content
- [x] Insured previous integration still functioning when filtering name and year 

## Notes

- Figma design for My Leaves Page
    - https://www.figma.com/file/w3lR4Elj1q5yZgK3Xw0eIx/HRIS-Wireframe?type=design&node-id=5361-28462&t=QBn5wJsfjM3jzELS-4
- Figma design for Leave Summary Tab Page
   - https://www.figma.com/file/w3lR4Elj1q5yZgK3Xw0eIx/HRIS-Wireframe?type=design&node-id=5344-28221&t=QBn5wJsfjM3jzELS-4
- Figma design for Yearly Summary Tab Page
   - https://www.figma.com/file/w3lR4Elj1q5yZgK3Xw0eIx/HRIS-Wireframe?type=design&node-id=5361-29609&t=QBn5wJsfjM3jzELS-4

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet watch`
- goto `My Leave Page, Leave Summary and Yearly Summary` pages

## Expected Output

- The My leaves, Leave Summary and Yearly Summary Dropdown Filter are removed and replaced to newly requested design by the client that shows only within the content

## Screenshots/Recordings
[test.webm](https://github.com/framgia/sph-hris/assets/108642414/7ed26368-5bf7-4d7b-a48a-9b475a820b31)
