### PR TITLE
HRIS-308 [BE/FE] Add filtering functionality in the my leaves and leave management pages

### DIFF
--- a/api/Enums/LeaveTypeEnum.cs
+++ b/api/Enums/LeaveTypeEnum.cs
@@ -2,11 +2,13 @@ namespace api.Enums
 {
     public class LeaveTypeEnum
     {
+        public const int ALL = 0;
         public const int SICK_LEAVE = 1;
         public const int BEREAVEMENT_LEAVE = 2;
         public const int EMERGENCY_LEAVE = 3;
         public const int VACATION_LEAVE = 4;
         public const int MATERNITY_LEAVE = 5;
         public const int UNDERTIME = 6;
+        public const int PENDING = 7;
     }
 }

--- a/api/Schema/Queries/LeaveQuery.cs
+++ b/api/Schema/Queries/LeaveQuery.cs
@@ -23,15 +23,15 @@ namespace api.Schema.Queries
         {
             return await _leaveService.GetLeaveTypes();
         }
-        public async Task<LeavesDTO> GetLeaves(int userId, int year)
+        public async Task<LeavesDTO> GetLeaves(int userId, int year, int leaveTypeId)
         {
-            return await _leaveService.GetLeavesSummary(userId, year);
+            return await _leaveService.GetLeavesSummary(userId, year, leaveTypeId);
         }
 
         [AdminUser]
-        public async Task<LeavesDTO> GetYearlyAllLeaves(int year)
+        public async Task<LeavesDTO> GetYearlyAllLeaves(int year, int leaveTypeId)
         {
-            return await _leaveService.ShowYearlyLeavesSummary(year);
+            return await _leaveService.ShowYearlyLeavesSummary(year, leaveTypeId);
         }
 
         public async Task<double> GetPaidLeaves(int id)

--- a/api/Services/LeaveService.cs
+++ b/api/Services/LeaveService.cs
@@ -42,10 +42,10 @@ namespace api.Services
 
                 switch (leaveTypeId)
                 {
-                    case 0:
+                    case LeaveTypeEnum.ALL:
                         query = query.OrderBy(o => o.LeaveDate.Day);
                         break;
-                    case 7:
+                    case LeaveTypeEnum.PENDING:
                         query = query.Where(u => u.IsManagerApproved == null || u.IsLeaderApproved == null)
                                     .OrderBy(o => o.LeaveDate.Day);
                         break;
@@ -79,10 +79,10 @@ namespace api.Services
 
                 switch (leaveTypeId)
                 {
-                    case 0:
+                    case LeaveTypeEnum.ALL:
                         query = query.OrderBy(o => o.LeaveDate.Day);
                         break;
-                    case 7:
+                    case LeaveTypeEnum.PENDING:
                         query = query.Where(u => u.IsManagerApproved == null || u.IsLeaderApproved == null)
                                     .OrderBy(o => o.LeaveDate.Day);
                         break;

--- a/client/src/components/molecules/SummaryFilterDropdown/index.tsx
+++ b/client/src/components/molecules/SummaryFilterDropdown/index.tsx
@@ -1,9 +1,11 @@
 import Select from 'react-select'
+import isEmpty from 'lodash/isEmpty'
 import { useRouter } from 'next/router'
 import React, { FC, useEffect, useState } from 'react'
 
 import useUserQuery from '~/hooks/useUserQuery'
 import Button from '~/components/atoms/Buttons/ButtonAction'
+import { leaveOptions } from '~/utils/constants/leaveOptions'
 import { customStyles } from '~/utils/customReactSelectStyles'
 import { optionType, usersSelectOptions, yearSelectOptions } from '~/utils/maps/filterOptions'
 
@@ -20,10 +22,12 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
 
   const NAME_FIELD = 'name'
   const YEAR_FIELD = 'year'
+  const LEAVE_FIELD = 'leave'
 
   // filter states
   const [year, setYear] = useState<number>(currentYear)
   const [selectedUser, setSelectedUser] = useState<number>()
+  const [selectedLeave, setSelectedLeave] = useState<number>()
 
   // filter options
   const [nameOptions, setNameOptions] = useState<optionType[]>([])
@@ -45,7 +49,8 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
       void router.replace({
         pathname: router.pathname,
         query: {
-          year
+          year,
+          leave: selectedLeave
         }
       })
     } else if (router.pathname.includes('/leave-management/leave-summary')) {
@@ -53,7 +58,8 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
         pathname: router.pathname,
         query: {
           id: selectedUser,
-          year
+          year,
+          leave: selectedLeave
         }
       })
     }
