### PR TITLE
HRIS-371 Position Middleware/Guards

### DIFF
--- a/api_v2/src/app.module.ts
+++ b/api_v2/src/app.module.ts
@@ -22,6 +22,8 @@ import { LogoutModule } from './logout/logout.module';
 import { FileUploadModule } from './file-upload/file-upload.module';
 import { graphqlUploadExpress } from 'graphql-upload-ts';
 import { WorkInterruptionModule } from './work-interruption/work-interruption.module';
+import { APP_GUARD } from '@nestjs/core';
+import { PositionsGuard } from './guards/position.guard';
 
 @Module({
   imports: [
@@ -80,7 +82,14 @@ import { WorkInterruptionModule } from './work-interruption/work-interruption.mo
     WorkInterruptionModule,
   ],
   controllers: [AppController],
-  providers: [AppService, AppResolver],
+  providers: [
+    AppService,
+    AppResolver,
+    {
+      provide: APP_GUARD,
+      useClass: PositionsGuard,
+    },
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/api_v2/src/decorators/position.decorator.ts
+++ b/api_v2/src/decorators/position.decorator.ts
@@ -1,0 +1,5 @@
+import { PositionEnum, PositionHelper } from '@/enums/position.enum';
+import { SetMetadata } from '@nestjs/common';
+
+export const Position = (...position: PositionEnum[] | PositionHelper[]) =>
+  SetMetadata('position', position);

--- a/api_v2/src/guards/position.guard.ts
+++ b/api_v2/src/guards/position.guard.ts
@@ -1,0 +1,69 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { PositionEnum } from '@/enums/position.enum';
+import { JwtService } from '@nestjs/jwt';
+import { MiddlewareErrorMessageEnum } from '@/enums/middleware-error-message.enum';
+
+@Injectable()
+export class PositionsGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private jwtService: JwtService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredPositions = this.reflector.getAllAndOverride<PositionEnum[]>(
+      'position',
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredPositions) {
+      return true;
+    }
+
+    const ctx = GqlExecutionContext.create(context);
+    const { req } = ctx.getContext();
+    const token = req.headers.authorization;
+
+    const decodedToken = await this.jwtService.verifyAsync(token);
+
+    const allRequiredPosition = new Set(requiredPositions.flat());
+
+    const accessGranted = allRequiredPosition.has(decodedToken.position);
+    if (accessGranted) {
+      return true;
+    } else {
+      if (allRequiredPosition.has(PositionEnum.MANAGER)) {
+        throw new ForbiddenException(
+          MiddlewareErrorMessageEnum.NOT_MANAGER_USER,
+        );
+      } else if (allRequiredPosition.has(PositionEnum.ASSISTANT_MANAGER)) {
+        throw new ForbiddenException(
+          MiddlewareErrorMessageEnum.NOT_MANAGER_USER,
+        );
+      } else if (
+        allRequiredPosition.has(PositionEnum.ADMIN) ||
+        allRequiredPosition.has(PositionEnum.WEB_DEVELOPER_TRAINER) ||
+        allRequiredPosition.has(PositionEnum.WEB_DEVELOPER_TEAM_LEADER)
+      ) {
+        throw new ForbiddenException(
+          MiddlewareErrorMessageEnum.NOT_LEADER_USER,
+        );
+      } else if (allRequiredPosition.has(PositionEnum.ADMIN)) {
+        throw new ForbiddenException(MiddlewareErrorMessageEnum.NOT_ADMIN_USER);
+      } else if (allRequiredPosition.has(PositionEnum.ESL_TEACHER)) {
+        throw new ForbiddenException(MiddlewareErrorMessageEnum.NOT_ESL_USER);
+      } else {
+        throw new ForbiddenException(
+          MiddlewareErrorMessageEnum.UNAUTHENTICATED_USER,
+        );
+      }
+    }
+  }
+}

--- a/api_v2/src/sign-in/sign-in.service.ts
+++ b/api_v2/src/sign-in/sign-in.service.ts
@@ -38,6 +38,7 @@ export class SignInService {
         user.id,
         user.email,
         user.roleId,
+        user.positionId,
       );
 
       return authToken;
@@ -74,7 +75,7 @@ export class SignInService {
   }
 
   /**
-   * Generates an authentication token based on the provided user ID, email, and role ID.
+   * Generates an authentication token based on the provided user ID, email, role ID and position ID.
    *
    * @param {number} id - The user ID for whom the token is generated.
    * @param {string | null} email - The email associated with the user.
@@ -85,11 +86,13 @@ export class SignInService {
     id: number,
     email: string | null,
     roleId: number,
+    positionId: number,
   ): Promise<string> {
     const signingPayload = {
       nameid: id,
       email,
       role: roleId,
+      position: positionId,
     };
 
     const signOptions = { issuer: 'sun-hris' };


### PR DESCRIPTION
## HRIS-371 Position Middleware/Guards

Backlog Link
https://framgiaph.backlog.com/view/HRIS-371
## Definition of Done

- [x] Users cannot access transactions that are not for there position

## Notes
I used create workInterruption to test the position guard

## Pre-condition
Add UseGuards(PositionGuard)
Add Position(PositionEnum.<Position Key from PositionEnum>) 
![image](https://github.com/framgia/sph-hris/assets/137018413/2b3d175b-c69d-4c59-9db3-29991eea5199)

Use sign in mutation of api_v2 to get the auth token
## Expected Output
A transaction should not succeed when transaction is for a specific Position that is not the position of the user

## Screenshots/Recordings
Successful transaction for position Web Developer
![image](https://github.com/framgia/sph-hris/assets/137018413/3d9723fa-0729-4647-ac97-aeabf1805273)

![image](https://github.com/framgia/sph-hris/assets/137018413/8e944709-7dcb-4d4a-b794-b5147fc27379)

Unsuccessful transaction for position Web Developer
![image](https://github.com/framgia/sph-hris/assets/137018413/0a61e668-099c-4b94-b6d4-68098aff2747)


![image](https://github.com/framgia/sph-hris/assets/137018413/33926412-5934-4416-a701-a64bcd92bc49)
