### PR TITLE
HRIS-335 [BE] Implement fetching of filed schedules on a specific user

### DIFF
--- a/api/Schema/Queries/EmployeeScheduleQuery.cs
+++ b/api/Schema/Queries/EmployeeScheduleQuery.cs
@@ -1,4 +1,5 @@
 using api.DTOs;
+using api.Entities;
 using api.Middlewares.Attributes;
 using api.Requests;
 using api.Services;
@@ -27,6 +28,11 @@ namespace api.Schema.Queries
         public async Task<List<UserDTO>> GetEmployeesBySchedule(int employeeScheduleId)
         {
             return await _employeeScheduleService.GetEmployeesBySchedule(employeeScheduleId);
+        }
+
+        public async Task<List<ChangeScheduleRequest>?> GetEmployeeChangeScheduleRequest(int userId)
+        {
+            return await _employeeScheduleService.GetEmployeeChangeScheduleRequest(userId);
         }
 
         [AdminUser]

--- a/api/Services/EmployeeScheduleService.cs
+++ b/api/Services/EmployeeScheduleService.cs
@@ -46,6 +46,12 @@ namespace api.Services
                 .ToListAsync();
         }
 
+        public async Task<List<ChangeScheduleRequest>?> GetEmployeeChangeScheduleRequest(int userId)
+        {
+            using HrisContext context = _contextFactory.CreateDbContext();
+            return await context.ChangeScheduleRequests.Where(x => x.UserId == userId).ToListAsync();
+        }
+
         public async Task<string> Create(CreateEmployeeScheduleRequest request, HrisContext context)
         {
             // validate inputs


### PR DESCRIPTION
## Issue Link

- https://framgiaph.backlog.com/view/HRIS-335

## Definition of Done

- [x] Users can fetch all the filed schedule requests

## Notes
- BE only

## Pre-condition
- In the api directory, run ``` dotnet watch ```
- Go to ``` http://localhost:5257/graphql/ ```
- Run this mutation:
```
query($userId: Int!) {
  employeeChangeScheduleRequest(userId: $userId) {
    id
    data
    isManagerApproved
    isLeaderApproved
    createdAt
  }
}
# Variables
{
    "userId": 57
}
```

## Expected Output
- It should fetch all the filed request for that user

## Screenshots/Recordings

![image](https://github.com/framgia/sph-hris/assets/109492180/2f9c2edb-7e50-4bac-8684-e19104fa1659)

