### PR TITLE
[FE] Add Canceling Text Indicator in Confirm Alert Modal

### DIFF
--- a/client/src/components/molecules/InterruptionTimeEntriesModal/columns.tsx
+++ b/client/src/components/molecules/InterruptionTimeEntriesModal/columns.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment'
 import Tippy from '@tippyjs/react'
+import toast from 'react-hot-toast'
 import { useRouter } from 'next/router'
 import { Edit, Trash } from 'react-feather'
 import React, { useRef, useState } from 'react'
@@ -57,10 +58,22 @@ export const columns = [
       }
 
       // Actual Deletion
-      const handleYesDeleteRemark = (remarkId: string | number, onClose: () => void): void => {
-        if (deleteButtonRef.current !== undefined) {
-          deleteInterruption.mutate({ id: remarkId as number })
-          onClose()
+      const handleYesDeleteRemark = async (
+        remarkId: string | number,
+        onClose: () => void
+      ): Promise<void> => {
+        if (deleteButtonRef.current !== null) {
+          try {
+            deleteButtonRef.current.innerHTML = 'Deleting...'
+            await deleteInterruption.mutateAsync({ id: remarkId as number })
+          } catch {
+            toast.error('Something went wrong')
+          } finally {
+            if (deleteButtonRef.current !== null) {
+              deleteButtonRef.current.innerHTML = 'Yes'
+              onClose()
+            }
+          }
         }
       }
 
@@ -81,7 +94,9 @@ export const columns = [
                   </button>
                   <button
                     ref={deleteButtonRef}
-                    onClick={() => handleYesDeleteRemark(remarkId, onClose)}
+                    onClick={() => {
+                      void handleYesDeleteRemark(remarkId, onClose)
+                    }}
                     className="rounded-lg bg-blue-500 py-1 px-6 transition duration-100 ease-in-out hover:bg-blue-600"
                   >
                     Yes
@@ -141,7 +156,9 @@ export const columns = [
           </Tippy>
           <Tippy content="Delete" placement="right" className="!text-xs">
             <Button
-              onClick={() => handleConfirmDeleteRemark(interruptionTimeEntry.id)}
+              onClick={() => {
+                void handleConfirmDeleteRemark(interruptionTimeEntry.id)
+              }}
               disabled={checkStatus}
               rounded="none"
               className="py-0.5 px-1 text-slate-500"

--- a/client/src/components/molecules/LeaveCellDetailsModal/index.tsx
+++ b/client/src/components/molecules/LeaveCellDetailsModal/index.tsx
@@ -52,8 +52,8 @@ const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
   const [leaveData, setLeaveData] = useState<LeaveCellDetailTable[]>()
 
   const dateCell: string = `${month} ${day}, ${year}`
-  const isReady = !isEmpty(month) && day !== 0
-  const isReadyYearly = isMyLeave === false
+  const isReady = !isEmpty(month) && day !== 0 && isMyLeave === true // Query will enable on My Leaves Page
+  const isReadyYearly = isMyLeave === false // Query will enable on Leave Summary and Yearly Summary
 
   // LEAVE HOOKS -> getLeavesByDate
   const { getLeaveByDateQuery } = useLeave()
@@ -72,7 +72,7 @@ const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
   } = getYearlyLeaveByDateQuery(dateCell, isReadyYearly)
 
   useEffect(() => {
-    if ((!isLeavesLoading && !isLeavesError) || (!isLeavesLoadingYearly && !isLeavesErrorYearly)) {
+    if (isReady && isOpen) {
       const leaveData = leavesByDate?.leavesByDate?.table.map((item, index) => ({
         id: index + 1,
         userName: item.userName,
@@ -82,6 +82,13 @@ const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
         reason: item.reason
       }))
 
+      setTotNumFiledLeaves(leavesByDate?.leavesByDate?.totalNumberOfFiledLeaves)
+      setLeaveData(leaveData ?? [])
+    }
+  }, [isLeavesLoading, isOpen])
+
+  useEffect(() => {
+    if (isReadyYearly && isOpen) {
       const leaveDatayearly = leavesByDateYearly?.yearlyAllLeavesByDate?.table.map(
         (item, index) => ({
           id: index + 1,
@@ -92,16 +99,10 @@ const LeaveCellDetailsModal: FC<Props> = (props): JSX.Element => {
           reason: item.reason
         })
       )
-
-      setTotNumFiledLeaves(
-        isMyLeave === true
-          ? leavesByDate?.leavesByDate?.totalNumberOfFiledLeaves
-          : leavesByDateYearly?.yearlyAllLeavesByDate?.totalNumberOfFiledLeaves ?? 0
-      )
-
-      setLeaveData(isMyLeave === true ? leaveData : leaveDatayearly ?? [])
+      setTotNumFiledLeaves(leavesByDateYearly?.yearlyAllLeavesByDate?.totalNumberOfFiledLeaves ?? 0)
+      setLeaveData(leaveDatayearly ?? [])
     }
-  }, [isLeavesLoading, isLeavesLoadingYearly])
+  }, [isLeavesLoadingYearly, isOpen])
 
   const table = useReactTable({
     data: leaveData ?? [],

--- a/client/src/hooks/useLeave.ts
+++ b/client/src/hooks/useLeave.ts
@@ -93,12 +93,14 @@ const useLeave = (): HookReturnType => {
       select: (data: YearlyLeaves) => data,
       enabled: ready
     })
+
   const handleLeaveTypeQuery = (): getLeaveTypeQueryType =>
     useQuery({
       queryKey: ['GET_LEAVE_TYPES_QUERY'],
       queryFn: async () => await client.request(GET_LEAVE_TYPES_QUERY),
       select: (data: LeaveTypes) => data
     })
+
   const handleLeaveMutation = (): handleLeaveMutationType =>
     useMutation({
       mutationFn: async (leave: LeaveRequest) => {
@@ -155,6 +157,9 @@ const useLeave = (): HookReturnType => {
       onError: async (err: Error) => {
         const [errorMessage] = err.message.split(/:\s/, 2)
         toast.error(errorMessage)
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries()
       }
     })
 
@@ -165,12 +170,12 @@ const useLeave = (): HookReturnType => {
           request
         })
       },
-      onSuccess: () => {
-        void queryClient.invalidateQueries()
-      },
       onError: async (err: Error) => {
         const [errorMessage] = err.message.split(/:\s/, 2)
         toast.error(errorMessage)
+      },
+      onSuccess: () => {
+        void queryClient.invalidateQueries()
       }
     })
 


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-323

## Definition of Done

- [x] Add Canceling/Deleting Text indicator in Confirm Modal when submitting 
- [x] Improve submitting behavior by modifying the mutateAsync function
- [x] Add invalidateQueries to update cache when Canceling Leave and Editing Leave 
- [x] Modified LeaveCellDetailsModal that enable only a query based on the page 

## Notes

- Improvements on Confirm Alert Modal Button

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet watch`

## Expected Output

- It should now have a simple text 'Canceling...'/'Deleting...' when clicking "Yes" on the alert modal

## Screenshots/Recordings

[222222.webm](https://github.com/framgia/sph-hris/assets/108642414/37a982d0-e447-4a2b-88b7-8f02e784dd74)

