### PR TITLE
HRIS-325 [FE] Modify design on Notification Details Modal

### DIFF
--- a/client/src/components/atoms/RequestStatusChip/index.tsx
+++ b/client/src/components/atoms/RequestStatusChip/index.tsx
@@ -1,20 +1,27 @@
-import React from 'react'
+import React, { FC } from 'react'
 import classNames from 'classnames'
 
 import { RequestStatus } from '~/utils/constants/requestStatus'
 
-const RequestStatusChip = ({ label }: { label: string }): JSX.Element => {
+type Props = {
+  label: string
+}
+
+const RequestStatusChip: FC<Props> = ({ label }): JSX.Element => {
   const styles = classNames(
     'border rounded-full px-1 font-normal select-none capitalize',
     label === RequestStatus.APPROVED.toLowerCase()
       ? 'border-green-300 bg-green-50 text-green-600'
-      : null,
+      : '',
     label === RequestStatus.PENDING.toLowerCase()
       ? 'border-amber-300 bg-amber-50 text-amber-600'
-      : null,
+      : '',
     label === RequestStatus.DISAPPROVED.toLowerCase()
       ? 'border-rose-300 bg-rose-50 text-rose-600'
-      : null
+      : '',
+    label === RequestStatus.CANCELLED.toLocaleLowerCase()
+      ? 'border-red-300 bg-red-50 text-red-600'
+      : ''
   )
   return <span className={styles}>{label}</span>
 }

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/ChangeShiftDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/ChangeShiftDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -39,6 +40,7 @@ const ChangeShiftDetails: FC<Props> = ({ notification }): JSX.Element => {
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
         <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/ChangeShiftResolved.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/ChangeShiftResolved.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -38,7 +39,7 @@ const ChangeShiftResolvedDetails: FC<Props> = ({ notification }): JSX.Element =>
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/ESLChangeShiftDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/ESLChangeShiftDetails.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
 import { IESLOffset } from '~/utils/interfaces/eslOffsetInterface'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -57,7 +58,7 @@ const ESLChangeShiftDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/LeaveDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/LeaveDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -33,7 +34,7 @@ const LeaveDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/LeaveResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/LeaveResolvedDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -33,7 +34,7 @@ const LeaveResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -33,7 +34,7 @@ const OffsetDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetResolvedDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -33,7 +34,7 @@ const OffsetResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetScheduleDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OffsetScheduleDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -33,7 +34,7 @@ const OffsetScheduleDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Description: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OvertimeDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OvertimeDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -33,7 +34,7 @@ const OvertimeDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/OvertimeResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/OvertimeResolvedDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -51,7 +52,7 @@ const OvertimeResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Manager Remarks: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/ResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/ResolvedDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -29,7 +30,7 @@ const ResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/UndertimeDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/UndertimeDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -33,7 +34,7 @@ const UndertimeDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/UndertimeResolvedDetails.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/UndertimeResolvedDetails.tsx
@@ -2,6 +2,7 @@ import moment from 'moment'
 import React, { FC } from 'react'
 
 import { INotification } from '~/utils/interfaces'
+import RequestStatusChip from '~/components/atoms/RequestStatusChip'
 
 type Props = {
   notification: INotification
@@ -33,7 +34,7 @@ const UndertimeResolvedDetails: FC<Props> = ({ notification }): JSX.Element => {
       </li>
       <li className="inline-flex items-center space-x-3 pt-2">
         <span className="text-slate-600">Status: </span>
-        <span className="flex items-center font-medium">{status}</span>
+        <RequestStatusChip label={status.toLocaleLowerCase()} />
       </li>
       <li className="inline-flex flex-col space-y-2 pt-2">
         <span className="text-slate-600">Remarks: </span>

--- a/client/src/components/molecules/NotificationList/ViewDetailsModal/index.tsx
+++ b/client/src/components/molecules/NotificationList/ViewDetailsModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { useRouter } from 'next/router'
-import { Check, X } from 'react-feather'
 import { BsFileEarmarkText } from 'react-icons/bs'
+import { ThumbsDown, ThumbsUp } from 'react-feather'
 
 import useLeave from '~/hooks/useLeave'
 import LeaveDetails from './LeaveDetails'
@@ -145,7 +145,8 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
     <ModalTemplate
       {...{
         isOpen,
-        closeModal: handleClose
+        closeModal: handleClose,
+        status: row.status
       }}
       className="w-full max-w-lg"
     >
@@ -158,7 +159,7 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
         }}
       />
       <main className="px-8 py-4 text-sm  text-slate-700">
-        <ul className="flex flex-col space-y-3 divide-y divide-slate-200">
+        <ul className="flex flex-col space-y-3 divide-y divide-slate-100">
           {/* DETAILS FOR OVERTIME DATA */}
           {row.type.toLocaleLowerCase() === NOTIFICATION_TYPE.OVERTIME && (
             <OvertimeDetails
@@ -286,18 +287,18 @@ const ViewDetailsModal: FC<Props> = ({ isOpen, row, user }): JSX.Element => {
             <>
               <Button
                 variant="success"
-                className="flex items-center space-x-1 py-0.5 px-4"
+                className="flex items-center space-x-1.5 py-0.5 px-4"
                 onClick={() => handleApproveDisapprove(true)}
               >
-                <Check className="h-4 w-4" />
+                <ThumbsUp className="h-4 w-4" />
                 <span>Approve</span>
               </Button>
               <Button
                 variant="danger-outline"
-                className="flex items-center space-x-1 py-0.5 px-2"
+                className="flex items-center space-x-1.5 py-0.5 px-2"
                 onClick={() => handleApproveDisapprove(false)}
               >
-                <X className="h-4 w-4" />
+                <ThumbsDown className="h-4 w-4" />
                 <span>Disapprove</span>
               </Button>
             </>

--- a/client/src/components/templates/ModalTemplate/ModalHeader.tsx
+++ b/client/src/components/templates/ModalTemplate/ModalHeader.tsx
@@ -27,7 +27,7 @@ const ModalHeader: FC<Props> = (props): JSX.Element => {
         className
       )}
     >
-      <div className="flex items-start space-x-2 text-slate-700">
+      <div className="flex flex-wrap items-center gap-2 text-slate-700">
         {hasAvatar === true ? (
           <Avatar
             onError={(e: React.SyntheticEvent<HTMLImageElement, Event>) =>

--- a/client/src/components/templates/ModalTemplate/index.tsx
+++ b/client/src/components/templates/ModalTemplate/index.tsx
@@ -2,16 +2,34 @@ import classNames from 'classnames'
 import { Dialog, Transition } from '@headlessui/react'
 import React, { Fragment, FC, ReactNode, useRef } from 'react'
 
+import { RequestStatus } from '~/utils/constants/requestStatus'
+
 type Props = {
   isOpen: boolean
   closeModal: () => void
   children: ReactNode
   className?: string
+  status?: string | undefined
 }
 
 const ModalTemplate: FC<Props> = (props): JSX.Element => {
   const refDiv = useRef<HTMLDivElement>(null)
-  const { isOpen, closeModal, children, className } = props
+  const { isOpen, closeModal, children, className, status } = props
+
+  const getStatusStyle = (status: string): string => {
+    switch (status) {
+      case RequestStatus.APPROVED:
+        return 'shadow-green-200 ring-1 ring-green-300'
+      case RequestStatus.DISAPPROVED:
+        return 'shadow-rose-200 ring-1 ring-rose-300'
+      case RequestStatus.PENDING:
+        return 'shadow-amber-200 ring-1 ring-amber-300'
+      case RequestStatus.CANCELLED:
+        return 'shadow-red-200 ring-1 ring-red-300'
+      default:
+        return ''
+    }
+  }
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
@@ -42,7 +60,8 @@ const ModalTemplate: FC<Props> = (props): JSX.Element => {
               <Dialog.Panel
                 className={classNames(
                   className,
-                  'transform overflow-hidden rounded-xl bg-white text-left align-middle shadow-xl transition-all'
+                  'transform overflow-hidden rounded-xl bg-white text-left align-middle shadow-xl transition-all',
+                  getStatusStyle(status as string)
                 )}
                 ref={refDiv}
               >
@@ -58,7 +77,8 @@ const ModalTemplate: FC<Props> = (props): JSX.Element => {
 
 ModalTemplate.defaultProps = {
   isOpen: false,
-  className: 'w-full max-w-3xl'
+  className: 'w-full max-w-3xl',
+  status: ''
 }
 
 export default ModalTemplate

--- a/client/src/utils/constants/requestStatus.ts
+++ b/client/src/utils/constants/requestStatus.ts
@@ -1,5 +1,6 @@
 export const RequestStatus = {
   PENDING: 'Pending',
   DISAPPROVED: 'Disapproved',
-  APPROVED: 'Approved'
-}
+  APPROVED: 'Approved',
+  CANCELLED: 'Cancelled'
+} as const


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-325

## Definition of Done

- [x] Reused Chip Component in Notification Status
- [x] Modified Notification Details with Border Style and Shadow
- [x] Added Style based on the Notification Status
     - [x] Pending: Amber Color 
     - [x] Cancelled: Red Color
     - [x] Disapproved: Rose Color
     - [x] Approved: Green Color
- [x] Modified Icon for Approved/Disapproved with ThumbsUp/Down Icon    

## Notes

- Notification Details Modal Improvement to emphasize the status of request

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet watch`
- go to notication dropdown menu and select notification data

## Expected Output

- The Notification Details Modal should now feature a modified user interface (UI) that incorporates shadows and borders based on the status of a request
- Modified Status details with Chip Component

## Screenshots/Recordings

[noti-noti.webm](https://github.com/framgia/sph-hris/assets/108642414/08cc7b2e-81fa-4157-85d1-1ff98aa721ae)
