### PR TITLE
HRIS-311 [Markup] Create Leaves Modal when user a clicks a cell on the Heatmap

### DIFF
--- a/client/src/components/molecules/LeaveCellDetailsModal/ShowReasonModal.tsx
+++ b/client/src/components/molecules/LeaveCellDetailsModal/ShowReasonModal.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react'
+import { BsFileEarmarkText } from 'react-icons/bs'
+
+import Button from '~/components/atoms/Buttons/ButtonAction'
+import ModalTemplate from '~/components/templates/ModalTemplate'
+import ModalFooter from '~/components/templates/ModalTemplate/ModalFooter'
+import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+  remarks: string | undefined
+}
+
+const ShowReasonModal: FC<Props> = ({ isOpen, closeModal, remarks }): JSX.Element => {
+  return (
+    <ModalTemplate
+      {...{
+        isOpen,
+        closeModal
+      }}
+      className="w-full max-w-lg"
+    >
+      {/* Custom Modal Header */}
+      <ModalHeader
+        {...{
+          title: 'View Reason',
+          Icon: BsFileEarmarkText,
+          closeModal
+        }}
+      />
+      {/* Actual Remarks data */}
+      <div className="py-7 px-5 text-sm text-slate-800">{remarks}</div>
+
+      {/* Custom Modal Footer Style */}
+      <ModalFooter>
+        <Button onClick={closeModal} variant="secondary" className="px-5 py-1 text-sm">
+          Close
+        </Button>
+      </ModalFooter>
+    </ModalTemplate>
+  )
+}
+
+ShowReasonModal.defaultProps = {
+  remarks: ''
+}
+
+export default ShowReasonModal

