### PR TITLE
HRIS-322 [FE] Add Edit undertime form for undertime requests

### DIFF
--- a/client/src/components/molecules/EditUndertimeModal/index.tsx
+++ b/client/src/components/molecules/EditUndertimeModal/index.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react'
+import { Tab } from '@headlessui/react'
+
+import ModalTemplate from '~/components/templates/ModalTemplate'
+import ModalHeader from '~/components/templates/ModalTemplate/ModalHeader'
+import EditTab from './EditTab'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+}
+
+const EditUndertimeModal: FC<Props> = ({ isOpen, closeModal }): JSX.Element => {
+  return (
+    <ModalTemplate
+      {...{
+        isOpen,
+        closeModal
+      }}
+      className="w-full max-w-[800px]"
+    >
+      {/* Custom Modal Header */}
+      <ModalHeader
+        {...{
+          title: 'Edit Undertime',
+          closeModal
+        }}
+      />
+      <Tab.Group>
+        {/* Tab header */}
+        <Tab.Panels className="overflow-y-auto">
+          {/* Edit Tab Form */}
+          <EditTab
+            {...{
+              isOpen,
+              closeModal
+            }}
+          />
+        </Tab.Panels>
+      </Tab.Group>
+    </ModalTemplate>
+  )
+}
+
+EditUndertimeModal.defaultProps = {
+  isOpen: false
+}
+
+export default EditUndertimeModal


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-322

## Definition of Done

- [x] Users can edit undertime on a separate form
- [x] Reset button now resets the initial data of the request

## Notes
- Existing undertime request

## Pre-condition
- Running BE and FE
- Go to ``` http://localhost:3000/my-leaves?year=2023&leave=0 ```
- Edit a leave request to test the Reset button
- Edit an undertime request to test the save and reset button

## Expected Output
- It should allow the user to reset the data on the leave and undertime form
- It should allow the user to edit undertime requests

## Screenshots/Recordings

https://github.com/framgia/sph-hris/assets/109492180/e4f064b0-6655-42fc-a1d0-de9acd488781


