### PR TITLE
HRIS-312 [FE/BE] Fix user cannot login due to the modification of the authentication part of the application

### DIFF
--- a/api/Services/SigninService.cs
+++ b/api/Services/SigninService.cs
@@ -28,7 +28,7 @@ namespace api.Services
                 {
                     HttpClient httpClient = new HttpClient();
                     HttpContext? httpContext = _httpContextAccessor.HttpContext;
-                    string? accessToken = httpContext?.Request.Headers["access_token"];
+                    string? accessToken = httpContext?.Request.Headers["access-token"];
 
                     var response = await httpClient.GetAsync($"https://www.googleapis.com/oauth2/v3/userinfo?access_token={accessToken}");
 

--- a/client/src/utils/shared/client.ts
+++ b/client/src/utils/shared/client.ts
@@ -14,7 +14,7 @@ export const client = new GraphQLClient(process.env.NEXT_PUBLIC_BACKEND_URL as s
       ...request,
       headers: {
         ...request.headers,
-        access_token: accessToken as string,
+        'access-token': accessToken as string,
         authorization: authtoken as string
       }
     }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-312

## Definition of Done
- [x] Rename the `access_token` http header to `access-token`

## Pre-condition


## Expected Output
- User should be able to login in the dev server

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/111718037/970d0c35-cf16-4e18-a602-d6edc1d78cc0


