### PR TITLE
HRIS-309 [BE] Fix inaccurate display of worked hours in My DTR and DTR Management Pages

### DIFF
--- a/api/Services/TimeOutService.cs
+++ b/api/Services/TimeOutService.cs
@@ -38,7 +38,7 @@ namespace api.Services
 
                     timeEntry.TimeOutId = time.Entity.Id;
                     timeEntry.TimeOut = time.Entity;
-                    timeEntry.WorkedHours = timeout.WorkedHours;
+                    timeEntry.WorkedHours = GetWorkedHours(timeEntry);
                     timeEntry.TrackedHours = GetTrackedHours(timeEntry, time.Entity);
                     context.TimeEntries.Update(timeEntry);
 
@@ -66,6 +66,12 @@ namespace api.Services
             if ((ScheduledHours - LateTimeSpan).TotalMinutes < 0) LateTimeSpan = ScheduledHours - UndertimeTimeSpan;
 
             return ScheduledHours - UndertimeTimeSpan - LateTimeSpan;
+        }
+
+        private string? GetWorkedHours(TimeEntry timeEntry)
+        {
+            var workedHours = timeEntry.TimeOut?.TimeHour - timeEntry.TimeIn?.TimeHour;
+            return workedHours.ToString();
         }
     }
 }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-309

## Definition of Done
- [x] Moved computation of WorkedHours to BE

## Pre-condition
- (docker) run `docker compose up db api client -d`

## Expected Output
- The value of Worked Hours is now computed in the backend and not based on the frontend time

## Screenshots/Recordings
https://github.com/framgia/sph-hris/assets/111718037/4bcaa711-d406-4d83-b17a-1eae8b5cc377


