### PR TITLE
HRIS-321 [Bugfix] Fix displayed filed leaves of the clicked cell in the heat map data

### DIFF
--- a/api/DTOs/LeavesDTO.cs
+++ b/api/DTOs/LeavesDTO.cs
@@ -15,7 +15,7 @@ namespace api.DTOs
         {
             Heatmap = heatmapLeaves;
             User = user;
-            Table = table.OrderByDescending(table => table.CreatedAt).ToList();
+            Table = table.OrderBy(table => table.CreatedAt).ToList();
             Breakdown = new LeaveBreakdownDTO(table);
             TotalNumberOfFiledLeaves = table.Select(table => table.NumLeaves).ToList().Sum();
         }

--- a/client/src/components/molecules/AddNewLeaveModal/LeaveTab.tsx
+++ b/client/src/components/molecules/AddNewLeaveModal/LeaveTab.tsx
@@ -147,19 +147,11 @@ const LeaveTab: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
         },
         {
           onSuccess: () => {
-            void queryClient
-              .invalidateQueries({
-                queryKey: [
-                  'GET_MY_LEAVES_QUERY',
-                  user?.userById.id as number,
-                  parseInt(router.query.year as string)
-                ]
-              })
-              .then(() => {
-                resolve()
-                closeModal()
-                toast.success('Leave request filed successfully!')
-              })
+            void queryClient.invalidateQueries().then(() => {
+              resolve()
+              closeModal()
+              toast.success('Leave request filed successfully!')
+            })
           }
         }
       )

--- a/client/src/components/molecules/AddNewLeaveModal/UndertimeTab.tsx
+++ b/client/src/components/molecules/AddNewLeaveModal/UndertimeTab.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import toast from 'react-hot-toast'
 import ReactSelect from 'react-select'
 import { useRouter } from 'next/router'
 import { Tab } from '@headlessui/react'
@@ -31,6 +32,7 @@ import {
   generateNumberOfDaysSelect,
   generateProjectsMultiSelect
 } from '~/utils/createLeaveHelpers'
+import { queryClient } from '~/lib/queryClient'
 
 type Props = {
   isOpen: boolean
@@ -114,46 +116,47 @@ const UndertimeTab: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
 
   // This will handle form submit and save
   const handleSave = async (data: UndertimeFormValues): Promise<void> => {
-    return await new Promise((resolve) => {
-      // Other Project Name
-      const others = data.projects.map(
-        (project) => project.project_name.__isNew__ === true && project.project_name.value
-      )
+    // Other Project Name
+    const others = data.projects.map(
+      (project) => project.project_name.__isNew__ === true && project.project_name.value
+    )
 
-      leaveMutation.mutate(
-        {
-          userId: user?.userById.id as number,
-          leaveTypeId: LeaveTypes.UNDERTIME,
-          managerId: parseInt(data.manager.value),
-          reason: data.reason,
-          otherProject: others.filter((value) => value !== false).toString(),
-          leaveProjects: data.projects.map((project) => {
-            const otherProjectType = projects?.projects.find(
-              (project) => project.name.toLowerCase() === 'others'
-            ) as ProjectDetails
+    await leaveMutation.mutateAsync(
+      {
+        userId: user?.userById.id as number,
+        leaveTypeId: LeaveTypes.UNDERTIME,
+        managerId: parseInt(data.manager.value),
+        reason: data.reason,
+        otherProject: others.filter((value) => value !== false).toString(),
+        leaveProjects: data.projects.map((project) => {
+          const otherProjectType = projects?.projects.find(
+            (project) => project.name.toLowerCase() === 'others'
+          ) as ProjectDetails
 
-            return {
-              projectId: (project.project_name.__isNew__ as boolean)
-                ? otherProjectType.id
-                : parseInt(project.project_name.value),
-              projectLeaderId: parseInt(project.project_leader.value)
-            }
-          }),
-          leaveDates: [
-            {
-              leaveDate: data.undertime_leave_date,
-              isWithPay: false,
-              days: parseFloat(data.number_of_days_in_leave_undertime.value)
-            }
-          ]
-        },
-        {
-          onSuccess: () => closeModal()
+          return {
+            projectId: (project.project_name.__isNew__ as boolean)
+              ? otherProjectType.id
+              : parseInt(project.project_name.value),
+            projectLeaderId: parseInt(project.project_leader.value)
+          }
+        }),
+        leaveDates: [
+          {
+            leaveDate: data.undertime_leave_date,
+            isWithPay: false,
+            days: parseFloat(data.number_of_days_in_leave_undertime.value)
+          }
+        ]
+      },
+      {
+        onSuccess: () => {
+          void queryClient.invalidateQueries().then(() => {
+            closeModal()
+            toast.success('Leave request filed successfully!')
+          })
         }
-      )
-
-      resolve()
-    })
+      }
+    )
   }
 
   useEffect(() => {

--- a/client/src/components/molecules/LeaveCellDetailsModal/index.tsx
+++ b/client/src/components/molecules/LeaveCellDetailsModal/index.tsx
@@ -53,6 +53,7 @@ const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
 
   const dateCell: string = `${month} ${day}, ${year}`
   const isReady = !isEmpty(month) && day !== 0
+  const isReadyYearly = isMyLeave === false
 
   // LEAVE HOOKS -> getLeavesByDate
   const { getLeaveByDateQuery } = useLeave()
@@ -68,7 +69,7 @@ const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
     data: leavesByDateYearly,
     isLoading: isLeavesLoadingYearly,
     isError: isLeavesErrorYearly
-  } = getYearlyLeaveByDateQuery(dateCell, isReady)
+  } = getYearlyLeaveByDateQuery(dateCell, isReadyYearly)
 
   useEffect(() => {
     if ((!isLeavesLoading && !isLeavesError) || (!isLeavesLoadingYearly && !isLeavesErrorYearly)) {
@@ -76,8 +77,8 @@ const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
         id: index + 1,
         userName: item.userName,
         typeOfLeave: getLeaveLabel(item.leaveTypeId),
-        withPay: item.isWithPay ? 'With Pay' : 'WiThout Pay',
-        numOfLeaves: item.numLeaves.toString(),
+        withPay: item.isWithPay ? 'With Pay' : 'Without Pay',
+        numOfLeaves: parseFloat(item.numLeaves.toFixed(2)).toString(),
         reason: item.reason
       }))
 
@@ -86,8 +87,8 @@ const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
           id: index + 1,
           userName: item.userName,
           typeOfLeave: getLeaveLabel(item.leaveTypeId),
-          withPay: item.isWithPay ? 'With Pay' : 'WiThout Pay',
-          numOfLeaves: item.numLeaves.toString(),
+          withPay: item.isWithPay ? 'With Pay' : 'Without Pay',
+          numOfLeaves: parseFloat(item.numLeaves.toFixed(2)).toString(),
           reason: item.reason
         })
       )
