### PR TITLE
HRIS-329 [FE/BE] Update data fetched from employee schedules to cater BreakFrom and BreakTo values

### DIFF
--- a/api/DTOs/EmployeeScheduleDTO.cs
+++ b/api/DTOs/EmployeeScheduleDTO.cs
@@ -23,7 +23,7 @@ namespace api.DTOs
                 // For included days of the week
                 foreach (var workingDayTime in employeeSchedule.WorkingDayTimes)
                 {
-                    Day workingDayTimes = new(workingDayTime.Day, workingDayTime.From.ToString(@"hh\:mm"), workingDayTime.To.ToString(@"hh\:mm"), true);
+                    Day workingDayTimes = new(workingDayTime.Day, workingDayTime.From.ToString(@"hh\:mm"), workingDayTime.To.ToString(@"hh\:mm"), workingDayTime.BreakFrom.ToString(@"hh\:mm"), workingDayTime.BreakTo.ToString(@"hh\:mm"), true);
                     DaysOfTheWeek = DaysOfTheWeek.Where(val => val.ToLower() != workingDayTime.Day?.ToLower()).ToArray();
                     Days.Add(workingDayTimes);
                 }
@@ -31,7 +31,7 @@ namespace api.DTOs
                 // For exluded days of the week
                 foreach (var DayOfTheWeek in DaysOfTheWeek)
                 {
-                    Day workingDayTimes = new(DayOfTheWeek, "", "", false);
+                    Day workingDayTimes = new(DayOfTheWeek, "", "", "", "", false);
                     Days.Add(workingDayTimes);
                 }
             }
@@ -44,13 +44,17 @@ namespace api.DTOs
         public string? WorkingDay { get; set; }
         public string? TimeIn { get; set; }
         public string? TimeOut { get; set; }
+        public string? BreakFrom { get; set; }
+        public string? BreakTo { get; set; }
 
-        public Day(string? workingDay, string timeIn, string timeOut, bool selected)
+        public Day(string? workingDay, string timeIn, string timeOut, string breakFrom, string breakTo, bool selected)
         {
             IsDaySelected = selected;
             WorkingDay = workingDay;
             TimeIn = timeIn;
             TimeOut = timeOut;
+            BreakFrom = breakFrom;
+            BreakTo = breakTo;
         }
     }
 }

--- a/api/Requests/WorkingDayTimesRequest.cs
+++ b/api/Requests/WorkingDayTimesRequest.cs
@@ -5,5 +5,7 @@ namespace api.Requests
         public string? Day { get; set; }
         public string? From { get; set; }
         public string? To { get; set; }
+        public string? BreakFrom { get; set; }
+        public string? BreakTo { get; set; }
     }
 }

--- a/api/Services/EmployeeScheduleService.cs
+++ b/api/Services/EmployeeScheduleService.cs
@@ -66,7 +66,9 @@ namespace api.Services
                     EmployeeScheduleId = newEmployeeSchedule.Id,
                     Day = workingDay.Day,
                     From = TimeSpan.Parse(workingDay.From!),
-                    To = TimeSpan.Parse(workingDay.To!)
+                    To = TimeSpan.Parse(workingDay.To!),
+                    BreakFrom = TimeSpan.Parse(workingDay.BreakFrom!),
+                    BreakTo = TimeSpan.Parse(workingDay.BreakTo!),
                 };
                 context.WorkingDayTimes.Add(newWorkingDayTimes);
             }
@@ -207,7 +209,9 @@ namespace api.Services
                 EmployeeScheduleId = employeeScheduleId,
                 Day = x.Day,
                 From = TimeSpan.Parse(x.From!),
-                To = TimeSpan.Parse(x.To!)
+                To = TimeSpan.Parse(x.To!),
+                BreakFrom = TimeSpan.Parse(x.BreakFrom!),
+                BreakTo = TimeSpan.Parse(x.BreakTo!),
             });
             context.WorkingDayTimes.AddRange(newWorkingDays);
         }

--- a/api/Utils/Validation.cs
+++ b/api/Utils/Validation.cs
@@ -494,6 +494,16 @@ namespace api.Utils
                 {
                     errors.Add(buildError(nameof(workingDay.To), InputValidationMessageEnum.INVALID_END_TIME));
                 }
+
+                if (string.IsNullOrEmpty(workingDay.BreakFrom))
+                {
+                    errors.Add(buildError(nameof(workingDay.BreakFrom), InputValidationMessageEnum.INVALID_END_TIME));
+                }
+
+                if (string.IsNullOrEmpty(workingDay.BreakTo))
+                {
+                    errors.Add(buildError(nameof(workingDay.BreakTo), InputValidationMessageEnum.INVALID_END_TIME));
+                }
             }
 
             return errors;

--- a/client/src/components/templates/ScheduleManagementLayout/ScheduleList/ScheduleItem.tsx
+++ b/client/src/components/templates/ScheduleManagementLayout/ScheduleList/ScheduleItem.tsx
@@ -116,14 +116,14 @@ const ScheduleItem: FC<Props> = (props): JSX.Element => {
         }}
         className={classNames('w-full py-2.5 pr-4 pl-8 hover:bg-amber-50 md:pl-4')}
       >
