### PR TITLE
HRIS-313 [FE] Fix table search functionality in DTR Management Page

### DIFF
--- a/api/DTOs/OvertimeDTO.cs
+++ b/api/DTOs/OvertimeDTO.cs
@@ -24,7 +24,7 @@ namespace api.DTOs
         new public Over? User { get; set; }
         new public int Id { get; set; }
         public ICollection<MultiProject> Projects { get; set; } = default!;
-        new public string OtherProject { get; set; } = default!;
+        new public string? OtherProject { get; set; } = default!;
         public string Supervisor { get; set; }
         public DateTime? DateFiled { get; set; }
         new public string Remarks { get; set; }

--- a/client/src/components/molecules/DTRManagementTable/columns.tsx
+++ b/client/src/components/molecules/DTRManagementTable/columns.tsx
@@ -21,7 +21,7 @@ const columnHelper = createColumnHelper<ITimeEntry>()
 const EMPTY = 'N/A'
 
 export const columns = [
-  columnHelper.accessor('user', {
+  columnHelper.accessor('user.name', {
     header: () => <CellHeader label="Name" />,
     footer: (info) => info.column.id,
     cell: (props) => {
@@ -50,7 +50,7 @@ export const columns = [
     footer: (info) => info.column.id,
     cell: (props) => <WorkStatusChip label={props.getValue()} />
   }),
-  columnHelper.accessor('timeIn.timeHour', {
+  columnHelper.accessor((row) => row.timeIn?.timeHour, {
     id: 'Time In',
     header: () => <CellHeader label="Time In" />,
     footer: (info) => info.column.id,
@@ -101,7 +101,8 @@ export const columns = [
       )
     }
   }),
-  columnHelper.accessor('timeOut.timeHour', {
+  columnHelper.accessor((row) => row.timeOut?.timeHour, {
+    id: 'Time Out',
     header: () => <CellHeader label="Time Out" />,
     footer: (info) => info.column.id,
     cell: (props) => {


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-313

## Definition of Done
- [x] Fixed global filtering in DTR Management page

## Notes
- Also added fix for query in Overtime Management page

## Pre-condition
- (docker) run `docker compose up db api client -d`
- go to DTR Management page

## Expected Output
- The global filter for DTR Management page should be working now

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/111718037/72f49e59-88bc-47e4-a2e2-47aff1268e63


