### PR TITLE
[HRIS-381] [BE] My Daily Time Record > Index > View Work Interruptions > Edit Work Interruption

### DIFF
--- a/api_v2/src/utilities/date.util.ts
+++ b/api_v2/src/utilities/date.util.ts
@@ -1,6 +1,27 @@
 import { DateTime } from 'luxon';
 
 /**
+ * Converts a time string in the format 'HH:mm:ss' to ISO format.
+ * If the input is null, it returns null.
+ *
+ * @param {string | null} time - The time string to be converted. It should be in the format 'HH:mm:ss'.
+ * @returns {string | null} - The ISO formatted time string or null if the input is null.
+ *
+ * @example
+ * // returns '1970-01-01T10:30:00.000Z'
+ * formatToISO('10:30:00');
+ *
+ * @example
+ * // returns null
+ * formatToISO(null);
+ */
+const formatToISO = (time: string | null): string | null => {
+  return time
+    ? DateTime.fromFormat(time, 'HH:mm:ss', { zone: 'utc' }).toISO()
+    : null;
+};
+
+/**
  * Formats a given date string into a specified format using Luxon's DateTime object.
  *
  * @param {string} date - The date string to format.
@@ -57,4 +78,10 @@ const isBetweenTime = (
   return isAfterStartTime && isBeforeEndTime;
 };
 
-export { formatDate, getCurrentDate, getCurrentTimeDuration, isBetweenTime };
+export {
+  formatDate,
+  getCurrentDate,
+  getCurrentTimeDuration,
+  isBetweenTime,
+  formatToISO,
+};

--- a/api_v2/src/work-interruption/work-interruption.resolver.ts
+++ b/api_v2/src/work-interruption/work-interruption.resolver.ts
@@ -1,6 +1,9 @@
 import { Resolver, Mutation, Args } from '@nestjs/graphql';
 import { WorkInterruptionService } from './work-interruption.service';
-import { CreateInterruptionRequestInput } from '@/graphql/graphql';
+import {
+  CreateInterruptionRequestInput,
+  UpdateInterruptionRequestInput,
+} from '@/graphql/graphql';
 
 @Resolver('WorkInterruption')
 export class WorkInterruptionResolver {
@@ -20,5 +23,19 @@ export class WorkInterruptionResolver {
   @Mutation('createWorkInterruption')
   create(@Args('interruption') interruption: CreateInterruptionRequestInput) {
     return this.workInterruptionService.create(interruption);
+  }
+
+  @Mutation(() => Boolean)
+  async updateWorkInterruption(
+    @Args('interruption') interruption: UpdateInterruptionRequestInput,
+  ): Promise<boolean> {
+    try {
+      const updateSuccessful =
+        await this.workInterruptionService.updateInterruption(interruption);
+      return updateSuccessful;
+    } catch (error) {
+      console.error(`Error updating work interruption`);
+      return false;
+    }
   }
 }

--- a/api_v2/src/work-interruption/work-interruption.service.ts
+++ b/api_v2/src/work-interruption/work-interruption.service.ts
@@ -1,4 +1,7 @@
-import { CreateInterruptionRequestInput } from '@/graphql/graphql';
+import {
+  CreateInterruptionRequestInput,
+  UpdateInterruptionRequestInput,
+} from '@/graphql/graphql';
 import { PrismaService } from '@/prisma/prisma.service';
 import {
   BadRequestException,
@@ -6,7 +9,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
-import { formatDate } from '../utilities/date.util';
+import { formatDate, formatToISO } from '../utilities/date.util';
 
 @Injectable()
 export class WorkInterruptionService {
@@ -65,6 +68,32 @@ export class WorkInterruptionService {
       throw new InternalServerErrorException(
         'An error occurred while creating the interruption',
       );
+    }
+  }
+
+  async updateInterruption(
+    interruption: UpdateInterruptionRequestInput,
+  ): Promise<boolean> {
+    const { id, ...updateData } = interruption;
+
+    try {
+      const updatedInterruption = await this.prisma.workInterruption.update({
+        where: { id },
+        data: {
+          ...updateData,
+          timeOut: interruption.timeOut
+            ? formatToISO(interruption.timeOut)
+            : null,
+          timeIn: interruption.timeIn ? formatToISO(interruption.timeIn) : null,
+          timeEntryId: undefined,
+          createdAt: undefined,
+        },
+      });
+
+      return !!updatedInterruption;
+    } catch (error) {
+      console.error('Error updating interruption:', error);
+      return false;
     }
   }
 }

--- a/api_v2/src/work-interruption/work-interruption.service.ts
+++ b/api_v2/src/work-interruption/work-interruption.service.ts
@@ -151,22 +151,34 @@ export class WorkInterruptionService {
    * @param {UpdateInterruptionRequestInput} interruption - The data to update for the interruption.
    * @returns {Promise<boolean>} Returns true if the interruption was successfully updated, false otherwise.
    */
+
   async updateInterruption(
     interruption: UpdateInterruptionRequestInput,
   ): Promise<boolean> {
-    const { id, ...updateData } = interruption;
+    const {
+      id,
+      otherReason,
+      remarks,
+      timeOut,
+      timeIn,
+      workInterruptionTypeId,
+    } = interruption;
+
+    if (!otherReason && !remarks && !timeOut && !timeIn) {
+      return false;
+    }
 
     try {
       const updatedInterruption = await this.prisma.workInterruption.update({
         where: { id },
         data: {
-          ...updateData,
-          timeOut: interruption.timeOut
-            ? formatToISO(interruption.timeOut)
-            : null,
-          timeIn: interruption.timeIn ? formatToISO(interruption.timeIn) : null,
-          timeEntryId: undefined,
-          createdAt: undefined,
+          ...(otherReason && { otherReason }),
+          ...(remarks && { remarks }),
+          timeOut: timeOut ? formatToISO(timeOut) : undefined,
+          timeIn: timeIn ? formatToISO(timeIn) : undefined,
+          workInterruptionTypeId: workInterruptionTypeId
+            ? workInterruptionTypeId
+            : undefined,
         },
       });
 


### PR DESCRIPTION
## Issue Link

[Backlog Link](https://framgiaph.backlog.com/board/HRIS?selectedIssueKey=HRIS-381&milestone=316260)

## Definition of Done

- [x] Can Update a work interruption based on Id in NESTJS.
- [x] Same Output with the ASP.net

## Notes

Optional

- Please create a time entry first if not yet created and use its Id on the variables
-You can access the graphql playground enpoint at http://localhost:3001/graphql/
-To run the update mutation, use the following below:
`mutation($interruption: UpdateInterruptionRequestInput!){
  updateWorkInterruption(interruption:$interruption)
}`
- Use this as your variable respectively:
`{
  "interruption": {
    "id": 2,
    "otherReason":"Update NEW REASON",
    "remarks":"Update remarks",
    "timeIn":"09:30:00",
    "timeOut":"18:30:00",
    "workInterruptionTypeId": 3
  }
}`
## Pre-condition

- Create a time entry first if not yet created.
-run `docker compose up db`
-run `npm run dev or run start`

## Expected Output
-Same Output with the ASP.net and successfully update the data in database.

## Screenshots/Recordings

-NestJS GraphQL output:
![image](https://github.com/framgia/sph-hris/assets/142206621/85343b6e-67e6-4d6f-8731-2294ef703e7c)


-ASP.net GraphQL output:
![image](https://github.com/framgia/sph-hris/assets/142206621/d39cd93b-0d83-42fe-a353-26ceb571d65d)