-        <div className="flex items-center space-x-2">
-          <Calendar className="h-5 w-5 stroke-1" />
-          <span className="text-sm md:text-xs">{item.scheduleName}</span>
+        <div className="flex items-start space-x-2">
+          <Calendar className="h-5 w-5 shrink-0 stroke-1" />
+          <span className="pr-6 text-sm md:text-xs">{item.scheduleName}</span>
         </div>
       </div>
       <div
         className={classNames(
-          'insert-y-0 absolute right-6 z-50 flex items-center group-hover:opacity-100 md:right-5',
+          'insert-y-0 absolute right-6 z-50 flex items-center group-hover:opacity-100 hover:text-amber-600 md:right-5',
           active ? 'opacity-100' : 'opacity-0 '
         )}
       >

--- a/client/src/graphql/mutations/employeeScheduleMutation.ts
+++ b/client/src/graphql/mutations/employeeScheduleMutation.ts
@@ -8,8 +8,7 @@ export const CREATE_EMPLOYEE_SCHEDULE = gql`
 `
 export const EDIT_EMPLOYEE_SCHEDULE = gql`
   mutation ($request: UpdateEmployeeScheduleRequestInput!) {
-    updateEmployeeSchedule(request: $request){
-    }
+    updateEmployeeSchedule(request: $request)
   }
 `
 export const DELETE_EMPLOYEE_SCHEDULE = gql`

--- a/client/src/graphql/queries/employeeSchedule.ts
+++ b/client/src/graphql/queries/employeeSchedule.ts
@@ -5,6 +5,14 @@ export const GET_ALL_EMPLOYEE_SCHEDULE = gql`
     allEmployeeScheduleDetails {
       id
       scheduleName
+      days {
+        isDaySelected
+        workingDay
+        timeIn
+        timeOut
+        breakFrom
+        breakTo
+      }
     }
   }
 `
@@ -19,6 +27,8 @@ export const GET_EMPLOYEE_SCHEDULE = gql`
         workingDay
         timeIn
         timeOut
+        breakFrom
+        breakTo
       }
       memberCount
     }

--- a/client/src/utils/constants/shiftSchedule.ts
+++ b/client/src/utils/constants/shiftSchedule.ts
@@ -1,4 +1,4 @@
-import { ReactSelectOption } from '../types/formValues'
+import { ReactSelectOption } from './../types/formValues'
 
 export const shiftSchedule: ReactSelectOption[] = [
   {

--- a/client/src/utils/types/employeeScheduleTypes.ts
+++ b/client/src/utils/types/employeeScheduleTypes.ts
@@ -1,18 +1,21 @@
 export interface IGetAllEmployeeSchedule {
   id: number
   scheduleName: string
+  days: IDay[]
+}
+
+export interface IDay {
+  isDaySelected: boolean
+  workingDay: string
+  timeIn: string
+  timeOut: string
+  breakFrom: string
+  breakTo: string
 }
 
 export interface IGetEmployeeSchedule {
   id: number
-  days: Array<{
-    isDaySelected: boolean
-    workingDay: string
-    timeIn: string
-    timeOut: string
-    breakFrom: string
-    breakTo: string
-  }>
+  days: IDay[]
   scheduleName: string
   memberCount: number
 }
@@ -23,28 +26,27 @@ export interface IAddMemberToScheduleInput {
   scheduleId: number
 }
 
+export interface IWorkDay {
+  day: string
+  from: string
+  to: string
+  breakFrom: string
+  breakTo: string
+}
+
 export interface ICreateEmployeeScheduleRequestInput {
-  // eslint-disable-next-line @typescript-eslint/array-type
-  workingDays: {
-    day: string
-    from: string
-    to: string
-  }[]
+  workingDays: IWorkDay[]
   userId: number
   scheduleName: string
 }
 
 export interface IEditEmployeeScheduleRequestInput {
-  // eslint-disable-next-line @typescript-eslint/array-type
-  workingDays: {
-    day: string
-    from: string
-    to: string
-  }[]
+  workingDays: IWorkDay[]
   userId: number
   scheduleName: string
   employeeScheduleId: number
 }
+
 export interface IDeleteEmployeeScheduleRequestInput {
   userId: number
   employeeScheduleId: number


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-329

## Definition of Done

- [x] Update the fetched data to add the BreakFrom and BreakTo values
- [x] Integrate the dynamic data in Schedule Shift dropdown 

## Notes

- Integration with BE
- Only HR can access the page

## Pre-condition

### Docker

run `docker compose up --build`

### Local

- run `cd client && npm run dev`
- run `cd api && dotnet watch`

## Expected Output

- It should now have and update and save for the column of Break From and Break To
- The Schedule Shift dropdown are now integrated

## Screenshots/Recordings

[integration.webm](https://github.com/framgia/sph-hris/assets/108642414/f0600a4a-e4b9-4352-a7f3-c730dfa4f71d)

