### PR TITLE
HRIS-301 [BE] Implement Bulk Overtime Request for Team Leader

### DIFF
--- a/api/Enums/MiddlewareErrorMessageEnum.cs
+++ b/api/Enums/MiddlewareErrorMessageEnum.cs
@@ -5,6 +5,7 @@ namespace api.Enums
         public static readonly string UNAUTHENTICATED_USER = "Unauthenticated User!";
         public static readonly string NO_EXISTING_USER = "No Existing User!";
         public static readonly string NOT_ADMIN_USER = "Not an Admin User!";
+        public static readonly string NOT_LEADER_USER = "Not a Leader User!";
         public static readonly string NOT_MANAGER_USER = "Not a Manager User!";
         public static readonly string NOT_ESL_USER = "Not an ESL User!";
         public static readonly string NOT_NON_ESL_USER = "Not a Non-ESL User!";

--- a/api/Middlewares/Attributes/LeaderUserAttribute.cs
+++ b/api/Middlewares/Attributes/LeaderUserAttribute.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HotChocolate.Types.Descriptors;
+
+namespace api.Middlewares.Attributes
+{
+    public class LeaderUserAttribute : ObjectFieldDescriptorAttribute
+    {
+        public LeaderUserAttribute([CallerLineNumber] int order = 0)
+        {
+            Order = order;
+        }
+
+        protected override void OnConfigure(IDescriptorContext context,
+            IObjectFieldDescriptor descriptor, MemberInfo member)
+        {
+            descriptor.Use<LeaderUser>();
+        }
+    }
+
+}

--- a/api/Middlewares/AuthorizeUser.cs
+++ b/api/Middlewares/AuthorizeUser.cs
@@ -1,5 +1,6 @@
 using api.Context;
 using api.Enums;
+using HotChocolate.Language;
 using HotChocolate.Resolvers;
 using Microsoft.EntityFrameworkCore;
 
@@ -19,7 +20,7 @@ namespace api.Middlewares
             var httpContext = accessor.HttpContext!;
             try
             {
-                if (httpContext.Items["User"] != null || context.Path.ToString().Contains("/createSignIn"))
+                if (httpContext.Items["User"] != null || context.Path.ToString().Contains("/createSignIn") || context.Operation.Type == OperationType.Subscription)
                 {
                     await _next(context);
                 }

--- a/api/Middlewares/LeaderUser.cs
+++ b/api/Middlewares/LeaderUser.cs
@@ -1,0 +1,39 @@
+using api.Context;
+using api.Entities;
+using api.Enums;
+using HotChocolate.Resolvers;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Middlewares
+{
+    public class LeaderUser
+    {
+        private readonly FieldDelegate _next;
+
+        public LeaderUser(FieldDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(IMiddlewareContext context, IHttpContextAccessor accessor, IDbContextFactory<HrisContext> dbContextFactory)
+        {
+            var httpContext = accessor.HttpContext;
+            try
+            {
+                var user = httpContext!.Items["User"] != null ? (User)httpContext.Items["User"]! : null;
+
+                if (user == null) throw new Exception(MiddlewareErrorMessageEnum.NO_EXISTING_USER);
+                if (!PositionEnum.ALL_LEADERS.Contains(user.PositionId)) throw new Exception(MiddlewareErrorMessageEnum.NOT_LEADER_USER);
+            }
+            catch (Exception e)
+            {
+                var error = ErrorBuilder.New()
+                    .SetMessage(e.Message)
+                    .Build();
+
+                throw new GraphQLException(new[] { error });
+            }
+            await _next(context);
+        }
+    }
+}

--- a/api/NotificationDataClasses/OvertimeData.cs
+++ b/api/NotificationDataClasses/OvertimeData.cs
@@ -20,4 +20,9 @@ namespace api.NotificationDataClasses
     {
         public List<string> Projects { get; set; } = default!;
     }
+
+    public class BulkOvertimeManagerData : OvertimeManagerData
+    {
+        public NotificationUser ProjectMember { get; set; } = default!;
+    }
 }

--- a/api/Requests/CreateBulkOvertimeRequest.cs
+++ b/api/Requests/CreateBulkOvertimeRequest.cs
@@ -1,0 +1,13 @@
+namespace api.Requests
+{
+    public class CreateBulkOvertimeRequest
+    {
+        public int ManagerId { get; set; }
+        public string? OtherProject { get; set; }
+        public int RequestedMinutes { get; set; }
+        public string Remarks { get; set; } = default!;
+        public string Date { get; set; } = default!;
+        public List<int> EmployeeIds { get; set; } = default!;
+        public int ProjectId { get; set; } = default!;
+    }
+}

--- a/api/Schema/Mutations/OvertimeMutation.cs
+++ b/api/Schema/Mutations/OvertimeMutation.cs
@@ -1,5 +1,6 @@
 using api.Context;
 using api.Entities;
+using api.Middlewares.Attributes;
 using api.Requests;
 using api.Services;
 using HotChocolate.Subscriptions;
@@ -34,6 +35,44 @@ namespace api.Schema.Mutations
                 catch (GraphQLException error)
                 {
                     throw error;
+                }
+            }
+        }
+
+        [LeaderUser]
+        public async Task<List<Overtime>> CreateBulkOvertime(CreateBulkOvertimeRequest request, [Service] IHttpContextAccessor _accessor, [Service] OvertimeService _overtimeService, [Service] NotificationService _notificationService, [Service] ITopicEventSender eventSender, [Service] IDbContextFactory<HrisContext> contextFactory)
+        {
+            using (HrisContext context = contextFactory.CreateDbContext())
+            {
+                try
+                {
+                    var httpContext = _accessor.HttpContext;
+                    var leader = (User)httpContext?.Items["User"]!;
+                    using var transaction = context.Database.BeginTransaction();
+
+                    var newOvertimes = await _overtimeService.CreateBulk(request);
+
+                    var notificationList = await _notificationService.createBulkOvertimeNotification(newOvertimes, leader.Id);
+
+                    notificationList.ForEach(notif =>
+                    {
+                        _notificationService.sendOvertimeNotificationEvent(notif);
+                    });
+
+                    transaction.Commit();
+
+                    return newOvertimes;
+                }
+                catch (GraphQLException error)
+                {
+                    throw error;
+                }
+                catch (Exception e)
+                {
+                    throw new GraphQLException(ErrorBuilder.New()
+                    .SetMessage(e.Message)
+                    .SetCode("BAD_REQUEST")
+                    .Build());
                 }
             }
         }

