### PR TITLE
HRIS-318 [FE] Re-align the toast notification to be at the bottom of the navbar

### DIFF
--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -12,7 +12,7 @@ const MyApp = ({ Component, pageProps }: AppProps): JSX.Element => {
   return (
     <SessionProvider>
       <NextProgress />
-      <Toaster position="top-right" reverseOrder={false} />
+      <Toaster position="top-right" reverseOrder={false} containerStyle={{ top: 60 }} />
       <QueryClientProvider client={queryClient}>
         <Component {...pageProps} />
       </QueryClientProvider>


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-318

## Definition of Done

- [x] Re-aligned the toast notification message to be at the bottom of the nvabar

## Notes

- Client Request
- Style Guide: https://react-hot-toast.com/docs/styling

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet watch`

## Expected Output

- Any toast message are re-aligned to be at the bottom of the navbar

## Screenshots/Recordings

[toast notification message.webm](https://github.com/framgia/sph-hris/assets/108642414/67335967-91dc-48c9-bbda-327bf0a39b5c)
