### PR TITLE
HRIS-331 [BE]  Implement fetching of employee schedule for a specific user

### DIFF
--- a/api/Middlewares/AuthorizeUser.cs
+++ b/api/Middlewares/AuthorizeUser.cs
@@ -77,11 +77,6 @@ namespace api.Middlewares
                                         .AsSplitQuery()
                                         .FirstOrDefaultAsync();
 
-                    if (currentUser != null)
-                        currentUser.EmployeeSchedule.WorkingDayTimes = currentUser.EmployeeSchedule.WorkingDayTimes
-                                                                    .Where(p => p.Day == DateTime.Now.DayOfWeek.ToString())
-                                                                    .ToList();
-
                     if (currentUser == null) throw new Exception(MiddlewareErrorMessageEnum.UNAUTHENTICATED_USER);
 
                     httpContext.Items["User"] = currentUser;


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-331

## Definition of Done

- [x] Users can fetch the all of their working day times. It also includes breakFrom and breakTo data

## Notes
- BE implementation only

## Pre-condition
- In the api directory, run ``` dotnet run ```
- Go to ``` http://localhost:5257/graphql/ ```
- Run this query:
```
query {
    userById {
      employeeSchedule {
        workingDayTimes {
          id
          day
          from
          to
          breakFrom
          breakTo
        }
      }
    }
  }
```

## Expected Output
- It should return a list of schedule

## Screenshots/Recordings
![image](https://github.com/framgia/sph-hris/assets/109492180/b9e1acbf-77de-457b-8c0e-c3fe7809935a)

