### PR TITLE
HRIS-316 [BE/FE] Integrate new filter for summarized overtime in HR Admin page

### DIFF
--- a/api/Enums/SuccessMessageEnum.cs
+++ b/api/Enums/SuccessMessageEnum.cs
@@ -9,7 +9,7 @@ namespace api.Enums
         public const string EMPLOYEE_SCHEDULE_UPDATED = "Employee schedule sccessfully updated!";
         public const string LEAVE_UPDATED = "Leave successfully updated!";
         public const string LEAVE_CANCELLED = "Leave successfully cancelled";
-        public const string OVERTIME_SUMMARY_SUBMITTED = "Overtime summary request submitted";
+        public const string OVERTIME_SUMMARY_SUBMITTED = "Summary request submitted";
         public const string OVERTIME_SUMMARY_REVIEW_SUBMITTED = "Review submitted";
     }
 }

--- a/api/Requests/CreateSummaryRequest.cs
+++ b/api/Requests/CreateSummaryRequest.cs
@@ -2,7 +2,6 @@ namespace api.Requests
 {
     public class CreateSummaryRequest
     {
-        public int ManagerId { get; set; }
         public string StartDate { get; set; } = default!;
         public string EndDate { get; set; } = default!;
     }

--- a/api/Schema/Mutations/OvertimeMutation.cs
+++ b/api/Schema/Mutations/OvertimeMutation.cs
@@ -45,9 +45,9 @@ namespace api.Schema.Mutations
 
                 var summarizedOvertime = _overtimeService.CreateSummary(overtimeSummary);
 
-                var notificationList = await _notificationService.CreateSummarizedOvertimeNotification(summarizedOvertime, context);
+                var notificationLists = await _notificationService.CreateSummarizedOvertimeNotification(summarizedOvertime, context);
 
-                _notificationService.SendSummarizedOvertimeNotificationEvent(notificationList);
+                notificationLists.ForEach(notificationList => _notificationService.SendSummarizedOvertimeNotificationEvent(notificationList));
 
                 transaction.Commit();
 
@@ -74,10 +74,7 @@ namespace api.Schema.Mutations
 
                     var notificationList = await _notificationService.createBulkOvertimeNotification(newOvertimes, leader.Id);
 
-                    notificationList.ForEach(notif =>
-                    {
-                        _notificationService.sendOvertimeNotificationEvent(notif);
-                    });
+                    notificationList.ForEach(notif => _notificationService.sendOvertimeNotificationEvent(notif));
 
                     transaction.Commit();
 

--- a/api/Utils/Validation.cs
+++ b/api/Utils/Validation.cs
@@ -344,9 +344,6 @@ namespace api.Utils
         {
             var errors = new List<IError>();
 
-            if (!CheckManagerPosition(overtime.ManagerId).Result)
-                errors.Add(buildError(nameof(overtime.ManagerId), InputValidationMessageEnum.INVALID_MANAGER));
-
             if (!checkDateFormat(overtime.StartDate))
                 errors.Add(buildError(nameof(overtime.StartDate), InputValidationMessageEnum.INVALID_DATE));
 

--- a/client/src/components/molecules/MyOvertimeTable/OptionDropdown.tsx
+++ b/client/src/components/molecules/MyOvertimeTable/OptionDropdown.tsx
@@ -8,7 +8,7 @@ import FilterDropdownTemplate from '~/components/templates/FilterDropdownTemplat
 import SummaryConfirmationModal from '../OvertimeManagementTable/SummaryConfirmationModal'
 
 type Props = {
-  data: IOvertimeManagement[]
+  data: IOvertimeManagement[] | undefined
 }
 
 const OptionDropdown: FC<Props> = ({ data }): JSX.Element => {

--- a/client/src/components/molecules/NotificationList/NotificationItem.tsx
+++ b/client/src/components/molecules/NotificationList/NotificationItem.tsx
@@ -18,7 +18,7 @@ import useNotification from '~/hooks/useNotificationQuery'
 import { switchMessage } from '~/utils/notificationHelpers'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import useNotificationMutation from '~/hooks/useNotificationMutation'
-import { NOTIFICATION_TYPE } from '~/utils/constants/notificationTypes'
+import { NOTIFICATION_TYPE, SpecificType } from '~/utils/constants/notificationTypes'
 
 type Props = {
   table: Table<INotification>
@@ -48,7 +48,13 @@ const NotificationItem: FC<Props> = ({ table, isLoading }): JSX.Element => {
   }, [id])
 
   const handleViewDetails = (row: INotification): void => {
-    void router.push(`/notifications/?id=${row.id}`)
+    const { startDate, endDate, specificType, id } = row
+    const isSummary = specificType === SpecificType.SUMMARY
+    if (isSummary) {
+      void router.push(`/overtime-management?startDate=${startDate}&endDate=${endDate}`)
+    } else {
+      void router.push(`/notifications/?id=${id}`)
+    }
   }
 
   const handleLink = (row: INotification): void => {

--- a/client/src/components/molecules/OvertimeManagementTable/SummaryConfirmationModal.tsx
+++ b/client/src/components/molecules/OvertimeManagementTable/SummaryConfirmationModal.tsx
@@ -19,7 +19,7 @@ import { IManagerApproveOvertimeRequestInput } from '~/utils/types/overtimeTypes
 type Props = {
   isOpen: boolean
   closeModal: () => void
-  summary: IOvertimeManagement[]
+  summary: IOvertimeManagement[] | undefined
   state: boolean
 }
 
@@ -50,21 +50,23 @@ const SummaryConfirmationModal: FC<Props> = ({
 
   // This will handle Submit and Save New Overtime
   const handleSave: SubmitHandler<ApproveFormValues> = async (data): Promise<void> => {
-    const mappedOvertimeSummary = summary.map((x) => {
-      const mapped: IManagerApproveOvertimeRequestInput = {
-        userId: id as number,
-        overtimeId: x.id,
-        approvedMinutes: x.requestedMinutes,
-        isApproved: state,
-        managerRemarks: data.managerRemarks
-      }
-      return mapped
-    })
-    await approveOvertimeSummaryMutation.mutateAsync(mappedOvertimeSummary, {
-      onSuccess: () => {
-        void closeModal()
-      }
-    })
+    if (summary !== undefined) {
+      const mappedOvertimeSummary = summary?.map((x) => {
+        const mapped: IManagerApproveOvertimeRequestInput = {
+          userId: id as number,
+          overtimeId: x.id,
+          approvedMinutes: x.requestedMinutes,
+          isApproved: state,
+          managerRemarks: data.managerRemarks
+        }
+        return mapped
+      })
+      await approveOvertimeSummaryMutation.mutateAsync(mappedOvertimeSummary, {
+        onSuccess: () => {
+          void closeModal()
+        }
+      })
+    }
   }
 
   const statement = 'Do you want to approve the requested overtime summary?'

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -30,7 +30,8 @@ import { NotificationRequestInput, NotificationData } from '~/utils/types/notifi
 import {
   getChangeShiftNotificationSubQuery,
   getLeaveNotificationSubQuery,
-  getOvertimeNotificationSubQuery
+  getOvertimeNotificationSubQuery,
+  getSummaryOvertimeNotification
 } from '~/graphql/subscriptions/leaveSubscription'
 import useScreenCondition from '~/hooks/useScreenCondition'
 import { getESLOffsetNotificationSubscription } from '~/graphql/subscriptions/eslOffsetSubscription'
@@ -255,6 +256,19 @@ const Header: FC<Props> = (props): JSX.Element => {
     clientWebsocket.subscribe(
       {
         query: getFileOffsetNotificationSubscription(userId)
+      },
+      {
+        next: ({ data }: any) => {
+          void queryClient.invalidateQueries({ queryKey: ['GET_ALL_USER_NOTIFICATION'] })
+        },
+        error: () => null,
+        complete: () => null
+      }
+    )
+
+    clientWebsocket.subscribe(
+      {
+        query: getSummaryOvertimeNotification(userId)
       },
       {
         next: ({ data }: any) => {

--- a/client/src/graphql/mutations/overtimeMutation.ts
+++ b/client/src/graphql/mutations/overtimeMutation.ts
@@ -26,3 +26,9 @@ export const APROVE_DISAPPROVE_OVERTIME_SUMMARY_MUTATION = gql`
     approveDisapproveAllOvertimeSummary(approvingDatas: $approveOvertimeRequests)
   }
 `
+
+export const CREATE_OVERTIME_SUMMARY_MUTATION = gql`
+  mutation ($overtimeSummary: CreateSummaryRequestInput!) {
+    createSummarizedOvertime(overtimeSummary: $overtimeSummary)
+  }
+`

--- a/client/src/graphql/subscriptions/leaveSubscription.ts
+++ b/client/src/graphql/subscriptions/leaveSubscription.ts
@@ -33,3 +33,14 @@ export const getChangeShiftNotificationSubQuery = (id: number): string => `
     }
   }
 `
+export const getSummaryOvertimeNotification = (id: number): string => `
+subscription {
+  overtimeSummaryCreated(id: ${id}) {
+    id
+    type
+    data
+    readAt
+    isRead
+  }
+}
+`

--- a/client/src/hooks/useOvertime.ts
+++ b/client/src/hooks/useOvertime.ts
@@ -12,6 +12,7 @@ import { GET_ALL_OVERTIME } from '~/graphql/queries/overtimeQuery'
 import {
   CREATE_OVERTIME_MUTATION,
   CREATE_BULK_OVERTIME_MUTATION,
+  CREATE_OVERTIME_SUMMARY_MUTATION,
   APROVE_DISAPPROVE_OVERTIME_MUTATION,
   APROVE_DISAPPROVE_OVERTIME_SUMMARY_MUTATION
 } from '~/graphql/mutations/overtimeMutation'
@@ -20,6 +21,7 @@ import {
   IOvertimeRequestInput,
   IBulkOvertimeRequestInput,
   ILeaderApproveOvertimeRequestInput,
+  ICreateOvertimeSummaryRequestInput,
   IManagerApproveOvertimeRequestInput
 } from '~/utils/types/overtimeTypes'
 
@@ -48,11 +50,18 @@ type handleLeaderApproveOvertimeMutationType = UseMutationResult<
   ILeaderApproveOvertimeRequestInput,
   unknown
 >
+type handleCreateOvertimeSummaryMutationType = UseMutationResult<
+  any,
+  unknown,
+  ICreateOvertimeSummaryRequestInput,
+  unknown
+>
 
 type returnType = {
   handleOvertimeMutation: () => handleOvertimeMutationType
-  handleLeaderApproveOvertimeMutation: () => handleLeaderApproveOvertimeMutationType
   handleBulkOvertimeMutation: () => handleBulkOvertimeMutationType
+  handleLeaderApproveOvertimeMutation: () => handleLeaderApproveOvertimeMutationType
+  handleCreateOvertimeSummaryMutation: () => handleCreateOvertimeSummaryMutationType
   handleManagerApproveOvertimeMutation: () => handleManagerApproveOvertimeMutationType
   handleManagerApproveOvertimesSummaryMutation: () => handleManagerApproveOvertimeSummaryMutationType
 }
@@ -149,11 +158,27 @@ const useOvertime = (): returnType => {
       }
     })
 
+  const handleCreateOvertimeSummaryMutation = (): handleCreateOvertimeSummaryMutationType =>
+    useMutation({
+      mutationFn: async (data: ICreateOvertimeSummaryRequestInput) => {
+        return await client.request(CREATE_OVERTIME_SUMMARY_MUTATION, {
+          overtimeSummary: data
+        })
+      },
+      onSuccess: async (data) => {
+        toast.success(data.createSummarizedOvertime)
+      },
+      onError: async () => {
+        toast.error('Something went wrong')
+      }
+    })
+
   return {
     handleOvertimeMutation,
-    handleLeaderApproveOvertimeMutation,
-    handleManagerApproveOvertimeMutation,
     handleBulkOvertimeMutation,
+    handleLeaderApproveOvertimeMutation,
+    handleCreateOvertimeSummaryMutation,
+    handleManagerApproveOvertimeMutation,
     handleManagerApproveOvertimesSummaryMutation
   }
 }

--- a/client/src/utils/types/overtimeTypes.ts
+++ b/client/src/utils/types/overtimeTypes.ts
@@ -120,3 +120,8 @@ export interface ILeaderApproveOvertimeRequestInput {
   notificationId: number
   isApproved: boolean
 }
+
+export interface ICreateOvertimeSummaryRequestInput {
+  startDate: string | undefined | string[]
+  endDate: string | undefined | string[]
+}


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-316

## Definition of Done

- [x] Users can view the overtime request available on given dates
- [x] Can send a summary request to manager(s)
- [x] Manager can receive notification

## Notes
- HR Admin user

## Pre-condition
- (docker) run ``` docker compose up api db client -d```
- Go to ```http://localhost:3000/overtime-management```
- Change the filter days time sheet range


## Expected Output
- Choosing a range should filter the list of overtime base on date filed
- A button for ```send summary``` should appear
- Hitting ``` send summary ``` should disable the button

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/109492180/c5968f68-58d4-45bf-b1ef-f1e93945dcb0


