### PR TITLE
HRIS-317 [BE] Add .env file in the API and update the env.example

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,4 @@
+DB_HOST="localhost\\db-1,1433"
+DB_PASSWORD="P@ssw0rd"
+DB_NAME="hris"
+DB_USER="sa"

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -453,3 +453,6 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+#env
+.env

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -9,6 +9,7 @@ using LiteX.Storage.FileSystem;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 
+DotNetEnv.Env.Load();
 var builder = WebApplication.CreateBuilder(args);
 
 var MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
@@ -87,7 +88,6 @@ builder.Services.AddScoped<ESLChangeShiftService>();
 builder.Services.AddScoped<ESLOffsetService>();
 builder.Services.AddScoped<EmployeeScheduleService>();
 builder.Services.AddScoped<EmployeeService>();
-
 
 var app = builder.Build();
 

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -6,6 +6,7 @@
     <UserSecretsId>613f6ce2-edc1-4906-9ab0-b67a34c75ff1</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="DotNetEnv" Version="2.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-317

## Definition of Done

- [x] Add .env file in api directory

## Notes
- Conditional string can now be removed from here after we update the .env file in dev server
![image](https://github.com/framgia/sph-hris/assets/109492180/6b4a0ed4-e404-4ce8-8bbc-543bf39225c0)

- To use environment variables in the services, add these configurations
![image](https://github.com/framgia/sph-hris/assets/109492180/9cf21823-5682-4481-b971-9c8406d2faad)

- Sample usage
![image](https://github.com/framgia/sph-hris/assets/109492180/1abbbf13-6164-4090-bc2a-c3c74ad79e33)


## Pre-condition
- In the root directory, run ``` docker compose up api db client -d ```
- In the root directory, run ``` touch .env ```
- Access the ``` .env ``` file and paste this sample content
```
DB_HOST="localhost\\db-1,1433"
DB_PASSWORD="P@ssw0rd"
DB_NAME="hris"
DB_USER="sa"

```


## Expected Output
- It should let the services access the variables inside .env

## Screenshots/Recordings
- ```.env``` file
![image](https://github.com/framgia/sph-hris/assets/109492180/a3ed2a2a-133f-44c9-a90c-554ac3f51f82)
- Usage
![image](https://github.com/framgia/sph-hris/assets/109492180/1d1ff5fd-ec98-41d3-b992-89df63621ec6)

