### PR TITLE
HRIS-300 [FE] Optimize Table Layouts Across All Pages

### DIFF
--- a/client/src/components/atoms/Logo/index.tsx
+++ b/client/src/components/atoms/Logo/index.tsx
@@ -19,7 +19,11 @@ const Logo: FC<Props> = ({ isOpen = true, href = '/' }): JSX.Element => {
         isOpen ? 'px-7' : 'px-3'
       )}
     >
-      <Text theme="md" color="amber" weight="bold">
+      <Text
+        theme="md"
+        weight="bold"
+        className="bg-gradient-to-r from-amber-500 to-fuchsia-500 bg-clip-text text-transparent"
+      >
         Sun*
       </Text>
       <Text theme="md" weight="bold" className={classNames('duration-200', !isOpen && 'hidden')}>

--- a/client/src/components/atoms/ProjectChip/index.tsx
+++ b/client/src/components/atoms/ProjectChip/index.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 const ProjectChip: FC<Props> = ({ projects }): JSX.Element => {
   return (
-    <div className="-ml-2 flex w-full min-w-[100px] flex-wrap">
+    <div className="-ml-2 flex w-full min-w-[100px] flex-wrap gap-y-2">
       {projects.map((option, index) => {
         const projectName = option.project_name.label
         const otherProjects =

--- a/client/src/components/molecules/DTRManagementTable/DesktopTable.tsx
+++ b/client/src/components/molecules/DTRManagementTable/DesktopTable.tsx
@@ -23,11 +23,7 @@ const DesktopTable: FC<Props> = (props): JSX.Element => {
   } = props
 
   return (
-    <AnimatedTable
-      {...{
-        table
-      }}
-    >
+    <AnimatedTable className="w-full min-w-[1520px]">
       <thead className="border-b border-slate-200">
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>

--- a/client/src/components/molecules/DTRManagementTable/index.tsx
+++ b/client/src/components/molecules/DTRManagementTable/index.tsx
@@ -73,7 +73,7 @@ const DTRTable: FC<Props> = (props): JSX.Element => {
           }}
         />
       ) : (
-        <div className="mx-auto mb-12 w-full max-w-fit">
+        <div className="mb-12">
           <DesktopTable
             {...{
               table,

--- a/client/src/components/molecules/DTRSummaryTable/DesktopTable.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/DesktopTable.tsx
@@ -15,16 +15,12 @@ type Props = {
 
 const DesktopTable: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
   return (
-    <AnimatedTable
-      {...{
-        table
-      }}
-    >
+    <AnimatedTable className="w-full min-w-[1018px]">
       <thead className="border-b border-slate-200">
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
             {headerGroup.headers.map(({ id, colSpan, isPlaceholder, column, getContext }) => (
-              <th key={id} colSpan={colSpan} className="px-1 py-3 text-left">
+              <th key={id} colSpan={colSpan} className="shrink-0 px-4 py-3 text-left">
                 {isPlaceholder ? null : (
                   <div
                     {...{
@@ -67,7 +63,7 @@ const DesktopTable: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
                       )}
                     >
                       {row.getVisibleCells().map(({ id, column, getContext }) => (
-                        <td key={id} className="flex-wrap px-1 py-2 capitalize">
+                        <td key={id} className="flex-wrap px-4 py-2 capitalize">
                           {flexRender(column.columnDef.cell, getContext())}
                         </td>
                       ))}

--- a/client/src/components/molecules/DTRSummaryTable/columns.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/columns.tsx
@@ -1,22 +1,13 @@
 import React from 'react'
 import { createColumnHelper } from '@tanstack/react-table'
 
-import SortIcon from '~/utils/icons/SortIcon'
 import Avatar from '~/components/atoms/Avatar'
+import CellHeader from '~/components/atoms/CellHeader'
 import handleImageError from '~/utils/handleImageError'
 import CellTimeValue from '~/components/atoms/CellTimeValue'
 import { ITimesheetSummary } from '~/utils/types/timeEntryTypes'
 
 const columnHelper = createColumnHelper<ITimesheetSummary>()
-
-const CellHeader = ({ label }: { label: string }): JSX.Element => {
-  return (
-    <span className="group flex w-[13vw] items-center font-normal text-slate-500">
-      {label}
-      <SortIcon className="ml-2 h-3 w-3 shrink-0 fill-current group-active:scale-95" />
-    </span>
-  )
-}
 
 export const columns = [
   columnHelper.accessor('user.name', {

--- a/client/src/components/molecules/DTRSummaryTable/index.tsx
+++ b/client/src/components/molecules/DTRSummaryTable/index.tsx
@@ -73,15 +73,13 @@ const DTRSummaryTable: FC<Props> = (props): JSX.Element => {
           }}
         />
       ) : (
-        <div className="mx-auto w-full max-w-fit">
-          <DesktopTable
-            {...{
-              table,
-              isLoading: false,
-              error
-            }}
-          />
-        </div>
+        <DesktopTable
+          {...{
+            table,
+            isLoading: false,
+            error
+          }}
+        />
       )}
 
       {/* Table Pagination & Filtering */}

--- a/client/src/components/molecules/EmployeeManagementTable/DesktopTable.tsx
+++ b/client/src/components/molecules/EmployeeManagementTable/DesktopTable.tsx
@@ -14,11 +14,7 @@ const DesktopTable: FC<Props> = (props): JSX.Element => {
   const { table } = props
 
   return (
-    <AnimatedTable
-      {...{
-        table
-      }}
-    >
+    <AnimatedTable className="w-full min-w-[960px]">
       <thead className="border-b border-slate-200">
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>

--- a/client/src/components/molecules/EmployeeManagementTable/MobileDisclose.tsx
+++ b/client/src/components/molecules/EmployeeManagementTable/MobileDisclose.tsx
@@ -59,6 +59,17 @@ const MobileDisclose: FC<Props> = ({ table }): JSX.Element => {
                             <small className="text-slate-500">Web Developer</small>
                           </div>
                         </div>
+                        <span
+                          className={classNames(
+                            'py-0.25  ml-1 rounded-full border  px-1.5',
+                            row.original.status === 'Active' &&
+                              'border-green-200 bg-green-50 text-green-600',
+                            row.original.status === 'Inactive' &&
+                              'border-rose-200 bg-rose-50 text-rose-600'
+                          )}
+                        >
+                          {row.original.status}
+                        </span>
                       </div>
                       <ChevronRight
                         className={classNames(
@@ -85,20 +96,6 @@ const MobileDisclose: FC<Props> = ({ table }): JSX.Element => {
                         <li className="px-4 py-2">
                           Date Joined:{' '}
                           <span className="font-semibold">{row.original.date_joined}</span>
-                        </li>
-                        <li className="inline-flex items-center px-4 py-2 md:py-3">
-                          Status:{' '}
-                          <span
-                            className={classNames(
-                              'py-0.25  ml-1 rounded-full border  px-1.5',
-                              row.original.status === 'Active' &&
-                                'border-green-200 bg-green-50 text-green-600',
-                              row.original.status === 'Inactive' &&
-                                'border-rose-200 bg-rose-50 text-rose-600'
-                            )}
-                          >
-                            {row.original.status}
-                          </span>
                         </li>
                         <li className="flex items-center space-x-2 px-4 py-2">
                           <span>Actions:</span>

--- a/client/src/components/molecules/EmployeeManagementTable/columns.tsx
+++ b/client/src/components/molecules/EmployeeManagementTable/columns.tsx
@@ -4,22 +4,13 @@ import classNames from 'classnames'
 import { Edit, Trash2 } from 'react-feather'
 import { createColumnHelper } from '@tanstack/react-table'
 
-import SortIcon from '~/utils/icons/SortIcon'
 import Avatar from '~/components/atoms/Avatar'
 import Button from '~/components/atoms/Buttons/Button'
+import CellHeader from '~/components/atoms/CellHeader'
 import handleImageError from '~/utils/handleImageError'
 import { IEmployeeManagement } from '~/utils/interfaces'
 
 const columnHelper = createColumnHelper<IEmployeeManagement>()
-
-const CellHeader = ({ label }: { label: string }): JSX.Element => {
-  return (
-    <span className="group flex w-[273px] items-center font-normal text-slate-500">
-      {label}
-      <SortIcon className="ml-2 h-3 w-3 shrink-0 fill-current group-active:scale-95" />
-    </span>
-  )
-}
 
 export const columns = [
   columnHelper.accessor('name', {

--- a/client/src/components/molecules/EmployeeManagementTable/index.tsx
+++ b/client/src/components/molecules/EmployeeManagementTable/index.tsx
@@ -70,13 +70,11 @@ const EmployeeManagementTable: FC<Props> = (props): JSX.Element => {
           }}
         />
       ) : (
-        <div className="mx-auto w-full max-w-fit">
-          <DesktopTable
-            {...{
-              table
-            }}
-          />
-        </div>
+        <DesktopTable
+          {...{
+            table
+          }}
+        />
       )}
       {/* Table Pagination & Filtering */}
       {table.getPageCount() >= 1 && (

--- a/client/src/components/molecules/ListOfLeaveTable/DesktopTable.tsx
+++ b/client/src/components/molecules/ListOfLeaveTable/DesktopTable.tsx
@@ -5,6 +5,7 @@ import { flexRender, Table } from '@tanstack/react-table'
 import Tr from '~/components/atoms/Tr'
 import TableSkeleton from './../SkeletonTable'
 import { IListOfLeave } from '~/utils/interfaces'
+import AnimatedTable from '~/components/atoms/Table'
 
 type Props = {
   table: Table<IListOfLeave>
@@ -21,13 +22,7 @@ const DesktopTable: FC<Props> = (props): JSX.Element => {
   } = props
 
   return (
-    <table
-      {...{
-        style: {
-          width: table.getCenterTotalSize()
-        }
-      }}
-    >
+    <AnimatedTable className="w-full min-w-[1761px]">
       <thead className="border-b border-slate-200">
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
@@ -87,7 +82,7 @@ const DesktopTable: FC<Props> = (props): JSX.Element => {
           )}
         </>
       </tbody>
-    </table>
+    </AnimatedTable>
   )
 }
 

--- a/client/src/components/molecules/ListOfLeaveTable/index.tsx
+++ b/client/src/components/molecules/ListOfLeaveTable/index.tsx
@@ -14,6 +14,7 @@ import FooterTable from './../FooterTable'
 import MobileDisclose from './MobileDisclose'
 import { fuzzyFilter } from '~/utils/fuzzyFilter'
 import { IListOfLeave } from '~/utils/interfaces'
+import useScreenCondition from '~/hooks/useScreenCondition'
 
 type Props = {
   query: {
@@ -29,6 +30,9 @@ type Props = {
 }
 
 const ListOfLeaveTable: FC<Props> = (props): JSX.Element => {
+  // SCREEN SIZE CONDITION HOOKS
+  const isMediumScreen = useScreenCondition('(max-width: 768px)')
+
   const {
     query: { data: dummy, isLoading, error },
     table: { columns, globalFilter, setGlobalFilter }
@@ -61,7 +65,7 @@ const ListOfLeaveTable: FC<Props> = (props): JSX.Element => {
   return (
     <>
       {/* Show only on mobile size */}
-      <div className="block md:hidden">
+      {isMediumScreen ? (
         <MobileDisclose
           {...{
             table,
@@ -69,9 +73,8 @@ const ListOfLeaveTable: FC<Props> = (props): JSX.Element => {
             error
           }}
         />
-      </div>
-      {/* Show on medium size and beyond */}
-      <div className="mx-auto hidden w-full max-w-fit md:block">
+      ) : (
+        // Show on medium size and beyond
         <DesktopTable
           {...{
             table,
@@ -81,7 +84,7 @@ const ListOfLeaveTable: FC<Props> = (props): JSX.Element => {
             }
           }}
         />
-      </div>
+      )}
       {/* Table Pagination & Filtering */}
       {table.getPageCount() >= 1 && (
         <FooterTable

--- a/client/src/components/molecules/MyDailyTimeRecordTable/DesktopTable.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/DesktopTable.tsx
@@ -16,16 +16,12 @@ type Props = {
 
 const DesktopTable: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
   return (
-    <AnimatedTable
-      {...{
-        table
-      }}
-    >
+    <AnimatedTable className="w-full min-w-[1300px]">
       <thead className="border-b border-slate-200">
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
             {headerGroup.headers.map(({ id, colSpan, isPlaceholder, column, getContext }) => (
-              <th key={id} colSpan={colSpan} className="px-4 py-3 text-left">
+              <th key={id} colSpan={colSpan} className="shrink-0 px-4 py-3 text-left">
                 {isPlaceholder ? null : (
                   <div
                     {...{

--- a/client/src/components/molecules/MyDailyTimeRecordTable/index.tsx
+++ b/client/src/components/molecules/MyDailyTimeRecordTable/index.tsx
@@ -79,7 +79,6 @@ const MyDTRTable: FC<Props> = (props): JSX.Element => {
       ) : (
         <div
           className={classNames(
-            'mx-auto w-full max-w-fit',
             user?.userById.position.id === USER_POSITIONS.ESL_TEACHER ? ' mb-12' : 'mb-3'
           )}
         >

--- a/client/src/components/molecules/MyOvertimeTable/DesktopTable.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/DesktopTable.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const DesktopTable: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
   return (
-    <AnimatedTable {...{ table }}>
+    <AnimatedTable className="w-full min-w-[1120px]">
       <thead className="border-b border-slate-200">
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>

--- a/client/src/components/molecules/MyOvertimeTable/columns.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/columns.tsx
@@ -55,11 +55,6 @@ export const columns = [
       )
     }
   }),
-  columnHelper.display({
-    id: 'empty2',
-    header: () => '',
-    footer: (info) => info.column.id
-  }),
   columnHelper.accessor('dateFiled', {
     header: () => <CellHeader label="Date Filed" />,
     footer: (info) => info.column.id
@@ -68,11 +63,6 @@ export const columns = [
     header: () => <CellHeader label="Status" />,
     footer: (info) => info.column.id,
     cell: ({ row: { original } }) => <RequestStatusChip label={original?.status} />
-  }),
-  columnHelper.display({
-    id: 'empty3',
-    header: () => '',
-    footer: (info) => info.column.id
   }),
   columnHelper.display({
     id: 'actions',

--- a/client/src/components/molecules/MyOvertimeTable/index.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/index.tsx
@@ -72,7 +72,7 @@ const MyOvertimeTable: FC<Props> = (props): JSX.Element => {
           }}
         />
       ) : (
-        <div className="mx-auto mb-8 w-full max-w-fit">
+        <div className="mb-8">
           <DesktopTable
             {...{
               table,

--- a/client/src/components/molecules/OvertimeManagementTable/DesktopTable.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/DesktopTable.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const DesktopTable: FC<Props> = ({ table, isLoading, error }): JSX.Element => {
   return (
-    <AnimatedTable {...{ table }}>
+    <AnimatedTable className="w-full min-w-[1280px]">
       <thead className="border-b border-slate-200">
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>

--- a/client/src/components/molecules/OvertimeManagementTable/columns.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/columns.tsx
@@ -64,18 +64,8 @@ export const hrColumns = [
     footer: (info) => info.column.id,
     cell: (props) => <CellTimeValue initialMinutes={props.row.original.approvedMinutes} />
   }),
-  columnHelper.display({
-    id: 'empty2',
-    header: () => '',
-    footer: (info) => info.column.id
-  }),
   columnHelper.accessor('supervisor', {
     header: () => <CellHeader label="Supervisor" />,
-    footer: (info) => info.column.id
-  }),
-  columnHelper.display({
-    id: 'empty3',
-    header: () => '',
     footer: (info) => info.column.id
   }),
   columnHelper.accessor('dateFiled', {

--- a/client/src/components/molecules/OvertimeManagementTable/index.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/index.tsx
@@ -72,15 +72,13 @@ const OvertimeManagementTable: FC<Props> = (props): JSX.Element => {
           }}
         />
       ) : (
-        <div className="mx-auto w-full max-w-fit">
-          <DesktopTable
-            {...{
-              table,
-              isLoading: false,
-              error
-            }}
-          />
-        </div>
+        <DesktopTable
+          {...{
+            table,
+            isLoading: false,
+            error
+          }}
+        />
       )}
 
       {/* Table Pagination & Filtering */}

--- a/client/src/components/molecules/SummaryFilterDropdown/index.tsx
+++ b/client/src/components/molecules/SummaryFilterDropdown/index.tsx
@@ -108,7 +108,7 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
   }, [router])
 
   return (
-    <div className="flex flex-col items-center gap-y-4 space-x-2 text-xs sm:flex-row sm:items-end">
+    <div className="flex flex-col items-center gap-y-4 text-xs sm:flex-row sm:items-end sm:space-x-2">
       {!isListOfLeaveTabPage && (
         <div className="flex w-full flex-col items-center sm:w-auto sm:flex-row sm:space-x-2">
           {/* ===== PAGE FOR: LEAVE SUMMARY ===== */}
@@ -154,12 +154,12 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
         </div>
       )}
 
-      <div className="mb-0.5 w-full">
+      <div className="mb-[1px] w-full">
         <Button
           onClick={handleUpdateResult}
           type="button"
           variant="primary"
-          className="w-full py-2 px-4 sm:w-auto"
+          className="w-full py-[9px] px-4 sm:w-auto"
         >
           Filter
         </Button>

--- a/client/src/pages/dtr-management.tsx
+++ b/client/src/pages/dtr-management.tsx
@@ -11,6 +11,7 @@ import useUserQuery from '~/hooks/useUserQuery'
 import { Roles } from '~/utils/constants/roles'
 import FilterIcon from '~/utils/icons/FilterIcon'
 import Layout from '~/components/templates/Layout'
+import useScreenCondition from '~/hooks/useScreenCondition'
 import LegendTooltip from '~/components/molecules/LegendTooltip'
 import DTRTable from '~/components/molecules/DTRManagementTable'
 import DTRSummaryTable from '~/components/molecules/DTRSummaryTable'
@@ -52,6 +53,9 @@ type URLParameterType =
 const DTRManagement: NextPage = (): JSX.Element => {
   const router = useRouter()
   const { query } = router
+
+  // SCREEN SIZE CONDITION HOOKS
+  const isMediumScreen = useScreenCondition('(max-width: 768px)')
 
   const { handleUserQuery } = useUserQuery()
   const { data: currentUser } = handleUserQuery()
@@ -225,57 +229,61 @@ const DTRManagement: NextPage = (): JSX.Element => {
   return (
     <Layout metaTitle="DTR Management">
       <section className="default-scrollbar relative h-full min-h-full overflow-auto text-xs text-slate-800">
-        <div className="sticky top-0 z-20 block bg-slate-100 md:hidden">
-          <div className="flex items-center space-x-2 border-b border-slate-200 px-4 py-2">
-            <h1 className="text-base font-semibold text-slate-700">DTR Management</h1>
-            <LegendTooltip
-              {...{
-                placement: 'bottom'
-              }}
+        {isMediumScreen ? (
+          <div className="sticky top-0 z-20 block bg-slate-100">
+            <div className="flex items-center space-x-2 border-b border-slate-200 px-4 py-2">
+              <h1 className="text-base font-semibold text-slate-700">DTR Management</h1>
+              <LegendTooltip
+                {...{
+                  placement: 'bottom'
+                }}
+              />
+            </div>
+          </div>
+        ) : (
+          <header
+            className={classNames(
+              'sticky top-[41px] left-0 z-20 flex items-center justify-between md:top-0',
+              'border-b border-slate-200 bg-slate-100 px-4 py-2'
+            )}
+          >
+            <GlobalSearchFilter
+              value={globalFilter ?? ''}
+              onChange={(value) => setGlobalFilter(String(value))}
+              placeholder="Search"
             />
-          </div>
-        </div>
-        <header
-          className={classNames(
-            'sticky top-[41px] left-0 z-20 flex items-center justify-between md:top-0',
-            'border-b border-slate-200 bg-slate-100 px-4 py-2'
-          )}
-        >
-          <GlobalSearchFilter
-            value={globalFilter ?? ''}
-            onChange={(value) => setGlobalFilter(String(value))}
-            placeholder="Search"
-          />
-          <div className="flex items-center space-x-2 text-slate-500">
-            <TimeSheetFilterDropdown
-              className={classNames(
-                'flex items-center space-x-2 rounded border border-slate-200 bg-transparent bg-white',
-                'px-3 py-1 shadow-sm outline-none hover:text-slate-600 active:scale-95'
-              )}
-              filters={filters}
-              setFilters={setFilters}
-              handleFilterUpdate={handleFilterUpdate}
-              isOpenSummaryTable={isOpenSummaryTable}
-            >
-              <FilterIcon className="h-4 w-4 fill-current" />
-              <span>Filters</span>
-            </TimeSheetFilterDropdown>
-            <SummaryMenuDropdown
-              {...{
-                isOpenSummaryTable,
-                actions: {
-                  handleToggleSummaryTable
-                }
-              }}
-              className={classNames(
-                'rounded border border-slate-200 bg-white py-0.5 px-2 outline-none',
-                'shadow-sm hover:bg-white hover:text-slate-600 active:scale-95'
-              )}
-            >
-              <MoreHorizontal className="h-5 w-5" />
-            </SummaryMenuDropdown>
-          </div>
-        </header>
+            <div className="flex items-center space-x-2 text-slate-500">
+              <TimeSheetFilterDropdown
+                className={classNames(
+                  'flex items-center space-x-2 rounded border border-slate-200 bg-transparent bg-white',
+                  'px-3 py-1 shadow-sm outline-none hover:text-slate-600 active:scale-95'
+                )}
+                filters={filters}
+                setFilters={setFilters}
+                handleFilterUpdate={handleFilterUpdate}
+                isOpenSummaryTable={isOpenSummaryTable}
+              >
+                <FilterIcon className="h-4 w-4 fill-current" />
+                <span>Filters</span>
+              </TimeSheetFilterDropdown>
+              <SummaryMenuDropdown
+                {...{
+                  isOpenSummaryTable,
+                  actions: {
+                    handleToggleSummaryTable
+                  }
+                }}
+                className={classNames(
+                  'rounded border border-slate-200 bg-white py-0.5 px-2 outline-none',
+                  'shadow-sm hover:bg-white hover:text-slate-600 active:scale-95'
+                )}
+              >
+                <MoreHorizontal className="h-5 w-5" />
+              </SummaryMenuDropdown>
+            </div>
+          </header>
+        )}
+
         {!fetchedAllEmployeeData.isLoading &&
         fetchedAllEmployeeData.data !== undefined &&
         !fetchedSummaryData.isLoading ? (

--- a/client/src/pages/employee-management.tsx
+++ b/client/src/pages/employee-management.tsx
@@ -7,6 +7,7 @@ import NotFound from './404'
 import useUserQuery from '~/hooks/useUserQuery'
 import { Roles } from '~/utils/constants/roles'
 import Layout from '~/components/templates/Layout'
+import useScreenCondition from '~/hooks/useScreenCondition'
 import Button from '~/components/atoms/Buttons/ButtonAction'
 import GlobalSearchFilter from '~/components/molecules/GlobalSearchFilter'
 import AddNewEmployeeModal from '~/components/molecules/AddNewEmployeeModal'
@@ -25,11 +26,15 @@ export type QueryVariablesType = {
 }
 
 const EmployeeManagement: NextPage = (): JSX.Element => {
-  const { handleUserQuery } = useUserQuery()
-  const { data: currentUser } = handleUserQuery()
-
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [globalFilter, setGlobalFilter] = useState<string>('')
+
+  // SCREEN SIZE CONDITION HOOKS
+  const isMediumScreen = useScreenCondition('(max-width: 768px)')
+
+  // CURRENT USER HOOKS
+  const { handleUserQuery } = useUserQuery()
+  const { data: currentUser } = handleUserQuery()
 
   const handleToggle = (): void => setIsOpen(!isOpen)
 
@@ -40,41 +45,52 @@ const EmployeeManagement: NextPage = (): JSX.Element => {
   return (
     <Layout metaTitle="Employee Management">
       <section className="default-scrollbar relative h-full min-h-full overflow-auto text-xs text-slate-800">
-        <div className="sticky top-0 z-20 block bg-slate-100 md:hidden">
-          <div className="flex items-center space-x-2 border-b border-slate-200 px-4 py-2">
+        {isMediumScreen ? (
+          <div className="flex items-center justify-between space-x-2 border-b border-slate-200 px-4 py-2">
             <h1 className="text-base font-semibold text-slate-700">Employee Management</h1>
-          </div>
-        </div>
-        <header
-          className={classNames(
-            'sticky top-[41px] left-0 z-20 flex items-center justify-between md:top-0',
-            'border-b border-slate-200 bg-slate-100 px-4 py-2'
-          )}
-        >
-          <GlobalSearchFilter
-            value={globalFilter ?? ''}
-            onChange={(value) => setGlobalFilter(String(value))}
-            placeholder="Search"
-          />
-          <div className="flex items-center space-x-2 text-slate-500">
             <Button
               type="button"
               variant="primary"
               onClick={handleToggle}
-              className="flex items-center space-x-0.5 px-1.5 py-[3px]"
+              className="px-1.5 py-[3px]"
             >
-              <Plus className="h-4 w-4" /> {''}
-              Add Employee
+              <Plus className="h-4 w-4" />
             </Button>
           </div>
-          {/* File New Overtime Modal */}
-          <AddNewEmployeeModal
-            {...{
-              isOpen,
-              closeModal: handleToggle
-            }}
-          />
-        </header>
+        ) : (
+          <header
+            className={classNames(
+              'sticky top-[41px] left-0 z-20 flex items-center justify-between md:top-0',
+              'border-b border-slate-200 bg-slate-100 px-4 py-2'
+            )}
+          >
+            <GlobalSearchFilter
+              value={globalFilter ?? ''}
+              onChange={(value) => setGlobalFilter(String(value))}
+              placeholder="Search"
+            />
+            <div className="flex items-center space-x-2 text-slate-500">
+              <Button
+                type="button"
+                variant="primary"
+                onClick={handleToggle}
+                className="flex items-center space-x-0.5 px-1.5 py-[3px]"
+              >
+                <Plus className="h-4 w-4" />
+                <span>Employee</span>
+              </Button>
+            </div>
+          </header>
+        )}
+
+        {/* File New Overtime Modal */}
+        <AddNewEmployeeModal
+          {...{
+            isOpen,
+            closeModal: handleToggle
+          }}
+        />
+
         <EmployeeManagementTable
           {...{
             query: {

--- a/client/src/pages/my-daily-time-record.tsx
+++ b/client/src/pages/my-daily-time-record.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react'
 
 import useUserQuery from '~/hooks/useUserQuery'
 import Layout from '~/components/templates/Layout'
+import useScreenCondition from '~/hooks/useScreenCondition'
 import { getEmployeeTimesheet } from '~/hooks/useTimesheetQuery'
 import MyDTRTable from '~/components/molecules/MyDailyTimeRecordTable'
 import GlobalSearchFilter from '~/components/molecules/GlobalSearchFilter'
@@ -13,6 +14,8 @@ import { columns } from '~/components/molecules/MyDailyTimeRecordTable/columns'
 
 const MyDailyTimeRecord: NextPage = (): JSX.Element => {
   const router = useRouter()
+  // SCREEN SIZE CONDITION HOOKS
+  const isMediumScreen = useScreenCondition('(max-width: 768px)')
 
   const [globalFilter, setGlobalFilter] = useState<string>('')
 
@@ -43,23 +46,25 @@ const MyDailyTimeRecord: NextPage = (): JSX.Element => {
   return (
     <Layout metaTitle="My Daily Time Record">
       <section className="default-scrollbar relative h-full min-h-full overflow-auto text-xs text-slate-800">
-        <div className="block md:hidden">
+        {isMediumScreen ? (
           <div className="border-b border-slate-200 px-4 py-2">
             <h1 className="text-base font-semibold text-slate-700">My Daily Time Record</h1>
           </div>
-        </div>
-        <header
-          className={classNames(
-            'sticky top-0 left-0 flex items-center justify-between',
-            'border-b border-slate-200 bg-slate-100 px-4 py-2'
-          )}
-        >
-          <GlobalSearchFilter
-            value={globalFilter ?? ''}
-            onChange={(value) => setGlobalFilter(String(value))}
-            placeholder="Search"
-          />
-        </header>
+        ) : (
+          <header
+            className={classNames(
+              'sticky top-0 left-0 flex items-center justify-between',
+              'z-10 border-b border-slate-200 bg-slate-100 px-4 py-2'
+            )}
+          >
+            <GlobalSearchFilter
+              value={globalFilter ?? ''}
+              onChange={(value) => setGlobalFilter(String(value))}
+              placeholder="Search"
+            />
+          </header>
+        )}
+
         {!isLoading && data !== undefined ? (
           <MyDTRTable
             {...{


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-300

## Definition of Done

- [x] Modified the table layout to fill out the entire space of the content
- [x] Added a minimum width to display a horizontal scroll and prevent broken stretched content
- [x] Fix minor style in Summary Dropdown Filter 

## Notes

- Requested by the client

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet watch`

## Expected Output

- Each page's table layout fills out the entire space of the content and sets a minimum width to display a horizontal scroll, preventing the content from being stretched and broken
- List of Pages of table changed:
     - My Daily Time Record
     - My Overtime
     - Leave management -> List of Leave Tab Page
     - DTR Management 
     - Overtime Management 

## Screenshots/Recordings

[record for table improvements.webm](https://github.com/framgia/sph-hris/assets/108642414/3995cc71-9206-49aa-868e-4520bfb030ee)