--- a/api/Utils/Validation/OvertimeServiceInputValidation.cs
+++ b/api/Utils/Validation/OvertimeServiceInputValidation.cs
@@ -1,0 +1,43 @@
+using api.Context;
+using api.Enums;
+using api.Requests;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Utils
+{
+    public class OvertimeServiceInputValidation : CustomInputValidation
+    {
+        // constructor
+        public OvertimeServiceInputValidation(IDbContextFactory<HrisContext> contextFactory) : base(contextFactory)
+        {
+
+        }
+
+        public List<IError> checkBulkOvertimeRequestInput(CreateBulkOvertimeRequest request)
+        {
+            var errors = new List<IError>();
+            var index = 0;
+
+            if (!CheckManagerUser(request.ManagerId).Result)
+                errors.Add(buildError(nameof(request.ManagerId), InputValidationMessageEnum.INVALID_MANAGER));
+
+            if (!checkDateFormat(request.Date))
+                errors.Add(buildError(nameof(request.Date), InputValidationMessageEnum.INVALID_DATE));
+
+            if (!checkProjectExist(request.ProjectId))
+                errors.Add(buildError(nameof(request.ProjectId), InputValidationMessageEnum.INVALID_PROJECT, index));
+
+
+            index = 0;
+            request.EmployeeIds?.ForEach(id =>
+            {
+                if (!checkUserExist(id))
+                    errors.Add(buildError(nameof(id), InputValidationMessageEnum.INVALID_USER_ID, index));
+
+                index++;
+            });
+
+            return errors;
+        }
+    }
+}


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-301

## Definition of Done
- [x] Leaders can create bulk overtime requests on behalf of team members
- [x] Create notifications for each member included in the request

## Notes
- [x] There should be existing time entries for requested date

## Pre-condition
- (docker) run `docker compose up db api -d`
- go to `http://localhost:5257/graphql/`
- to create bulk request, run the following mutation
```
mutation ($request: CreateBulkOvertimeRequestInput!) {
  createBulkOvertime(request: $request){
    id
  }
}
  
 # Variables
 {
  "request": {
    "managerId": 70,
    "requestedMinutes": 69,
    "remarks": "testing",
    "employeeIds": [4,5],
    "date": "2023-06-13",
    "projectId":1
  }
}
```
- to monitor notification, run the following subscription
```
subscription {
  overtimeCreated(id: 70) {
    id
    type
    data
    readAt
    isRead
  }
}
```
  

## Expected Output
- Only leaders (positionId = 3, 6, or 7) can create bulk overtime requests
- Overtimes created should be pre-approved by leader
- There should be one notification for every project member included in the request
- Notification data should have `ProjectMember` data

## Screenshots/Recordings
https://github.com/framgia/sph-hris/assets/111718037/e1e98de9-52e2-4b66-b529-a30f01b7482b


