### PR TITLE
HRIS-400 [BE] Leave Management: List of Leave > Index

### DIFF
--- a/api_v2/src/app.module.ts
+++ b/api_v2/src/app.module.ts
@@ -29,6 +29,7 @@ import { UserModule } from './user/user.module';
 import { DtrManagementModule } from './dtr-management/dtr-management.module';
 import { TimeOutModule } from './time-out/time-out.module';
 import { OvertimeModule } from './overtime/overtime.module';
+import { LeavesModule } from './leaves/leaves.module';
 
 @Module({
   imports: [
@@ -90,6 +91,7 @@ import { OvertimeModule } from './overtime/overtime.module';
     DtrManagementModule,
     TimeOutModule,
     OvertimeModule,
+    LeavesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/api_v2/src/graphql/graphql.ts
+++ b/api_v2/src/graphql/graphql.ts
@@ -522,7 +522,7 @@ export class LeaveDTO {
   managerId?: Nullable<number>;
   otherProject?: Nullable<string>;
   isDeleted: boolean;
-  leaveProjects: MultiProject[];
+  leaveProjects?: Nullable<MultiProject[]>;
   user: User;
   leaveNotifications: LeaveNotification[];
   updatedAt?: Nullable<DateTime>;

--- a/api_v2/src/graphql/schema.gql
+++ b/api_v2/src/graphql/schema.gql
@@ -272,7 +272,7 @@ type LeaveDTO {
   managerId: Int
   otherProject: String
   isDeleted: Boolean!
-  leaveProjects: [MultiProject!]!
+  leaveProjects: [MultiProject!]
   user: User!
   leaveNotifications: [LeaveNotification!]!
   updatedAt: DateTime

--- a/api_v2/src/leaves/leaves.module.ts
+++ b/api_v2/src/leaves/leaves.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { LeavesService } from './leaves.service';
+import { LeavesResolver } from './leaves.resolver';
+import { PrismaService } from '@/prisma/prisma.service';
+
+@Module({
+  providers: [LeavesResolver, LeavesService, PrismaService],
+})
+export class LeavesModule {}

--- a/api_v2/src/leaves/leaves.resolver.spec.ts
+++ b/api_v2/src/leaves/leaves.resolver.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeavesResolver } from './leaves.resolver';
+import { LeavesService } from './leaves.service';
+import { PrismaService } from '@/prisma/prisma.service';
+
+describe('LeavesResolver', () => {
+  let resolver: LeavesResolver;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LeavesResolver, LeavesService, PrismaService],
+    }).compile();
+
+    resolver = module.get<LeavesResolver>(LeavesResolver);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+});

--- a/api_v2/src/leaves/leaves.resolver.ts
+++ b/api_v2/src/leaves/leaves.resolver.ts
@@ -1,0 +1,13 @@
+import { Query, Resolver } from '@nestjs/graphql';
+import { LeavesService } from './leaves.service';
+import { LeaveDTO } from '@/graphql/graphql';
+
+@Resolver('Leave')
+export class LeavesResolver {
+  constructor(private readonly leavesService: LeavesService) {}
+
+  @Query(() => [LeaveDTO])
+  async allLeaves() {
+    return await this.leavesService.allLeaves();
+  }
+}

--- a/api_v2/src/leaves/leaves.service.spec.ts
+++ b/api_v2/src/leaves/leaves.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeavesService } from './leaves.service';
+import { PrismaService } from '@/prisma/prisma.service';
+
+describe('LeavesService', () => {
+  let service: LeavesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LeavesService, PrismaService],
+    }).compile();
+
+    service = module.get<LeavesService>(LeavesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/api_v2/src/leaves/leaves.service.ts
+++ b/api_v2/src/leaves/leaves.service.ts
@@ -1,0 +1,38 @@
+import { PrismaService } from '@/prisma/prisma.service';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class LeavesService {
+  constructor(private readonly prisma: PrismaService) {}
+  async allLeaves() {
+    const leaves = await this.prisma.leave.findMany({
+      include: {
+        user: {
+          include: {
+            role: true,
+          },
+        },
+        leaveType: true,
+        manager: true,
+      },
+    });
+
+    return leaves.map((leave) => ({
+      id: leave.id,
+      userId: leave.userId,
+      userName: leave.user.name,
+      userRole: leave.user.role.name,
+      leaveType: leave.leaveType.name,
+      manager: leave.manager?.name,
+      reason: leave.reason,
+      leaveDate: leave.leaveDate,
+      isWithPay: leave.isWithPay,
+      isLeaderApproved: leave.isLeaderApproved,
+      isManagerApproved: leave.isManagerApproved,
+      days: leave.days,
+      createdAt: leave.createdAt,
+      updatedAt: leave.updatedAt,
+      isDeleted: leave.isDeleted,
+    }));
+  }
+}


### PR DESCRIPTION
## Issue Link

https://framgiaph.backlog.com/view/HRIS-400

## Definition of Done

- [x] Users can Query the list of leaves of all users


## Notes
- The avatar is null because the function for the file upload hasn't been implemented yet

## Pre-condition

Commands to run:
-[x] npm run dev


## Expected Output

It should show the query for all the leaves of all employees

## Screenshots/Recordings

NestJS Query for all employees leaves
![image](https://github.com/user-attachments/assets/d25ca4a1-d90e-40d1-88b8-bfc31d2d42ba)

Dotnet Query for all employees leaves
![image](https://github.com/user-attachments/assets/c0d7307b-b2b6-4876-9285-d4eee91f8673)

