### PR TITLE
HRIS-320 [Bugfix] Inaccurate value  computation of Work Hours in My DTR and DTR Management

### DIFF
--- a/api/Services/TimeOutService.cs
+++ b/api/Services/TimeOutService.cs
@@ -70,8 +70,17 @@ namespace api.Services
 
         private string? GetWorkedHours(TimeEntry timeEntry)
         {
-            var workedHours = timeEntry.TimeOut?.TimeHour - timeEntry.TimeIn?.TimeHour;
-            return workedHours.ToString();
+            string? workedHours = null;
+            TimeSpan? totalTimeSpan = timeEntry.TimeOut?.CreatedAt - timeEntry.TimeIn?.CreatedAt;
+
+            if (totalTimeSpan != null)
+            {
+                var duration = (TimeSpan)totalTimeSpan;
+                var totalDays = duration.Days;
+                var totalHours = duration.Hours + (24 * totalDays);
+                workedHours = $"{totalHours}:{duration.ToString(@"mm\:ss")}";
+            }
+            return workedHours;
         }
     }
 }


### PR DESCRIPTION
## Issue Link
https://framgiaph.backlog.com/view/HRIS-320

## Definition of Done
- [x] Corrected computation of Work Hours on Clock Out

## Pre-condition
- (docker) run `docker compose up db api client -d`
- There should be Time In from previous day

## Expected Output
- When user clocked-out the next day, the worked hours value should be computed correctly

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/111718037/3ccefd52-84cc-4c76-be28-5f86a536661e