--- a/client/src/components/molecules/LeaveCellDetailsModal/Table.tsx
+++ b/client/src/components/molecules/LeaveCellDetailsModal/Table.tsx
@@ -1,0 +1,102 @@
+import React, { FC } from 'react'
+import classNames from 'classnames'
+import { flexRender, Table } from '@tanstack/react-table'
+
+import TableSkeleton from '../SkeletonTable'
+import AnimatedTable from '~/components/atoms/Table'
+import { LeaveCellDetailTable } from '~/utils/types/leaveTypes'
+
+type Props = {
+  table: Table<LeaveCellDetailTable>
+  query: {
+    isLoading: boolean
+    isError: boolean
+  }
+}
+
+const LeaveCellDetailsTable: FC<Props> = (props) => {
+  const {
+    table,
+    query: { isLoading = false, isError = false }
+  } = props
+
+  return (
+    <AnimatedTable className="w-full min-w-[620px]">
+      <thead className="border-b border-slate-200">
+        {table.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <th key={header.id} colSpan={header.colSpan} className="px-4 py-3 text-left text-sm">
+                {header.isPlaceholder ? null : (
+                  <div
+                    {...{
+                      className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
+                      onClick: header.column.getToggleSortingHandler()
+                    }}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                  </div>
+                )}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody
+        className={classNames(
+          'h-full min-h-[80vh] w-full divide-y divide-slate-200 border-b border-slate-200',
+          table.getPageCount() === 0 || isError ? 'h-[20vh]' : ''
+        )}
+      >
+        <>
+          {!isError ? (
+            isLoading ? (
+              <TableSkeleton rows={4} column={4} />
+            ) : table.getPageCount() === 0 ? (
+              <TableMesagge message="No Data Available" />
+            ) : (
+              <>
+                {table.getRowModel().rows.map((row) => (
+                  <tr
+                    key={row.id}
+                    className={classNames(
+                      'group hover:bg-white hover:shadow-md hover:shadow-slate-200'
+                    )}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id} className="z-20 flex-wrap px-4 py-2 text-xs capitalize">
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </>
+            )
+          ) : (
+            <TableError message="Something went wrong" />
+          )}
+        </>
+      </tbody>
+    </AnimatedTable>
+  )
+}
+
+const TableMesagge = ({ message }: { message: string }): JSX.Element => {
+  return (
+    <tr className="absolute inset-x-0 left-0 right-0 w-full flex-1">
+      <td className="py-2"></td>
+      <td className="w-full py-2 text-center text-xs font-medium text-slate-500">{message}</td>
+      <td className="py-2"></td>
+    </tr>
+  )
+}
+const TableError = ({ message }: { message: string }): JSX.Element => {
+  return (
+    <tr className="absolute inset-x-0 left-0 right-0 w-full flex-1 bg-rose-50">
+      <td className="py-2"></td>
+      <td className="w-full py-2 text-center font-medium  text-rose-500">{message}</td>
+      <td className="py-2"></td>
+    </tr>
+  )
+}
+export default LeaveCellDetailsTable

--- a/client/src/components/molecules/LeaveCellDetailsModal/columns.tsx
+++ b/client/src/components/molecules/LeaveCellDetailsModal/columns.tsx
@@ -1,0 +1,69 @@
+import Tippy from '@tippyjs/react'
+import React, { useState } from 'react'
+import { BsFileEarmarkText } from 'react-icons/bs'
+import { createColumnHelper } from '@tanstack/react-table'
+
+import ShowReasonModal from './ShowReasonModal'
+import Button from '~/components/atoms/Buttons/Button'
+import CellHeader from '~/components/atoms/CellHeader'
+import { getLeaveLabel } from '~/utils/createLeaveHelpers'
+import { LeaveCellDetailTable } from '~/utils/types/leaveTypes'
+
+const columnHelper = createColumnHelper<LeaveCellDetailTable>()
+
+export const columns = [
+  columnHelper.display({
+    id: 'numberCount',
+    header: () => <div className="!font-medium">No.</div>,
+    cell: (props) => parseInt(props.row.id) + 1,
+    footer: (info) => info.column.id
+  }),
+  columnHelper.accessor('typeOfLeave', {
+    header: () => <CellHeader label="Type of leave" className="!font-medium" />,
+    cell: ({ row: { original } }) => getLeaveLabel(original.typeOfLeave),
+    footer: (info) => info.column.id
+  }),
+  columnHelper.accessor('withPay', {
+    header: () => <CellHeader label="Pay?" className="!font-medium" />,
+    cell: (props) => (props.getValue() ? 'With Pay' : 'Without Pay'),
+    footer: (info) => info.column.id
+  }),
+  columnHelper.accessor('numOfLeaves', {
+    header: () => <CellHeader label="No. of leaves" className="!font-medium" />,
+    footer: (info) => info.column.id
+  }),
+  columnHelper.display({
+    id: 'action',
+    header: () => <span className="font-medium">Actions</span>,
+    cell: (props) => {
+      const [isOpen, setIsOpen] = useState<boolean>(false)
+
+      const handleToggle = (): void => setIsOpen(!isOpen)
+
+      return (
+        <div className="inline-flex items-center space-x-1 rounded">
+          <Tippy content="Reason" placement="left" className="!text-xs">
+            <Button
+              type="button"
+              onClick={handleToggle}
+              rounded="none"
+              className="py-0.5 px-1 text-slate-500"
+            >
+              <BsFileEarmarkText className="h-4 w-4" />
+            </Button>
+          </Tippy>
+
+          {/* Show The Reason Modal */}
+          <ShowReasonModal
+            {...{
+              isOpen,
+              closeModal: handleToggle,
+              remarks: props.row.original.reason
+            }}
+          />
+        </div>
+      )
+    },
+    footer: (info) => info.column.id
+  })
+]

--- a/client/src/components/molecules/LeaveCellDetailsModal/index.tsx
+++ b/client/src/components/molecules/LeaveCellDetailsModal/index.tsx
@@ -1,0 +1,108 @@
+import { Calendar } from 'react-feather'
+import React, { FC, useState } from 'react'
+import {
+  SortingState,
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel
+} from '@tanstack/react-table'
+
+import { columns } from './columns'
+import FooterTable from './../FooterTable'
+import LeaveCellDetailsTable from './Table'
+import { fuzzyFilter } from '~/utils/fuzzyFilter'
+import GlobalSearchFilter from './../GlobalSearchFilter'
+import ModalTemplate from '~/components/templates/ModalTemplate'
+import { Chip } from '~/components/templates/LeaveManagementLayout'
+import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+import { dummyCellDetailsData } from '~/utils/constants/dummyMyLeaveCellDetails'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+  selectedDate: {
+    month: string
+    day: number
+    year: number
+  }
+}
+
+const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
+  const {
+    isOpen,
+    closeModal,
+    selectedDate: { month, day, year }
+  } = props
+
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [globalFilter, setGlobalFilter] = useState<string>('')
+
+  const table = useReactTable({
+    data: dummyCellDetailsData ?? [],
+    columns,
+    // Options
+    state: {
+      sorting,
+      globalFilter
+    },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: fuzzyFilter,
+    // Pipeline
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel()
+  })
+
+  return (
+    <ModalTemplate
+      {...{
+        isOpen,
+        closeModal
+      }}
+      className="w-full max-w-3xl"
+    >
+      <ModalHeader
+        {...{
+          title: `Leave for ${month} ${day}, ${year}`,
+          closeModal,
+          Icon: Calendar
+        }}
+      />
+      <div className="text-sm">
+        <header className="flex flex-wrap items-center justify-between gap-y-2 bg-slate-50 px-4 py-2">
+          <GlobalSearchFilter
+            {...{
+              value: globalFilter ?? '',
+              onChange: (value) => setGlobalFilter(String(value)),
+              placeholder: 'Search'
+            }}
+          />
+          <div className="inline-flex items-center space-x-2">
+            <p className="text-slate-700">Total number of leaves</p>
+            <Chip count={26} />
+          </div>
+        </header>
+        <main className="border-t border-slate-200">
+          <div className="default-scrollbar overflow-auto">
+            <LeaveCellDetailsTable
+              {...{
+                table,
+                query: {
+                  isLoading: false,
+                  isError: false
+                }
+              }}
+            />
+          </div>
+          <FooterTable {...{ table }} className="!bg-white text-xs" />
+        </main>
+      </div>
+    </ModalTemplate>
+  )
+}
+
+export default LeaveCellDetailsModal

--- a/client/src/components/molecules/LeaveManagementResultTable/index.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/index.tsx
@@ -14,6 +14,7 @@ import LeaveManagementTable from './Table'
 import Card from '~/components/atoms/Card'
 import MobileDisclose from './MobileDisclose'
 import { LeaveTable } from '~/utils/types/leaveTypes'
+import useScreenCondition from '~/hooks/useScreenCondition'
 
 type Props = {
   query: {
@@ -27,6 +28,9 @@ const LeaveManagementResultTable: FC<Props> = (props): JSX.Element => {
   const {
     query: { isLoading, isError, data }
   } = props
+
+  // SCREEN SIZE CONDITION HOOKS
+  const isMediumScreen = useScreenCondition('(max-width: 768px)')
 
   const [sorting, setSorting] = useState<SortingState>([])
 
@@ -52,29 +56,33 @@ const LeaveManagementResultTable: FC<Props> = (props): JSX.Element => {
   return (
     <div className="flex flex-1 flex-col space-y-1">
       {/* Show on Desktop */}
-      <Card className="hidden overflow-visible md:block" shadow-size="sm">
-        <LeaveManagementTable
-          {...{
-            query: {
-              isLoading,
-              isError
-            },
-            table
-          }}
-        />
-      </Card>
-      {/* Shows on Mobile */}
-      <Card className="block overflow-hidden md:hidden" shadow-size="sm">
-        <MobileDisclose
-          {...{
-            query: {
-              isLoading,
-              isError
-            },
-            table
-          }}
-        />
-      </Card>
+      {!isMediumScreen ? (
+        <Card className="overflow-visible" shadow-size="sm">
+          <LeaveManagementTable
+            {...{
+              query: {
+                isLoading,
+                isError
+              },
+              table
+            }}
+          />
+        </Card>
+      ) : (
+        // Shows on Mobile
+        <Card className="overflow-hidden" shadow-size="sm">
+          <MobileDisclose
+            {...{
+              query: {
+                isLoading,
+                isError
+              },
+              table
+            }}
+          />
+        </Card>
+      )}
+
       {/* Table Pagination & Filtering */}
       <div className="-mx-4">
         {table.getPageCount() >= 1 && (
@@ -88,7 +96,5 @@ const LeaveManagementResultTable: FC<Props> = (props): JSX.Element => {
     </div>
   )
 }
-
-LeaveManagementResultTable.defaultProps = {}
 
 export default LeaveManagementResultTable

--- a/client/src/components/molecules/SummaryFilterDropdown/index.tsx
+++ b/client/src/components/molecules/SummaryFilterDropdown/index.tsx
@@ -86,6 +86,9 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
 
       if (field === NAME_FIELD && router.query.id !== undefined)
         return nameOptions.find((option) => option.value === selectedUser) ?? null
+
+      if (field === LEAVE_FIELD && router.query.id !== undefined)
+        return leaveOptions.find((option) => option.value === selectedUser) ?? null
     }
 
     if (isYearlySummaryTabPage && router.query.year !== undefined) {
@@ -107,7 +110,11 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
           ? data.allUsers[0].id
           : parseInt(router.query.id as string)
       )
-      setSelectedLeave(parseInt(router.query.leave as string))
+      setSelectedLeave(
+        router.query.leave === undefined || router.query.leave === ''
+          ? leaveOptions[0].value
+          : parseInt(router.query.leave as string)
+      )
     }
   }, [isSuccess])
 
@@ -118,7 +125,11 @@ const SummaryFilterDropdown: FC<Props> = (): JSX.Element => {
           ? currentYear
           : parseInt(router.query.year as string)
       )
-      setSelectedLeave(parseInt(router.query.leave as string))
+      setSelectedLeave(
+        router.query.leave === undefined || router.query.leave === ''
+          ? leaveOptions[0].value
+          : parseInt(router.query.leave as string)
+      )
     }
   }, [router])
 

