### PR TITLE
[HRIS-407] [BE] DTR Management > Index > View Work Interruptions > Delete Work Interruption

### DIFF
--- a/api_v2/src/work-interruption/work-interruption.resolver.ts
+++ b/api_v2/src/work-interruption/work-interruption.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
+import { Resolver, Mutation, Args, Query, Int } from '@nestjs/graphql';
 import { WorkInterruptionService } from './work-interruption.service';
 import {
   CreateInterruptionRequestInput,
@@ -38,5 +38,22 @@ export class WorkInterruptionResolver {
     return this.workInterruptionService.interruptionsByTimeEntryId(
       interruption,
     );
+  }
+  /**
+   * GraphQL Mutation: Deletes a WorkInterruption record from the database.
+   * @param {number} id - The ID of the WorkInterruption to delete.
+   * @returns {Promise<boolean>} A boolean indicating whether the deletion was successful.
+   */
+  @Mutation(() => Boolean)
+  async deleteWorkInterruption(
+    @Args('id', { type: () => Int }) id: number,
+  ): Promise<boolean> {
+    try {
+      const deleted =
+        await this.workInterruptionService.deleteWorkInterruption(id);
+      return !!deleted;
+    } catch (error) {
+      throw error;
+    }
   }
 }

--- a/api_v2/src/work-interruption/work-interruption.service.ts
+++ b/api_v2/src/work-interruption/work-interruption.service.ts
@@ -141,4 +141,20 @@ export class WorkInterruptionService {
       updatedAt: type.updatedAt ? getCurrentDate : null,
     };
   }
+  /**
+   * Deletes a WorkInterruption record from the database.
+   * @param {number} id - The ID of the WorkInterruption to delete.
+   * @returns {Promise<boolean>} A boolean indicating whether the deletion was successful.
+   */
+  async deleteWorkInterruption(id: number): Promise<boolean> {
+    try {
+      const result = await this.prisma.workInterruption.delete({
+        where: { id },
+      });
+      return !!result;
+    } catch (error) {
+      console.error(`Error deleting WorkInterruption with ID ${id}:`, error);
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
## Issue Link

[Backlog Link](https://framgiaph.backlog.com/board/HRIS?selectedIssueKey=HRIS-407&milestone=316260)

## Definition of Done

- [x] Can Delete a work interruption based on Id

## Notes
- Please create a time entry first if not yet created and use its Id on the variables
- To run delete mutation, use the following below:

`mutation($id:Int!){
  deleteWorkInterruption(id:$id)
}   `

`{
  "id":2
}`

## Pre-condition
- `docker compose up db`
- `npm start` or `npm run dev`

## Expected Output

It should be the same output with the GraphQL of ASP.net

## Screenshots/Recordings

NestJS output in GraphQL:
![image](https://github.com/framgia/sph-hris/assets/142206621/ee052528-aead-4e67-813c-af16061feeeb)


ASP.net output in GraphQL:
![image](https://github.com/framgia/sph-hris/assets/142206621/411d5bd5-8fca-4872-a4ad-86da300e5734)