@@ -146,14 +147,14 @@ const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
           />
           <div className="inline-flex items-center space-x-2">
             <p className="text-slate-700">Total number of filed leaves</p>
-            {isLeavesLoading || isLeavesLoadingYearly ? (
+            {isLeavesLoading && isLeavesLoadingYearly ? (
               <SpinnerIcon className="h-4 w-4 fill-amber-500" />
             ) : (
               <Chip count={totNumFiledLeaves} />
             )}
           </div>
         </header>
-        {isLeavesLoading || isLeavesLoadingYearly ? (
+        {isLeavesLoading && isLeavesLoadingYearly ? (
           <div className="flex min-h-[10vh] items-center justify-center">
             <PulseLoader color="#ffb40b" size={8} />
           </div>

--- a/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
+++ b/client/src/components/molecules/LeaveManagementResultTable/columns.tsx
@@ -96,7 +96,6 @@ export const columns = [
     cell: (props) => {
       const router = useRouter()
       const { pathname } = router
-      const { year } = router.query
       const { userId } = props.row.original
       const leaveId = props.row.original.leaveId
       const { handleCancelLeaveMutation } = useLeave()
@@ -144,13 +143,9 @@ export const columns = [
                         { userId, leaveId },
                         {
                           onSuccess: ({ cancelLeave }) => {
-                            void queryClient
-                              .invalidateQueries({
-                                queryKey: ['GET_MY_LEAVES_QUERY', userId, Number(year)]
-                              })
-                              .then(() => {
-                                toast.success(cancelLeave)
-                              })
+                            void queryClient.invalidateQueries().then(() => {
+                              toast.success(cancelLeave)
+                            })
                           }
                         }
                       )

--- a/client/src/hooks/useLeave.ts
+++ b/client/src/hooks/useLeave.ts
@@ -2,6 +2,7 @@ import { toast } from 'react-hot-toast'
 import { useMutation, UseMutationResult, useQuery, UseQueryResult } from '@tanstack/react-query'
 
 import { client } from '~/utils/shared/client'
+import { queryClient } from '~/lib/queryClient'
 import {
   GET_LEAVES_BY_DATE,
   GET_MY_LEAVES_QUERY,
@@ -14,13 +15,13 @@ import {
   Leaves,
   LeaveTypes,
   IUserLeave,
+  LeaveByDate,
   YearlyLeaves,
   LeaveRequest,
+  YearlyLeaveByDate,
   UpdateLeaveRequest,
   CancelLeaveRequest,
-  IApproveLeaveUndertimeRequestInput,
-  LeaveByDate,
-  YearlyLeaveByDate
+  IApproveLeaveUndertimeRequestInput
 } from '~/utils/types/leaveTypes'
 import {
   CREATE_LEAVE_MUTATION,
@@ -107,6 +108,9 @@ const useLeave = (): HookReturnType => {
       },
       onError: async () => {
         toast.error('Something went wrong')
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries()
       }
     })
 
@@ -160,6 +164,9 @@ const useLeave = (): HookReturnType => {
         return await client.request(CANCEL_LEAVE_MUTATION, {
           request
         })
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries()
       },
       onError: async (err: Error) => {
         const [errorMessage] = err.message.split(/:\s/, 2)

--- a/client/src/utils/createLeaveHelpers.ts
+++ b/client/src/utils/createLeaveHelpers.ts
@@ -23,7 +23,9 @@ export const generateUserSelect = (users: User[]): SelectOptionType[] =>
   users?.map((user) => ({ label: user?.name, value: user?.id.toString() }))
 
 export const generateLeaveTypeSelect = (types: LeaveType[]): SelectOptionType[] =>
-  types?.map((type) => ({ label: type.name, value: type.id.toString() }))
+  types
+    ?.filter((item) => item.name !== 'Undertime')
+    ?.map((type) => ({ label: type.name, value: type.id.toString() }))
 
 export const generateNumberOfDaysSelect = (
   types: Array<{ id: number; value: string }>


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-321

## Definition of Done

- [x] Fix the displayed data in the heatmap cell when fetching leaves
- [x] Invalidated queries for File Leave and Cancel Leave but not Edit Leave 
- [x] Add Ascending Order on Leaves Query 
- [x] When filing leaves the type of leave dropdown "Undertime" value is removed 

## Notes

- Not yet fixed the invalidate queries for edit leave

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet watch`

## Expected Output

- Any User should be able to view the data when clicking the heatmap cell
- Data should be ascending order

## Screenshots/Recordings
[fix.webm](https://github.com/framgia/sph-hris/assets/108642414/673358e9-067d-495a-87b4-7db08a00c663)