--- a/client/src/components/templates/ModalTemplate/index.tsx
+++ b/client/src/components/templates/ModalTemplate/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
-import React, { Fragment, FC, ReactNode } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
+import React, { Fragment, FC, ReactNode, useRef } from 'react'
 
 type Props = {
   isOpen: boolean
@@ -10,11 +10,12 @@ type Props = {
 }
 
 const ModalTemplate: FC<Props> = (props): JSX.Element => {
+  const refDiv = useRef<HTMLDivElement>(null)
   const { isOpen, closeModal, children, className } = props
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50" onClose={() => closeModal()}>
+      <Dialog as="div" className="relative z-50" onClose={() => closeModal()} initialFocus={refDiv}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"
@@ -43,6 +44,7 @@ const ModalTemplate: FC<Props> = (props): JSX.Element => {
                   className,
                   'transform overflow-hidden rounded-xl bg-white text-left align-middle shadow-xl transition-all'
                 )}
+                ref={refDiv}
               >
                 {children}
               </Dialog.Panel>

--- a/client/src/utils/constants/dummyMyLeaveCellDetails.ts
+++ b/client/src/utils/constants/dummyMyLeaveCellDetails.ts
@@ -1,0 +1,64 @@
+import { LeaveCellDetailTable } from './../types/leaveTypes'
+
+export const dummyCellDetailsData: LeaveCellDetailTable[] = [
+  {
+    typeOfLeave: 1,
+    withPay: true,
+    numOfLeaves: 1,
+    reason: 'I would like to take a leave because I felt like to'
+  },
+  {
+    typeOfLeave: 2,
+    withPay: false,
+    numOfLeaves: 3,
+    reason: 'geeeeeeeeeeeeeeeeeeeeeeeeeeee'
+  },
+  {
+    typeOfLeave: 3,
+    withPay: true,
+    numOfLeaves: 31,
+    reason: 'reeeeeeeeeeeeeeeeeeeeeeeeeeee'
+  },
+  {
+    typeOfLeave: 4,
+    withPay: false,
+    numOfLeaves: 31,
+    reason: 'uyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
+  },
+  {
+    typeOfLeave: 5,
+    withPay: true,
+    numOfLeaves: 1,
+    reason: 'I adsfasdf asdf asdf asdf asdf as'
+  },
+  {
+    typeOfLeave: 6,
+    withPay: false,
+    numOfLeaves: 5,
+    reason: 'gsfhfsgh sf gsdfg sdfg sdfg '
+  },
+  {
+    typeOfLeave: 1,
+    withPay: true,
+    numOfLeaves: 2,
+    reason: 'jkfhkf fgh jfgh jfgh jfghj fg jghj '
+  },
+  {
+    typeOfLeave: 5,
+    withPay: false,
+    numOfLeaves: 1,
+    reason: 'kfherae asdf asd fasf fad fasdf adhssdfg'
+  },
+  {
+    typeOfLeave: 1,
+    withPay: true,
+    numOfLeaves: 4,
+    reason: 'sfdh dgfh dytjdyt jfhkj dsgfh dftgaa df asdf asdf '
+  },
+  {
+    typeOfLeave: 3,
+    withPay: true,
+    numOfLeaves: 1,
+    reason: 'asd fhsfg dfg sdfsg sdfhstrh fsgjhjdg hdfgh dfghdfgh'
+  }
+]

--- a/client/src/utils/createLeaveHelpers.ts
+++ b/client/src/utils/createLeaveHelpers.ts
@@ -3,6 +3,7 @@ import moment from 'moment'
 import { User } from '~/utils/types/userTypes'
 import { LeaveType } from './types/leaveTypes'
 import { ProjectDetails } from './types/projectTypes'
+import { leaveOptions } from './constants/leaveOptions'
 import { IUnusedESLOffset } from './interfaces/unusedELSOffsetInterface'
 
 export type SelectOptionType = {
@@ -41,3 +42,8 @@ export const generateUnusedESLDateSelect = (
     })`,
     value: item.id.toString()
   }))
+
+export const getLeaveLabel = (typeOfLeave: number): string => {
+  const leaveType = leaveOptions.find((option) => option.value === typeOfLeave)
+  return leaveType !== undefined ? leaveType.label : ''
+}

--- a/client/src/utils/generateData.ts
+++ b/client/src/utils/generateData.ts
@@ -4,6 +4,7 @@ export type Series = {
   x: string
   y: number
 }
+
 export const generateData = (count: number, yrange: { min: number; max: number }): any[] => {
   let i = 0
   const series = []
@@ -15,6 +16,7 @@ export const generateData = (count: number, yrange: { min: number; max: number }
   }
   return series
 }
+
 export const getHeatmapData = (count: number, heatmap: HeatmapDetails[]): Series[] => {
   let i = 0
   const series = []
@@ -28,6 +30,25 @@ export const getHeatmapData = (count: number, heatmap: HeatmapDetails[]): Series
     i++
   }
   return series
+}
+
+export type ConfigApexChart = {
+  config: {
+    series: ISeries[]
+  }
+  seriesIndex: number
+  dataPointIndex: number
+}
+
+type ISeries = {
+  name: string
+  data: IData[]
+}
+
+type IData = {
+  x: string
+  y: number
+  leaveName: number | null | string
 }
 
 export const initialChartOptions = {

--- a/client/src/utils/types/leaveTypes.ts
+++ b/client/src/utils/types/leaveTypes.ts
@@ -53,6 +53,14 @@ export type LeaveTable = {
   leaveId: number
   createdAt: string
 }
+
+export type LeaveCellDetailTable = {
+  typeOfLeave: number
+  withPay: boolean
+  numOfLeaves: number
+  reason: string
+}
+
 export type Breakdown = {
   sickLeave: number
   undertime: number


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-311

## Definition of Done

- [x] Created `LeaveCellDetailsModal` Component
    - [x]  Reused and applied to `My Leaves` and `Leave Management` Tab Pages
- [x] Created `Table` and `ShowReasonModal` for the Cells Details
- [x] Created Isolated Click Event for Triggering Modal in the Heatmap Chart  in each pages
- [x] Added Dynamic Date based on the selected/clicked cell in the chart 
- [x] Fixed bug in the Leave management filter for initial leave which default to `0` or `all` 

## Notes

- Client Request
- For the meantime, any cells will be clickable even if the cell is empty and I will experiment how to prevent it in the near future

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet watch`
- goto `my-leaves`, `/leave-management/leave-summary` and `/leave-management/yearly-summary`

## Expected Output

- User will able to click the cell in the heatmap and will show the markup design for Leave Modal Details

## Screenshots/Recordings

[leave heatmap cell.webm](https://github.com/framgia/sph-hris/assets/108642414/23906f38-815e-4022-b142-f54740951d93)