@@ -69,6 +75,9 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
       case NAME_FIELD:
         defaultValue = nameOptions[0]
         break
+      case LEAVE_FIELD:
+        defaultValue = leaveOptions[0]
+        break
     }
 
     if (isLeaveSummaryTabPage) {
@@ -83,6 +92,10 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
       return yearOptions.find((option) => option.value === year) ?? null
     }
 
+    if (!isEmpty(router.query.leave)) {
+      return leaveOptions.find((option) => option.value === selectedLeave) ?? null
+    }
+
     return defaultValue
   }
 
@@ -94,6 +107,7 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
           ? data.allUsers[0].id
           : parseInt(router.query.id as string)
       )
+      setSelectedLeave(parseInt(router.query.leave as string))
     }
   }, [isSuccess])
 
@@ -104,19 +118,21 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
           ? currentYear
           : parseInt(router.query.year as string)
       )
+      setSelectedLeave(parseInt(router.query.leave as string))
     }
   }, [router])
 
   return (
-    <div className="flex flex-col items-center gap-y-4 text-xs sm:flex-row sm:items-end sm:space-x-2">
+    <div className="flex flex-col items-center gap-y-4 text-xs lg:flex-row lg:items-end lg:space-x-2">
       {!isListOfLeaveTabPage && (
-        <div className="flex w-full flex-col items-center sm:w-auto sm:flex-row sm:space-x-2">
+        <div className="flex w-full flex-col items-center lg:w-auto lg:flex-row lg:space-x-2">
           {/* ===== PAGE FOR: LEAVE SUMMARY ===== */}
           {router.pathname === '/leave-management/leave-summary' && (
-            <div className="mt-4 w-full sm:w-64">
+            <div className="mt-4 w-full lg:w-64">
               <label htmlFor="leaveSummaryFilterName" className="flex flex-col space-y-1">
                 <span className="text-xs text-slate-500">Name</span>
                 <Select
+                  instanceId="leaveSummaryFilterName"
                   id="leaveSummaryFilterName"
                   styles={customStyles}
                   defaultValue={handleDefaultValues(NAME_FIELD)}
@@ -134,10 +150,11 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
           )}
 
           {/* ===== PAGE FOR: MY LEAVE PAGE AND YEARLY SUMMARY ===== */}
-          <div className="mt-4 w-full sm:w-64">
+          <div className="mt-4 w-full lg:w-64">
             <label htmlFor="myleaveFilterYear" className="flex flex-col space-y-1">
               <span className="text-xs text-slate-500">Filter By Year</span>
               <Select
+                instanceId="myleaveFilterYear"
                 id="myleaveFilterYear"
                 styles={customStyles}
                 defaultValue={handleDefaultValues(YEAR_FIELD)}
@@ -151,6 +168,26 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
               />
             </label>
           </div>
+
+          {/* ===== FILTER BY LEAVE ===== */}
+          <div className="mt-4 w-full lg:w-64">
+            <label htmlFor="leaveFilter" className="flex flex-col space-y-1">
+              <span className="text-xs text-slate-500">Filter By Leave</span>
+              <Select
+                instanceId="leaveFilter"
+                id="leaveFilter"
+                styles={customStyles}
+                defaultValue={handleDefaultValues(LEAVE_FIELD)}
+                name={LEAVE_FIELD}
+                className="w-full"
+                classNames={{
+                  control: (state) => (state.isFocused ? 'border-primary' : 'border-slate-300')
+                }}
+                onChange={(e) => (e !== null ? setSelectedLeave(e.value) : null)}
+                options={leaveOptions}
+              />
+            </label>
+          </div>
         </div>
       )}
 
@@ -159,7 +196,7 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
           onClick={handleUpdateResult}
           type="button"
           variant="primary"
-          className="w-full py-[9px] px-4 sm:w-auto"
+          className="w-full py-[9px] px-4 lg:w-auto"
         >
           Filter
         </Button>

--- a/client/src/graphql/queries/leaveQuery.ts
+++ b/client/src/graphql/queries/leaveQuery.ts
@@ -8,8 +8,8 @@ export const GET_LEAVE_TYPES_QUERY = gql`
   }
 `
 export const GET_MY_LEAVES_QUERY = gql`
-  query ($userId: Int!, $year: Int!) {
-    leaves(userId: $userId, year: $year) {
+  query ($userId: Int!, $year: Int!, $leaveTypeId: Int!) {
+    leaves(userId: $userId, year: $year, leaveTypeId: $leaveTypeId) {
       user {
         id
         paidLeaves
@@ -104,8 +104,8 @@ export const GET_MY_LEAVES_QUERY = gql`
 `
 
 export const GET_YEARLY_ALL_LEAVES_QUERY = gql`
-  query ($year: Int!) {
-    yearlyAllLeaves(year: $year) {
+  query ($year: Int!, $leaveTypeId: Int!) {
+    yearlyAllLeaves(year: $year, leaveTypeId: $leaveTypeId) {
       heatmap {
         january {
           value

--- a/client/src/hooks/useLeave.ts
+++ b/client/src/hooks/useLeave.ts
@@ -43,20 +43,24 @@ type handleApproveLeaveUndertimeMutationType = UseMutationResult<
 type returnType = {
   handleLeaveTypeQuery: () => getLeaveTypeQueryType
   getSpecificLeaveQuery: (userId: number) => getSpecificLeaveQuery
-  getLeaveQuery: (userId: number, year: number) => getLeaveQueryType
+  getLeaveQuery: (userId: number, year: number, leaeTypeId: number) => getLeaveQueryType
   handleApproveLeaveMutation: () => handleApproveLeaveUndertimeMutationType
   handleApproveUndertimeMutation: () => handleApproveLeaveUndertimeMutationType
   handleLeaveMutation: (userId: number, year: number) => handleLeaveMutationType
-  getYearlyAllLeaveQuery: (year: number, ready: boolean) => getYearlyLeaveQueryType
+  getYearlyAllLeaveQuery: (
+    year: number,
+    leaveById: number,
+    ready: boolean
+  ) => getYearlyLeaveQueryType
   handleUpdateLeaveMutation: (userId: number, year: number) => handleUpdateLeaveMutationType
   handleCancelLeaveMutation: (userId: number, leaveIds: number) => handleCancelLeaveMutationType
 }
 
 const useLeave = (): returnType => {
-  const getLeaveQuery = (userId: number, year: number): getLeaveQueryType =>
+  const getLeaveQuery = (userId: number, year: number, leaveTypeId: number): getLeaveQueryType =>
     useQuery({
       queryKey: ['GET_MY_LEAVES_QUERY', userId, year],
-      queryFn: async () => await client.request(GET_MY_LEAVES_QUERY, { userId, year }),
+      queryFn: async () => await client.request(GET_MY_LEAVES_QUERY, { userId, year, leaveTypeId }),
       select: (data: Leaves) => data,
       enabled: Boolean(userId) && Boolean(year)
     })
@@ -69,10 +73,14 @@ const useLeave = (): returnType => {
       enabled: !isNaN(leaveId)
     })
 
-  const getYearlyAllLeaveQuery = (year: number, ready: boolean): getYearlyLeaveQueryType =>
+  const getYearlyAllLeaveQuery = (
+    year: number,
+    leaveTypeId: number,
+    ready: boolean
+  ): getYearlyLeaveQueryType =>
     useQuery({
-      queryKey: ['GET_YEARLY_ALL_LEAVES_QUERY', year],
-      queryFn: async () => await client.request(GET_YEARLY_ALL_LEAVES_QUERY, { year }),
+      queryKey: ['GET_YEARLY_ALL_LEAVES_QUERY', year, leaveTypeId],
+      queryFn: async () => await client.request(GET_YEARLY_ALL_LEAVES_QUERY, { year, leaveTypeId }),
       select: (data: YearlyLeaves) => data,
       enabled: ready
     })

--- a/client/src/pages/leave-management/leave-summary.tsx
+++ b/client/src/pages/leave-management/leave-summary.tsx
@@ -2,10 +2,8 @@ import { NextPage } from 'next'
 import dynamic from 'next/dynamic'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
-import { Filter } from '@icon-park/react'
 import { PulseLoader } from 'react-spinners'
 import React, { useEffect, useState } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
 
 import NotFound from './../404'
 import Card from '~/components/atoms/Card'
@@ -13,8 +11,6 @@ import useLeave from '~/hooks/useLeave'
 import useUserQuery from '~/hooks/useUserQuery'
 import { Roles } from '~/utils/constants/roles'
 import FadeInOut from '~/components/templates/FadeInOut'
-import useLocalStorageState from 'use-local-storage-state'
-import Button from '~/components/atoms/Buttons/ButtonAction'
 import { Breakdown, LeaveTable } from '~/utils/types/leaveTypes'
 import MaxWidthContainer from '~/components/atoms/MaxWidthContainer'
 import BreakdownOfLeaveCard from '~/components/molecules/BreakdownOfLeavesCard'
@@ -39,11 +35,6 @@ type SeriesData = {
 
 const LeaveSummary: NextPage = (): JSX.Element => {
   const router = useRouter()
-  const [isHideFilter, setHideFilter] = useLocalStorageState('hideFilter', {
-    defaultValue: false
-  })
-
-  const handleHideFilterToggle = (): void => setHideFilter(!isHideFilter)
 
   // CURRENT USER HOOKS
   const { getLeaveQuery } = useLeave()
@@ -63,7 +54,8 @@ const LeaveSummary: NextPage = (): JSX.Element => {
       : (user?.userById.id as number),
     router.query.year !== undefined
       ? parseInt(router.query.year as string)
-      : new Date().getFullYear()
+      : new Date().getFullYear(),
+    router.query.leave !== undefined ? parseInt(router.query.leave as string) : 0
   )
   const [series, setSeries] = useState<SeriesData[]>(initialSeriesData)
 
@@ -138,36 +130,9 @@ const LeaveSummary: NextPage = (): JSX.Element => {
             <p className="text-sm text-slate-500">Available Paid Leaves:</p>
             <Chip count={leaves?.leaves.user.paidLeaves} />
           </div>
-          {/* FOR INTEGRATOR: Filter it by shallow route */}
-          <div className="flex items-center space-x-2">
-            <Button
-              type="button"
-              rounded="full"
-              variant="secondary"
-              onClick={handleHideFilterToggle}
-              className="flex items-center space-x-0.5 !bg-white px-2 py-[3px]"
-            >
-              <Filter size={14} theme="outline" />
-              <span className="hidden sm:block">
-                {isHideFilter ? 'Hide Filter' : 'Show Filter'}
-              </span>
-            </Button>
-          </div>
         </header>
-        {/* This will trigger filter */}
-        <AnimatePresence initial={false}>
-          {isHideFilter && (
-            <motion.div
-              key="dropdown"
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: 'auto' }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.3 }}
-            >
-              <SummaryFilterDropdown />
-            </motion.div>
-          )}
-        </AnimatePresence>
+        <SummaryFilterDropdown />
+
         {!isLeavesLoading ? (
           <main className="flex flex-col space-y-4">
             <MaxWidthContainer>

--- a/client/src/pages/leave-management/yearly-summary.tsx
+++ b/client/src/pages/leave-management/yearly-summary.tsx
@@ -52,6 +52,7 @@ const YearlySummary: NextPage = (): JSX.Element => {
     isNaN(parseInt(router.query.year as string))
       ? moment().year()
       : parseInt(router.query.year as string),
+    isNaN(parseInt(router.query.leave as string)) ? 0 : parseInt(router.query.leave as string),
     router.isReady
   )
 

--- a/client/src/utils/constants/leaveOptions.ts
+++ b/client/src/utils/constants/leaveOptions.ts
@@ -1,0 +1,12 @@
+import { optionType } from './../maps/filterOptions'
+
+export const leaveOptions: optionType[] = [
+  { value: 0, label: 'All' },
+  { value: 1, label: 'Sick Leave' },
+  { value: 2, label: 'Bereavement leave' },
+  { value: 3, label: 'Emergency Leave' },
+  { value: 4, label: 'Vacation leave' },
+  { value: 5, label: 'Maternity/Paternity leave' },
+  { value: 6, label: 'Undertime' },
+  { value: 7, label: 'Pending' }
+]


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-308

## Definition of Done

- [x] [Markup] Create Leave Filter Dropdown Markup
- [x] [FE] Add `leaveTypeId` query param for My Leave, Leave Summary and Yearly Summary for `leaveType` Filter
- [x] [BE] Modified `GetLeavesSummary` and `ShowYearlyLeavesSummary` for additional `leaveTypeId` Filter

## Notes

- This is project client request
- The Filter functionality is Serverside
- Default `LeaveTypeId` set to `0` which is `All`
- The `leaveTypeId` are based in this image
![image](https://github.com/framgia/sph-hris/assets/108642414/d033e1cc-54c7-4127-9b61-c5b98f563ed0)
- The `leaveTypeId` of 7 is equal to `Pending` Status

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet watch`
- go to `My Leaves`, `Leave Summary` and `Yearly Summary` Page to test the filter

## Expected Output

- The `My Leaves`, `Leave Management` Pages are now have a Leave Filter Functionality

## Screenshots/Recordings

[leave filter record.webm](https://github.com/framgia/sph-hris/assets/108642414/14bf5707-e1bb-4984-9c64-cd6ca2e67a43)
